### PR TITLE
Add site preferences model

### DIFF
--- a/app/controllers/admin/site_preferences_controller.rb
+++ b/app/controllers/admin/site_preferences_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  class SitePreferencesController < ::BaseAdminController
+    before_action :load_site_preferences, only: %i[edit update]
+
+    def edit; end
+
+    def update
+      if @site_preferences.update(site_preferences_params)
+        redirect_to edit_admin_site_preferences_path, notice: 'Got it.  The new preferences are in place.'
+      else
+        render action: 'edit'
+      end
+    end
+
+    private
+
+    def load_site_preferences
+      @site_preferences = SitePreferences.instance
+    end
+
+    def site_preferences_params
+      params.require(:site_preferences).permit(:social_media_tags)
+    end
+  end
+end

--- a/app/models/site_preferences.rb
+++ b/app/models/site_preferences.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require Rails.root.join('app/lib/safe_cache')
+
+class SitePreferences < ApplicationRecord
+  self.table_name = :site_preferences
+
+  after_save :write_through_cache
+
+  CACHE_KEY = :site_preferences
+
+  def self.instance(check_cache = false)
+    (check_cache && cached) || first || create
+  end
+
+  def self.cached
+    r = SafeCache.read(CACHE_KEY)
+    return nil unless r
+
+    new(JSON.parse(r).with_indifferent_access[:site_preferences])
+  end
+
+  def write_through_cache
+    SafeCache.write(CACHE_KEY, to_json)
+  end
+end

--- a/app/presenters/admin_navigation.rb
+++ b/app/presenters/admin_navigation.rb
@@ -9,6 +9,8 @@ class AdminNavigation < ViewPresenter
 
   def admin_links
     pr_links = [
+      [:open_studios_events, { display: 'os dates' }],
+      [:site_preferences, { link: url_helpers.edit_admin_site_preferences_path }],
       [:favorites, {}],
       [:catalog, { link: '/catalog' }],
       [:cms_documents, { display: 'cms', link: url_helpers.admin_cms_documents_path }],
@@ -22,7 +24,6 @@ class AdminNavigation < ViewPresenter
       [:emaillist, { display: 'member emails', link: url_helpers.admin_member_emails_path }],
     ]
     admin_links = [
-      [:open_studios_events, { display: 'os dates' }],
       [:roles, {}],
       [:internal_email, { display: 'admin email lists', link: url_helpers.admin_email_lists_path }],
       [:blacklist, { display: 'blacklist', link: url_helpers.admin_blacklist_domains_path }],

--- a/app/presenters/new_art_piece_presenter.rb
+++ b/app/presenters/new_art_piece_presenter.rb
@@ -17,19 +17,19 @@ class NewArtPiecePresenter
   end
 
   def hash_tags
-    tags.uniq.map { |t| tag_cleaner(t) }.uniq.join(' ')
+    tags.uniq.map { |t| tag_cleaner(t) }.uniq.join(' ').gsub(/\s+/, ' ')
   end
 
   private
 
   def tags
     (
+      [custom_tag_string] +
       tags_from_tags +
       tags_from_medium +
       tags_for_open_studios +
-      custom_tags +
       base_tags
-    )
+    ).compact(&:present?)
   end
 
   def tag_cleaner(tag)
@@ -61,8 +61,8 @@ class NewArtPiecePresenter
     end
   end
 
-  def custom_tags
-    %w[#artinthetimeofcovid]
+  def custom_tag_string
+    SitePreferences.instance(true).social_media_tags
   end
 
   def base_tags

--- a/app/views/admin/site_preferences/edit.html.slim
+++ b/app/views/admin/site_preferences/edit.html.slim
@@ -1,0 +1,11 @@
+.pure-g
+  .pure-u-1-1.padded-content
+    = semantic_form_for [:admin, @site_preferences], url: admin_site_preferences_path do |f|
+      = render partial: 'common/form_errors', locals: { form: f }
+      = f.inputs do
+        = f.input :social_media_tags, placeholder: 'e.g. #supertag, #anotherTag', hint: "Tags here will be the first tags shown in the new art email that goes out to all our new art watchers."
+      = f.actions do
+        .form-controls
+          = f.submit class: 'pure-button pure-button-primary'
+          = link_to 'Cancel', edit_admin_site_preferences_path, class: 'pure-button'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Mau::Application.routes.draw do
 
     get :os_status
 
+    resource :site_preferences, only: %i[edit update]
     resources :mau_fans, only: [:index]
     resource :palette, only: [:show]
     resource :member_emails, only: [:show]

--- a/db/migrate/20200314234551_create_site_preferences.rb
+++ b/db/migrate/20200314234551_create_site_preferences.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateSitePreferences < ActiveRecord::Migration[5.2]
+  def change
+    create_table :site_preferences do |t|
+      t.string :social_media_tags
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,277 +12,282 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_14_220622) do
-
-  create_table "application_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "type"
-    t.string "message"
-    t.text "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+ActiveRecord::Schema.define(version: 2020_03_14_234551) do
+  create_table 'application_events', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.string 'type'
+    t.string 'message'
+    t.text 'data'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "art_piece_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "slug"
+  create_table 'art_piece_tags', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.string 'slug'
   end
 
