### PR TITLE
Improve performance for Open Studios Status page

### DIFF
--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -26,7 +26,7 @@ module Admin
     end
 
     def update
-      @os_event = OpenStudiosEventService.find(params[:id])
+      @os_event = OpenStudiosEvent.find(params[:id])
       if OpenStudiosEventService.update(@os_event, open_studios_event_params)
         redirect_to admin_open_studios_events_path, flash: { notice: 'Successfully updated an Open Studios Event' }
       else
@@ -35,7 +35,7 @@ module Admin
     end
 
     def destroy
-      @os_event = OpenStudiosEventService.find(params[:id])
+      @os_event = OpenStudiosEvent.find(params[:id])
       OpenStudiosEventService.destroy(@os_event)
       redirect_to admin_open_studios_events_path, notice: 'The Event has been removed'
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,8 +10,8 @@ class AdminController < BaseAdminController
   end
 
   def os_status
-    @os = Artist.active.by_lastname
-    @open_studios_events = OpenStudiosEvent.all.includes(:open_studios_participants)
+    @artists = Artist.active.includes(:open_studios_events).by_lastname
+    @open_studios_events = OpenStudiosEvent.all.order(start_date: :desc)
     @totals = @open_studios_events.each_with_object({}) do |open_studio, memo|
       memo[open_studio.key] = open_studio.artists.count
     end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -119,8 +119,11 @@ class Artist < User
   end
 
   def doing_open_studios?(key = nil)
-    os = key ? OpenStudiosEventService.find_by(key: key) : OpenStudiosEventService.current
-    !!(os && open_studios_events.find_by(id: os.to_param))
+    if key
+      open_studios_events.find_by(key: key)
+    else
+      open_studios_events.include? OpenStudiosEventService.current
+    end
   end
 
   alias doing_open_studios doing_open_studios?

--- a/app/presenters/admin_email_list.rb
+++ b/app/presenters/admin_email_list.rb
@@ -79,7 +79,7 @@ class AdminEmailList < ViewPresenter
     when 'no_images'
       Artist.active.reject { |a| a.art_pieces.count.positive? }
     when *available_open_studios_keys
-      OpenStudiosEventService.find_by(key: list_name).try(:artists).presence || []
+      OpenStudiosEventService.find_by_key(list_name).try(:artists).presence || []
     end
   end
 

--- a/app/services/site_statistics.rb
+++ b/app/services/site_statistics.rb
@@ -13,7 +13,7 @@ class SiteStatistics
     {}.tap do |os_stats|
       available_open_studios_keys.sort_by { |k| OpenStudiosEventService.date(k) }.reverse_each do |ostag|
         key = display_key(ostag)
-        os_stats[key] = OpenStudiosEventService.find_by(key: ostag).try(:artists).try(:count) || 0
+        os_stats[key] = OpenStudiosEventService.find_by_key(ostag).try(:artists).try(:count) || 0
       end
     end
   end

--- a/app/views/admin/os_status.slim
+++ b/app/views/admin/os_status.slim
@@ -1,4 +1,3 @@
-- keys = @open_studios_events.map(&:key).sort_by { |k| OpenStudiosEventService.date(k) }.reverse
 .pure-g
   .pure-u-1-1.padded-content
     h1 Open Studios Status
@@ -7,19 +6,20 @@
       thead
         tr
           th name
-          - keys.each do |key|
-            th = OpenStudiosEventService.for_display(key)
+          - @open_studios_events.map(&:for_display).each do |date|
+            th = date
       tbody
-        - @os.each_with_index do |artist,idx|
+        - @artists.each_with_index do |artist,idx|
           tr
             td.os-status__artist-name
               a href=user_path(artist) = artist.get_name
-            - keys.each do |ostag|
+            - stars = @open_studios_events.map{|event| artist.open_studios_events.include?(event)}
+            - stars.each do |star|
               td.tf
-                - if artist.doing_open_studios?(ostag)
+                - if star
                   .fa.fa-star
       tfoot
         tr.totals
           td Totals:
