### PR TITLE
Update when we show the 'register now' reminder

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -197,7 +197,7 @@ class User < ApplicationRecord
   end
 
   def artist?
-    self[:type] == 'Artist'
+    is_a?(Artist)
   end
 
   def manages?(studio)

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -15,6 +15,7 @@ class ArtistPresenter < UserPresenter
            :active?,
            :address,
            :address?,
+           :artist?,
            :artist_info,
            :at_art_piece_limit?,
            :can_register_for_open_studios?,
@@ -30,10 +31,6 @@ class ArtistPresenter < UserPresenter
            :updated_at,
            to: :artist, allow_nil: true
   delegate(*ALLOWED_LINKS, to: :artist, allow_nil: true)
-
-  def artist?
-    artist && model.is_a?(Artist)
-  end
 
   def artist
     model

--- a/app/presenters/user_navigation.rb
+++ b/app/presenters/user_navigation.rb
@@ -19,9 +19,10 @@ class UserNavigation < Navigation
 
   def remind_for_open_studios_register?
     current_event = OpenStudiosEventService.current
-    return false if !current_event || current_artist&.doing_open_studios?
 
-    Time.zone.now < current_event.start_date && current_event.start_date <= Time.zone.now + EVENT_REGISTER_COUNTDOWN
+    return false if !current_event || !current_artist || current_artist&.doing_open_studios?
+
+    current_event.start_date.between?(Time.zone.now, Time.zone.now + EVENT_REGISTER_COUNTDOWN)
   end
 
   private

--- a/app/services/update_artist_service.rb
+++ b/app/services/update_artist_service.rb
@@ -10,7 +10,7 @@ class UpdateArtistService
     @params = params
     @current_os = OpenStudiosEventService.current
     raise UpdateArtistService::Error, 'artist cannot be nil' unless artist
-    raise UpdateArtistService::Error, 'artist must be an artist' unless artist.is_a?(Artist)
+    raise UpdateArtistService::Error, 'artist must be an artist' unless artist.artist?
   end
 
   def update

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 
 require 'capistrano/bundler'
 
-lock '~> 3.11.0'
+lock '~> 3.12.0'
 
 set :stages, %w[production acceptance]
 

--- a/spec/presenters/social_catalog_presenter_spec.rb
+++ b/spec/presenters/social_catalog_presenter_spec.rb
@@ -31,6 +31,7 @@ describe SocialCatalogPresenter do
     name = Faker::Name.name
     art_pieces = [fake_art]
     attrs = attributes_for(:artist).merge(gen_links).merge(
+      artist?: true,
       art_pieces: art_pieces,
       artist_info: build_stubbed(:artist_info),
       doing_open_studios?: true,
@@ -53,6 +54,7 @@ describe SocialCatalogPresenter do
       name = Faker::Name.name
       art_pieces = [fake_art]
       attrs = attributes_for(:artist).merge(gen_links).merge(
+        artist?: true,
         art_pieces: [instance_double(ArtPiece, persisted?: true)],
         artist_info: build_stubbed(:artist_info, max_pieces: 4),
         doing_open_studios?: true,

--- a/spec/presenters/user_navigation_spec.rb
+++ b/spec/presenters/user_navigation_spec.rb
@@ -3,54 +3,63 @@
 require 'rails_helper'
 
 describe UserNavigation do
-  let(:artist) { create :artist }
-  let(:artist_nav) { described_class.new(artist) }
-
   describe 'remind_for_open_studios_register?' do
-    let(:artist_to_remind) { create(:artist) }
-    let(:artist_to_remind_nav) { described_class.new(:artist_to_remind) }
+    let(:artist) { create(:artist) }
+    subject(:navigation) { described_class.new(artist) }
 
-    before do
-      Timecop.freeze
-    end
-
-    after do
-      Timecop.return
-    end
-
-    context 'when there is a future open studios event' do
-      let(:future_open_studios_event) { FactoryBot.create(:open_studios_event, :future) }
-
+    context 'when open studios is less than 12 weeks away' do
       before do
-        Timecop.freeze
-        artist.open_studios_events << future_open_studios_event
+        @os = create(:open_studios_event, start_date: 10.weeks.since)
+      end
+      it 'returns true' do
+        expect(navigation.remind_for_open_studios_register?).to eq true
       end
 
-      after do
-        Timecop.return
+      context 'if the user is already signed up' do
+        before do
+          artist.open_studios_events << @os
+        end
+        it 'returns false' do
+          expect(navigation.remind_for_open_studios_register?).to eq false
+        end
       end
 
-      it 'returns true if artist has not registered for current event and it is no more than 12 weeks away' do
-        expect(artist_to_remind_nav.remind_for_open_studios_register?).to eq(true)
+      context 'when the user is not logged in' do
+        let(:artist) { nil }
+        it 'returns false' do
+          expect(navigation.remind_for_open_studios_register?).to eq false
+        end
       end
 
-      it 'returns false if the artist is already registered for current event' do
-        expect(artist_nav.remind_for_open_studios_register?).to eq(false)
+      context 'when the user is logged in as a fan' do
+        let(:artist) { create(:fan) }
+        it 'returns false' do
+          expect(navigation.remind_for_open_studios_register?).to eq false
+        end
+      end
+    end
+
+    context 'when open studios is more than 12 weeks away' do
+      before do
+        @os = create(:open_studios_event, start_date: 13.weeks.since)
+      end
+      it 'returns false' do
+        expect(navigation.remind_for_open_studios_register?).to eq false
+      end
+    end
+
+    context 'when open studios are only in the past' do
+      before do
+        create(:open_studios_event, start_date: 1.month.ago)
+      end
+      it 'returns false' do
+        expect(navigation.remind_for_open_studios_register?).to eq(false)
       end
     end
 
     context 'when there are no open studios events' do
       it 'returns false' do
-        expect(artist_to_remind_nav.remind_for_open_studios_register?).to eq(false)
-      end
-    end
-
-    context 'when there is no future open studios event' do
-      before do
-        create(:open_studios_event, start_date: 1.month.ago)
-      end
-      it 'returns false' do
-        expect(artist_to_remind_nav.remind_for_open_studios_register?).to eq(false)
+        expect(navigation.remind_for_open_studios_register?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Problem
-------

We were showing `register now` to all logged out users.

Solution
--------

Make sure we check for logged in users before we show that message.

Changes
-------

* update the `remind_...?` check method to include checking for
`current_artist`
* revamp and add a few more specs.