### PR TITLE
Add #artinthetimeofcovid tag to new art presenter

### DIFF
--- a/app/presenters/new_art_piece_presenter.rb
+++ b/app/presenters/new_art_piece_presenter.rb
@@ -27,6 +27,7 @@ class NewArtPiecePresenter
       tags_from_tags +
       tags_from_medium +
       tags_for_open_studios +
+      custom_tags +
       base_tags
     )
   end
@@ -60,8 +61,12 @@ class NewArtPiecePresenter
     end
   end
 
+  def custom_tags
+    %w[#artinthetimeofcovid]
+  end
+
   def base_tags
-    ['@missionartists', '#sfart']
+    %w[#missionartists #sfart]
   end
 
   def after_current_os?

--- a/spec/presenters/new_art_piece_presenter_spec.rb
+++ b/spec/presenters/new_art_piece_presenter_spec.rb
@@ -51,10 +51,18 @@ describe NewArtPiecePresenter do
   end
 
   describe '#hash_tags' do
-    its(:hash_tags) { is_expected.to include '@missionartists' }
-    its(:hash_tags) { is_expected.to include "##{art_piece.tags.first.name.gsub(/[\s-]/, '')}" }
-    its(:hash_tags) { is_expected.to include '#mymedium' }
-    its(:hash_tags) { is_expected.to include '#sfart' }
+    it 'includes tags from the art' do
+      expect(subject.hash_tags).to include "##{art_piece.tags.first.name.gsub(/[\s-]/, '')}"
+    end
+    it 'includes tags from the art medium' do
+      expect(subject.hash_tags).to include '#mymedium'
+    end
+    it 'includes base tags' do
+      expect(subject.hash_tags).to include '#missionartists #sfart'
+    end
+    it 'includes custom tags' do
+      expect(subject.hash_tags).to include '#artinthetimeofcovid'
+    end
     it 'does not include any os tags' do
       os_tags = [
         '#SFOS',


### PR DESCRIPTION
Problem
-------

Coronavirus

Solution
--------

Trish wanted to promote an art hashtag in this weird time so we're
adding this to the new art presenter email that goes to trish and the
watchers to now include #artinthetimeofcovid