### PR TITLE
Add social icons to user edit form

### DIFF
--- a/app/assets/stylesheets/gto/_forms.scss
+++ b/app/assets/stylesheets/gto/_forms.scss
@@ -70,6 +70,8 @@ tr.error-msg {
   label {
     display: block;
     margin-bottom: 5px;
+    color: $medium-gray;
+    font-size: 0.9rem;
   }
   select {
     height: 35px;

--- a/app/assets/stylesheets/gto/users/_users.scss
+++ b/app/assets/stylesheets/gto/users/_users.scss
@@ -18,6 +18,15 @@
   height: 0;
   display: none;
 }
+
+.user-edit__link-icon {
+  font-size: 1.4rem;
+  margin-right: 5px;
+  & + span {
+    position: relative;
+    bottom: 2px;
+  }
+}
 .panel-group {
   margin-bottom: 20px;
   .panel-heading {

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -149,7 +149,7 @@ class UserPresenter < ViewPresenter
 
       formatted_site = format_link(site)
       site_display = format_link_for_display(site)
-      link_icon_class = icon_link_class(key, site)
+      link_icon_class = self.class.icon_link_class(key, site)
       content_tag 'a', href: formatted_site, title: site_display, target: '_blank' do
         content_tag(:i, '', class: link_icon_class)
       end
@@ -170,7 +170,33 @@ class UserPresenter < ViewPresenter
     (User.stored_attributes[:links] || []).select { |attr| ALLOWED_LINKS.include? attr }
   end
 
+  def self.icon_link_class(key, site = '')
+    site = strip_http_from_link(site)
+    clz = [:ico, 'ico-invert', "ico-#{key}"]
+    icon_chooser = begin
+                     if /\.tumblr\./.match?(site)
+                       'ico-tumblr'
+                     elsif key.to_sym == :blog
+                       if /\.blogger\./.match?(site)
+                         'ico-blogger'
+                       elsif !site.empty?
+                         site_bits = site.split('.')
+                         'ico-' + (site_bits.length > 2 ? site_bits[-3] : site_bits[0])
+                       end
+                     else
+                       ''
+                     end
+                   end
+    (clz + [icon_chooser]).join(' ')
+  end
+
   private
+
+  class << self
+    def strip_http_from_link(link)
+      link.gsub %r{^https?:\/\/}, ''
+    end
+  end
 
   def my_favorites
     if !@user_favorites || !@art_piece_favorites
@@ -190,32 +216,10 @@ class UserPresenter < ViewPresenter
   end
 
   def format_link_for_display(link)
-    strip_http_from_link(link)
+    self.class.strip_http_from_link(link)
   end
 
   def format_link(link)
     (%r{^https?://}.match?(link) ? link : "http://#{link}") if link.present?
-  end
-
-  def icon_link_class(key, site)
-    site = strip_http_from_link(site)
-    clz = [:ico, 'ico-invert', "ico-#{key}"]
-    icon_chooser = begin
-                     if /\.tumblr\./.match?(site)
-                       'ico-tumblr'
-                     elsif key.to_sym == :blog
-                       if /\.blogger\./.match?(site)
-                         'ico-blogger'
-                       else
-                         site_bits = site.split('.')
-                         'ico-' + (site_bits.length > 2 ? site_bits[-3] : site_bits[0])
-                       end
-                     end
-                   end
-    (clz + [icon_chooser]).join(' ')
-  end
-
-  def strip_http_from_link(link)
-    link.gsub %r{^https?:\/\/}, ''
   end
 end

--- a/app/views/users/edit/_links.html.slim
+++ b/app/views/users/edit/_links.html.slim
@@ -11,7 +11,8 @@
         - link_info.each do |key|
           - placeholder = "e.g. http://#{key}.com/mypage" if key.to_sym != :website
           .pure-u-1-1.pure-u-sm-1-2
-            = form.input key, label: key, placeholder: placeholder
+            - label = content_tag('i', '',class: "user-edit__link-icon #{UserPresenter::icon_link_class(key)}") + content_tag("span", key.to_s.titleize)
+            = form.input key, label: label, placeholder: placeholder
     = form.actions do
       = form.submit 'Save Changes', class: "pure-button pure-button-primary"
       = form.submit 'Cancel', class: "pure-button"

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -49,25 +49,25 @@ describe UserPresenter do
     end
   end
 
-  describe '#icon_link_class' do
+  describe '.icon_link_class' do
     it 'returns ico-tumblr for www.whatever.tumblr.com' do
-      clz = presenter.send(:icon_link_class, :blog, 'http://www.whatever.tumblr.com')
+      clz = described_class.send(:icon_link_class, :blog, 'http://www.whatever.tumblr.com')
       expect(clz).to include 'ico-tumblr'
       expect(clz).to include 'ico-blog'
     end
 
     it 'returns ico-tumblr for whatever.tumblr.com' do
-      clz = presenter.send(:icon_link_class, :blog, 'http://whatever.tumblr.com')
+      clz = described_class.send(:icon_link_class, :blog, 'http://whatever.tumblr.com')
       expect(clz).to include 'ico-tumblr'
     end
 
     it 'returns ico-blogger for www.blogger.com' do
-      clz = presenter.send(:icon_link_class, :blog, 'http://www.blogger.com')
+      clz = described_class.send(:icon_link_class, :blog, 'http://www.blogger.com')
       expect(clz).to include 'ico-blogger'
     end
 
     it 'returns ico-twitter for www.twitter.com/herewego' do
-      clz = presenter.send(:icon_link_class, :twitter, 'whatever')
+      clz = described_class.send(:icon_link_class, :twitter, 'whatever')
       expect(clz).to include 'ico-twitter'
     end
   end


### PR DESCRIPTION
On the user edit links section, we want people to better understand what
links are associated with which icons in the app.

So this PR adds the icons to the form in front of the name of the link
input form.

<img width="1005" alt="Screen Shot 2019-11-10 at 9 51 35 AM" src="https://user-images.githubusercontent.com/427380/68548260-bfc0fa00-039f-11ea-8c8a-edce6781b728.png">
