### PR TITLE
Update sample data os participation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow the post-install instructions to get your MySQL server running.  For easy
 
 Use `homebrew` to install the following packages:
 
-    brew install markdown imagemagick	memcached chromedriver elasticsearch@2.4
+    brew install markdown imagemagick	memcached elasticsearch@2.4
 
 At this point, you should have all the binary resources you'll need (hopefully).
 

--- a/db/sample_data/open_studios.rb
+++ b/db/sample_data/open_studios.rb
@@ -13,6 +13,6 @@ ensure_open_studios_event(Time.zone.local(2017, 4, 1))
 
 OpenStudiosEvent.all.each do |os_event|
   Artist.active.each do |artist|
-    artist.update_os_participation os_event, true
+    artist.open_studios_events << os_event
   end
 end


### PR DESCRIPTION
Problem
--------

A whlies back (PR #4) we removed the `update_os_participation` method
when we moved to actually joining `Artist` with `OpenStudiosEvent` (as
it should be).  The sample data script was still depending on that
method.

Solution
--------

Update the sample data method to build the join records with a shovel
(`<<`) and not try to use a non-existing method.