-  create_table "art_pieces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title"
-    t.string "dimensions"
-    t.integer "artist_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "medium_id"
-    t.integer "year"
-    t.integer "position", default: 0
-    t.string "photo_file_name"
-    t.string "photo_content_type"
-    t.integer "photo_file_size"
-    t.datetime "photo_updated_at"
-    t.index ["artist_id"], name: "index_art_pieces_on_artist_id"
-    t.index ["medium_id"], name: "index_art_pieces_on_medium_id"
+  create_table 'art_pieces', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'title'
+    t.string 'dimensions'
+    t.integer 'artist_id'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.integer 'medium_id'
+    t.integer 'year'
+    t.integer 'position', default: 0
+    t.string 'photo_file_name'
+    t.string 'photo_content_type'
+    t.integer 'photo_file_size'
+    t.datetime 'photo_updated_at'
+    t.index ['artist_id'], name: 'index_art_pieces_on_artist_id'
+    t.index ['medium_id'], name: 'index_art_pieces_on_medium_id'
   end
 
-  create_table "art_pieces_tags", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "art_piece_tag_id"
-    t.integer "art_piece_id"
-    t.index ["art_piece_id"], name: "index_art_pieces_tags_on_art_piece_id"
-    t.index ["art_piece_tag_id"], name: "index_art_pieces_tags_on_art_piece_tag_id"
+  create_table 'art_pieces_tags', id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'art_piece_tag_id'
+    t.integer 'art_piece_id'
+    t.index ['art_piece_id'], name: 'index_art_pieces_tags_on_art_piece_id'
+    t.index ['art_piece_tag_id'], name: 'index_art_pieces_tags_on_art_piece_tag_id'
   end
 
-  create_table "artist_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'artist_images', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "artist_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "artist_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "bio"
-    t.string "street"
-    t.string "city", limit: 200
-    t.string "addr_state", limit: 4
-    t.integer "zip"
-    t.integer "max_pieces", default: 20
-    t.string "studionumber"
-    t.float "lat"
-    t.float "lng"
-    t.string "deprecated_open_studios_participation"
-    t.index ["artist_id"], name: "index_artist_infos_on_artist_id", unique: true
+  create_table 'artist_infos', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'artist_id'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.text 'bio'
+    t.string 'street'
+    t.string 'city', limit: 200
+    t.string 'addr_state', limit: 4
+    t.integer 'zip'
+    t.integer 'max_pieces', default: 20
+    t.string 'studionumber'
+    t.float 'lat'
+    t.float 'lng'
+    t.string 'deprecated_open_studios_participation'
+    t.index ['artist_id'], name: 'index_artist_infos_on_artist_id', unique: true
   end
 
-  create_table "artist_profile_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'artist_profile_images', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "blacklist_domains", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "domain"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'blacklist_domains', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.string 'domain'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "cms_documents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "page"
-    t.string "section"
-    t.text "article"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "user_id"
-    t.index ["user_id"], name: "index_cms_documents_on_user_id"
+  create_table 'cms_documents', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'page'
+    t.string 'section'
+    t.text 'article'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.integer 'user_id'
+    t.index ['user_id'], name: 'index_cms_documents_on_user_id'
   end
 
-  create_table "email_list_memberships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "email_id"
-    t.integer "email_list_id"
-    t.index ["email_id"], name: "index_email_list_memberships_on_email_id"
-    t.index ["email_list_id"], name: "index_email_list_memberships_on_email_list_id"
+  create_table 'email_list_memberships', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'email_id'
+    t.integer 'email_list_id'
+    t.index ['email_id'], name: 'index_email_list_memberships_on_email_id'
+    t.index ['email_list_id'], name: 'index_email_list_memberships_on_email_list_id'
   end
 
