### PR TITLE
Add #sfart to the list of tags

### DIFF
--- a/app/presenters/new_art_piece_presenter.rb
+++ b/app/presenters/new_art_piece_presenter.rb
@@ -61,7 +61,7 @@ class NewArtPiecePresenter
   end
 
   def base_tags
-    ['@missionartists']
+    ['@missionartists', '#sfart']
   end
 
   def after_current_os?

--- a/spec/presenters/new_art_piece_presenter_spec.rb
+++ b/spec/presenters/new_art_piece_presenter_spec.rb
@@ -54,6 +54,7 @@ describe NewArtPiecePresenter do
     its(:hash_tags) { is_expected.to include '@missionartists' }
     its(:hash_tags) { is_expected.to include "##{art_piece.tags.first.name.gsub(/[\s-]/, '')}" }
     its(:hash_tags) { is_expected.to include '#mymedium' }
+    its(:hash_tags) { is_expected.to include '#sfart' }
     it 'does not include any os tags' do
       os_tags = [
         '#SFOS',


### PR DESCRIPTION
Problem
-------

The default list of tags does not include `#sfart`

Solution
--------

Add `#sfart` to the base tags generated for a social post