### PR TITLE
Remove Medium data migration (in favor of seeding)

### DIFF
--- a/db/migrate/20091029072600_add_encaustic_to_media.rb
+++ b/db/migrate/20091029072600_add_encaustic_to_media.rb
@@ -1,15 +1,7 @@
-class AddEncausticToMedia < ActiveRecord::Migration
-  def self.add_medium(name)
-    unless Medium.find_by_name(name)
-      Medium.new(:name=>name).save
-    else
-      puts "Medium " + name + " has already been added"
-    end
-  end
-  def self.up
-    self.add_medium('Painting - Encaustic')
-  end
+# frozen_string_literal: true
 
-  def self.down
-  end
+class AddEncausticToMedia < ActiveRecord::Migration
+  def self.up; end
+
+  def self.down; end
 end


### PR DESCRIPTION
Problem
-------

When I wrote the app, I didn't understand the danger of data migrations
and I didn't understand the way one could use a seed file.

Over time, I finally learned about seeds so all the `Medium` values that
we need are seeded with `db:seed` but I neglected to remove the
migration that I put in (in 2009) that tries to add one more medium to
the mix.

The real issue is that for new developers, if they try to migrate
they'll find that the new `Medium` model needs a slug but the data
migration was written before slug was required so it fails.

Solution
--------

Dump the offending migration file and know that the seeds file actually
adds that medium properly.