-  create_table "email_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["type"], name: "index_email_lists_on_type", unique: true
+  create_table 'email_lists', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'type'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.index ['type'], name: 'index_email_lists_on_type', unique: true
   end
 
-  create_table "emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["email"], name: "index_emails_on_email", unique: true
+  create_table 'emails', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name'
+    t.string 'email'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.index ['email'], name: 'index_emails_on_email', unique: true
   end
 
-  create_table "favorites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "favoritable_id"
-    t.string "favoritable_type"
-    t.integer "user_id"
-    t.index ["favoritable_type", "favoritable_id", "user_id"], name: "index_favorites_uniq_on_user_and_favorite", unique: true
+  create_table 'favorites', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.integer 'favoritable_id'
+    t.string 'favoritable_type'
+    t.integer 'user_id'
+    t.index %w[favoritable_type favoritable_id user_id], name: 'index_favorites_uniq_on_user_and_favorite', unique: true
   end
 
-  create_table "feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "subject"
-    t.string "email"
-    t.string "login"
-    t.string "page"
-    t.text "comment"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "url"
-    t.string "skillsets"
-    t.string "bugtype"
+  create_table 'feedbacks', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'subject'
+    t.string 'email'
+    t.string 'login'
+    t.string 'page'
+    t.text 'comment'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.string 'url'
+    t.string 'skillsets'
+    t.string 'bugtype'
   end
 
-  create_table "friendly_id_slugs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "slug", null: false
-    t.integer "sluggable_id", null: false
-    t.string "sluggable_type", limit: 40
-    t.datetime "created_at"
-    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true
-    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
-    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  create_table 'friendly_id_slugs', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.string 'slug', null: false
+    t.integer 'sluggable_id', null: false
+    t.string 'sluggable_type', limit: 40
+    t.datetime 'created_at'
+    t.index %w[slug sluggable_type], name: 'index_friendly_id_slugs_on_slug_and_sluggable_type', unique: true
+    t.index ['sluggable_id'], name: 'index_friendly_id_slugs_on_sluggable_id'
+    t.index ['sluggable_type'], name: 'index_friendly_id_slugs_on_sluggable_type'
   end
 
-  create_table "media", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "slug"
-    t.index ["slug"], name: "index_media_on_slug", unique: true
+  create_table 'media', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.string 'slug'
+    t.index ['slug'], name: 'index_media_on_slug', unique: true
   end
 
-  create_table "open_studios_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.datetime "start_date"
-    t.datetime "end_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "key"
-    t.string "title", default: "Open Studios", null: false
-    t.string "start_time", default: "noon"
-    t.string "end_time", default: "6p"
-    t.boolean "promote", default: true, null: false
-    t.index ["key"], name: "index_open_studios_events_on_key", unique: true
+  create_table 'open_studios_events', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.datetime 'start_date'
+    t.datetime 'end_date'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'key'
+    t.string 'title', default: 'Open Studios', null: false
+    t.string 'start_time', default: 'noon'
+    t.string 'end_time', default: '6p'
+    t.boolean 'promote', default: true, null: false
+    t.index ['key'], name: 'index_open_studios_events_on_key', unique: true
   end
 
-  create_table "open_studios_participants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "open_studios_event_id"
-    t.index ["open_studios_event_id"], name: "index_open_studios_participants_on_open_studios_event_id"
-    t.index ["user_id", "open_studios_event_id"], name: "idx_os_participants_on_user_and_open_studios_event", unique: true
-    t.index ["user_id"], name: "index_open_studios_participants_on_user_id"
+  create_table 'open_studios_participants', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'user_id'
+    t.integer 'open_studios_event_id'
+    t.index ['open_studios_event_id'], name: 'index_open_studios_participants_on_open_studios_event_id'
+    t.index %w[user_id open_studios_event_id], name: 'idx_os_participants_on_user_and_open_studios_event', unique: true
+    t.index ['user_id'], name: 'index_open_studios_participants_on_user_id'
   end
 
-  create_table "open_studios_tallies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "count"
-    t.string "oskey"
-    t.date "recorded_on"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'open_studios_tallies', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.integer 'count'
+    t.string 'oskey'
+    t.date 'recorded_on'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "promoted_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "event_id"
-    t.datetime "publish_date"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'promoted_events', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.integer 'event_id'
+    t.datetime 'publish_date'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "role"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'roles', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'role'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "roles_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "role_id"
-    t.index ["role_id"], name: "index_roles_users_on_role_id"
-    t.index ["user_id"], name: "index_roles_users_on_user_id"
+  create_table 'roles_users', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.integer 'user_id'
+    t.integer 'role_id'
+    t.index ['role_id'], name: 'index_roles_users_on_role_id'
+    t.index ['user_id'], name: 'index_roles_users_on_user_id'
   end
 