-          - keys.each do |key|
-            td.tf = @totals[key]
+          - @open_studios_events.each do |ev|
+            td.tf = @totals[ev.key]

--- a/db/migrate/20190715064832_add_index_to_open_studios_events_key.rb
+++ b/db/migrate/20190715064832_add_index_to_open_studios_events_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToOpenStudiosEventsKey < ActiveRecord::Migration[5.2]
+  def change
+    add_index :open_studios_events, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_103855) do
+ActiveRecord::Schema.define(version: 2019_07_15_064832) do
 
   create_table "application_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_103855) do
     t.string "title", default: "Open Studios", null: false
     t.string "start_time", default: "noon"
     t.string "end_time", default: "6p"
+    t.index ["key"], name: "index_open_studios_events_on_key", unique: true
   end
 
   create_table "open_studios_participants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -53,8 +53,8 @@ describe AdminController do
       expect(response).to be_successful
     end
     it 'sets a list of artists in alpha order by last name' do
-      expect(assigns(:os)).to have(Artist.active.count).items
-      expect(assigns(:os).map(&:lastname).map(&:downcase)).to be_monotonically_increasing
+      expect(assigns(:artists)).to have(Artist.active.count).items
+      expect(assigns(:artists).map(&:lastname).map(&:downcase)).to be_monotonically_increasing
       expect(assigns(:totals).count).to eql 1
     end
   end

--- a/spec/factories/open_studios_events.rb
+++ b/spec/factories/open_studios_events.rb
@@ -13,5 +13,8 @@ FactoryBot.define do
     trait :future do
       start_date { Time.zone.now + 1.week }
     end
+    trait :past do
+      start_date { Time.zone.now - 6.months }
+    end
   end
 end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -6,6 +6,7 @@ describe Artist do
   let(:max_pieces) { 10 }
   subject(:artist) { FactoryBot.create(:artist, :active, :with_studio, :with_art, max_pieces: max_pieces, firstname: 'Joe', lastname: 'Blow') }
   let!(:open_studios_event) { FactoryBot.create(:open_studios_event) }
+  let!(:past_open_studios_event) { FactoryBot.create(:open_studios_event, :past) }
   let(:wayout_artist) { FactoryBot.create(:artist, :active, :out_of_the_mission) }
   let(:nobody) { FactoryBot.create(:artist, :active, :without_address) }
   let(:artist_without_studio) { FactoryBot.create(:artist, :active, :with_art, :in_the_mission) }
@@ -247,15 +248,23 @@ describe Artist do
   end
 
   describe 'doing_open_studios?' do
+    let(:past_artist) { create(:artist) }
     before do
       artist.open_studios_events << open_studios_event
+      past_artist.open_studios_events << past_open_studios_event
       artist_without_studio
     end
 
     it 'returns true for an artist doing this open studios (with no args)' do
       doing, notdoing = Artist.all.partition(&:doing_open_studios?)
-      expect(doing.size).to eq(1)
-      expect(notdoing.size).to eq(1)
+      expect(doing).to eq([artist])
+      expect(notdoing.size).to eq(2)
+    end
+
+    it 'returns true for an artist doing this a past open studios' do
+      doing, notdoing = Artist.all.partition { |artist| artist.doing_open_studios?(past_open_studios_event.key) }
+      expect(doing).to eq([past_artist])
+      expect(notdoing.size).to eq(2)
     end
   end
 


### PR DESCRIPTION
Problem
-------
The Open Studios Status page on the admin side has gotten really slow.
Close to 30 seconds.

Solution
--------
Let's improve that.

After some investigation, we rejiggered the controller actions to do
some more efficient way of figuring out who's doing open studios (using
the new `OpenStudiosEvent` model) as well as adding an index to
`OpenStudiosEvent.key` and then revamp the `OpenStudiosEventService` so
it is smarter (caching by event key instead of by id b/c we always
search by the event key).

Locally speed of rendering increased by about 50x.  Hopefully we'll see
the same on deployed versions.