-  create_table "scammers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.text "email"
-    t.text "name"
-    t.integer "faso_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table 'scammers', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci', force: :cascade do |t|
+    t.text 'email'
+    t.text 'name'
+    t.integer 'faso_id'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 
-  create_table "studios", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.string "street"
-    t.string "city"
-    t.string "state"
-    t.integer "zip"
-    t.string "url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "profile_image"
-    t.float "lat", limit: 53
-    t.float "lng", limit: 53
-    t.string "cross_street"
-    t.string "phone"
-    t.string "slug"
-    t.string "photo_file_name"
-    t.string "photo_content_type"
-    t.integer "photo_file_size"
-    t.datetime "photo_updated_at"
-    t.integer "position", default: 1000
-    t.index ["slug"], name: "index_studios_on_slug", unique: true
+  create_table 'site_preferences', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'social_media_tags'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "login", limit: 40
-    t.string "name", limit: 100, default: ""
-    t.string "email", limit: 100
-    t.string "crypted_password", limit: 128, default: "", null: false
-    t.string "password_salt", limit: 128, default: "", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "remember_token", limit: 40
-    t.datetime "remember_token_expires_at"
-    t.string "firstname", limit: 40
-    t.string "lastname", limit: 40
-    t.string "nomdeplume", limit: 80
-    t.string "url", limit: 200
-    t.string "profile_image", limit: 200
-    t.integer "studio_id"
-    t.string "activation_code", limit: 40
-    t.datetime "activated_at"
-    t.string "state", default: "passive"
-    t.datetime "deleted_at"
-    t.string "reset_code", limit: 40
-    t.string "email_attrs", default: "{\"fromartist\": true, \"favorites\": true, \"fromall\": true}"
-    t.string "type", default: "Artist"
-    t.date "mailchimp_subscribed_at"
-    t.string "persistence_token"
-    t.integer "login_count", default: 0, null: false
-    t.datetime "last_request_at"
-    t.datetime "last_login_at"
-    t.datetime "current_login_at"
-    t.string "last_login_ip"
-    t.string "current_login_ip"
-    t.string "slug"
-    t.string "photo_file_name"
-    t.string "photo_content_type"
-    t.integer "photo_file_size"
-    t.datetime "photo_updated_at"
-    t.text "links"
-    t.index ["last_request_at"], name: "index_users_on_last_request_at"
-    t.index ["login"], name: "index_artists_on_login", unique: true
-    t.index ["persistence_token"], name: "index_users_on_persistence_token"
-    t.index ["slug"], name: "index_users_on_slug", unique: true
-    t.index ["state"], name: "index_users_on_state"
-    t.index ["studio_id"], name: "index_users_on_studio_id"
+  create_table 'studios', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name'
+    t.string 'street'
+    t.string 'city'
+    t.string 'state'
+    t.integer 'zip'
+    t.string 'url'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.string 'profile_image'
+    t.float 'lat', limit: 53
+    t.float 'lng', limit: 53
+    t.string 'cross_street'
+    t.string 'phone'
+    t.string 'slug'
+    t.string 'photo_file_name'
+    t.string 'photo_content_type'
+    t.integer 'photo_file_size'
+    t.datetime 'photo_updated_at'
+    t.integer 'position', default: 1000
+    t.index ['slug'], name: 'index_studios_on_slug', unique: true
   end
 
-  add_foreign_key "open_studios_participants", "open_studios_events"
-  add_foreign_key "open_studios_participants", "users"
+  create_table 'users', id: :integer, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'login', limit: 40
+    t.string 'name', limit: 100, default: ''
+    t.string 'email', limit: 100
+    t.string 'crypted_password', limit: 128, default: '', null: false
+    t.string 'password_salt', limit: 128, default: '', null: false
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
+    t.string 'remember_token', limit: 40
+    t.datetime 'remember_token_expires_at'
+    t.string 'firstname', limit: 40
+    t.string 'lastname', limit: 40
+    t.string 'nomdeplume', limit: 80
+    t.string 'url', limit: 200
+    t.string 'profile_image', limit: 200
+    t.integer 'studio_id'
+    t.string 'activation_code', limit: 40
+    t.datetime 'activated_at'
+    t.string 'state', default: 'passive'
+    t.datetime 'deleted_at'
+    t.string 'reset_code', limit: 40
+    t.string 'email_attrs', default: '{"fromartist": true, "favorites": true, "fromall": true}'
+    t.string 'type', default: 'Artist'
+    t.date 'mailchimp_subscribed_at'
+    t.string 'persistence_token'
+    t.integer 'login_count', default: 0, null: false
+    t.datetime 'last_request_at'
+    t.datetime 'last_login_at'
+    t.datetime 'current_login_at'
+    t.string 'last_login_ip'
+    t.string 'current_login_ip'
+    t.string 'slug'
+    t.string 'photo_file_name'
+    t.string 'photo_content_type'
+    t.integer 'photo_file_size'
+    t.datetime 'photo_updated_at'
+    t.text 'links'
+    t.index ['last_request_at'], name: 'index_users_on_last_request_at'
+    t.index ['login'], name: 'index_artists_on_login', unique: true
+    t.index ['persistence_token'], name: 'index_users_on_persistence_token'
+    t.index ['slug'], name: 'index_users_on_slug', unique: true
+    t.index ['state'], name: 'index_users_on_state'
+    t.index ['studio_id'], name: 'index_users_on_studio_id'
+  end
+
+  add_foreign_key 'open_studios_participants', 'open_studios_events'
+  add_foreign_key 'open_studios_participants', 'users'
 end

--- a/spec/factories/site_preferences.rb
+++ b/spec/factories/site_preferences.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_preferences do
+    social_media_tags { '#whatever' }
+  end
+end

--- a/spec/models/site_preferences_spec.rb
+++ b/spec/models/site_preferences_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SitePreferences, type: :model do
+  describe '.instance' do
+    it 'tries first then create' do
+      allow(SitePreferences).to receive(:first)
+      allow(SitePreferences).to receive(:create)
+      SitePreferences.instance
+      expect(SitePreferences).to have_received(:first)
+      expect(SitePreferences).to have_received(:create)
+    end
+
+    it 'returns first if it exists' do
+      create(:site_preferences)
+      allow(SitePreferences).to receive(:create)
+      SitePreferences.instance
+      expect(SitePreferences).to_not have_received(:create)
+    end
+
+    context 'sending in `cached = true`' do
+      it 'tries the cache first' do
+        allow(SitePreferences).to receive(:first)
+        allow(SitePreferences).to receive(:create)
+        allow(SafeCache).to receive(:read).and_return(build_stubbed(:site_preferences).to_json)
+        SitePreferences.instance(true)
+        expect(SitePreferences).to_not have_received(:first)
+        expect(SitePreferences).to_not have_received(:create)
+      end
+    end
+  end
+end

--- a/spec/presenters/new_art_piece_presenter_spec.rb
+++ b/spec/presenters/new_art_piece_presenter_spec.rb
@@ -51,6 +51,9 @@ describe NewArtPiecePresenter do
   end
 
   describe '#hash_tags' do
+    before do
+      SitePreferences.instance.update(social_media_tags: '#whatever-man')
+    end
     it 'includes tags from the art' do
       expect(subject.hash_tags).to include "##{art_piece.tags.first.name.gsub(/[\s-]/, '')}"
     end
@@ -61,7 +64,7 @@ describe NewArtPiecePresenter do
       expect(subject.hash_tags).to include '#missionartists #sfart'
     end
     it 'includes custom tags' do
-      expect(subject.hash_tags).to include '#artinthetimeofcovid'
+      expect(subject.hash_tags).to start_with('#whateverman')
     end
     it 'does not include any os tags' do
       os_tags = [


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171799466

We want to save Social Media tags which are to be used in some system
emails.  It made sense to add a `SitePreferences` model which can just
hold whatever "global" things we might have to save.  Currently it'll
just be social media tags.

Then we can use it in the new_art_piece_presenter to send the new custom
tags to the folks watching for new email.

Screenshots
-------------

<img width="293" alt="Screen Shot 2020-03-15 at 4 29 23 PM" src="https://user-images.githubusercontent.com/427380/76712932-47b26a00-66da-11ea-8491-4ac9655f6b83.png">
<img width="702" alt="Screen Shot 2020-03-15 at 4 29 33 PM" src="https://user-images.githubusercontent.com/427380/76712934-497c2d80-66da-11ea-92c4-040fa16d5f98.png">
