### PR TITLE
Don't promote the register button if the OpenStudios is not promoted

### DIFF
--- a/app/presenters/open_studios_presenter.rb
+++ b/app/presenters/open_studios_presenter.rb
@@ -3,17 +3,11 @@
 class OpenStudiosPresenter
   PAGE = 'main_openstudios'
 
+  delegate :promote?, to: :current_os
+
   def packaged_summary
     section = 'summary'
     @packaged_summary ||= CmsDocument.packaged(PAGE, section)
-  end
-
-  def summary_data
-    @summary_data = editable_content_data(packaged_summary)
-  end
-
-  def summary
-    packaged_summary[:content]
   end
 
   def packaged_preview_reception
@@ -21,25 +15,15 @@ class OpenStudiosPresenter
     @packaged_preview_reception ||= CmsDocument.packaged(PAGE, section)
   end
 
-  def preview_reception_data
-    @preview_reception_data ||= editable_content_data(packaged_preview_reception)
-  end
-
-  def preview_reception
-    packaged_preview_reception[:content]
-  end
-
-  def os_participants
-    @os_participants ||= OpenStudiosEventService.current.artists.in_the_mission
-  end
-
   def participating_studios
-    @participating_studios ||= sort_studios_by_name(os_participants.map(&:studio).compact.uniq)
+    @participating_studios ||= sort_studios_by_name(os_participants.map(&:studio))
   end
 
   def participating_indies
     @participating_indies ||= sort_artists_by_name(os_participants.reject { |a| a.studio || a.address.blank? })
   end
+
+  private
 
   def sort_studios_by_name(studios)
     studios.compact.uniq.sort(&Studio::SORT_BY_NAME)
@@ -49,9 +33,11 @@ class OpenStudiosPresenter
     artists.compact.uniq.sort(&Artist::SORT_BY_LASTNAME)
   end
 
-  private
+  def current_os
+    @current_os ||= OpenStudiosEventService.current
+  end
 
-  def editable_content_data(packaged_data)
-    Hash[packaged_data.reject { |k, _v| k == :content }.map { |item| ["data-#{item[0]}", item[1]] }]
+  def os_participants
+    @os_participants ||= current_os.artists.in_the_mission
   end
 end

--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -74,4 +74,4 @@
                 i.fa.fa-icon.fa-edit
               - if !a.suspended? && a != current_user
                 = link_to suspend_admin_artist_path(a.to_param), method: :post, confirm: 'Are you sure you want to suspend this artist?', title: "Suspend artist", class: 'admin-artist-suspend-link' do
-                  i.fa.fa-icon.fa-bomb
+                  i.far.fa-icon.fa-bomb

--- a/app/views/open_studios/show.html.slim
+++ b/app/views/open_studios/show.html.slim
@@ -1,8 +1,9 @@
 .pure-g.sticky-header
   .pure-u-1-1.header.padded-content.with-action-button.bordered-header
     h2.title #{open_studios_page_title}
-    .action-button
-      = link_to "Register to Participate", register_open_studios_path, class: "pure-button-primary pure-button"
+    - if @presenter.promote?    
+      .action-button
+        = link_to "Register to Participate", register_open_studios_path, class: "pure-button-primary pure-button"
 
 - if @gallery.items.any?
   .pure-g

--- a/features/artists/open_studios_signup.feature
+++ b/features/artists/open_studios_signup.feature
@@ -27,6 +27,11 @@ Scenario: "when I'm not logged in"
   When I click on "Yes" in the ".ngdialog"
   Then I see the update my registration message
 
+Scenario: "when the open studios is not promoted"
+  Given the current open studios is not promoted
+  When I visit the open studios page
+  Then I do not see "Register to Participate"
+
 Scenario: "when I'm logged in"
   When I login as "artist"
   And I visit the open studios page

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -72,6 +72,10 @@ rescue ActiveRecord::RecordInvalid
   # there's already one there
 end
 
+Given /the current open studios is not promoted/ do
+  OpenStudiosEvent.current.update(promote: false)
+end
+
 Given /there are open studios artists with art in the system/ do
   steps %(
     Given there are artists with art in the system
@@ -140,8 +144,8 @@ Given /^the email lists have been created with emails$/ do
     clz = mailing_list.constantize
     begin
       clz.create unless clz.first
-    rescue Exception => ex
-      ::Rails.logger.debug("Failed to create #{mailing_list} : #{ex}")
+    rescue Exception => e
+      ::Rails.logger.debug("Failed to create #{mailing_list} : #{e}")
     end
     clz.first.emails.create(name: Faker::Name.name, email: Faker::Internet.email)
   end

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -141,6 +141,10 @@ Then(/^I see an error in the form "(.*?)"$/) do |msg|
   end
 end
 
+Then(/^I do not see "(.*?)"/) do |string|
+  expect(page).to_not have_content(string)
+end
+
 Then(/^I do not see an error message$/) do
   expect(page).to_not have_selector '.error-msg, .flash__error, .err'
 end

--- a/spec/presenters/open_studios_presenter_spec.rb
+++ b/spec/presenters/open_studios_presenter_spec.rb
@@ -4,91 +4,70 @@ require 'rails_helper'
 
 describe OpenStudiosPresenter do
   subject(:presenter) { described_class.new }
+  let(:open_studios_event) { create(:open_studios_event) }
+  let!(:summary) do
+    create(:cms_document,
+           page: :main_openstudios,
+           section: :summary,
+           article: "# spring 2004\n\n## spring 2004 header2 \n\nwhy _spring_.")
+  end
+  let!(:preview_reception) do
+    create(:cms_document,
+           page: :main_openstudios,
+           section: :preview_reception,
+           article: "# pr header\n\n## pr header2\n\ncome out to the *preview* receiption")
+  end
 
   before do
-    allow(CmsDocument).to receive(:packaged)
-      .with('main_openstudios', 'summary')
+    allow(OpenStudiosEventService).to receive(:current).and_return(open_studios_event)
+    allow(open_studios_event).to receive_message_chain(:artists, :in_the_mission)
       .and_return(
-        page: 'main_openstudios',
-        section: 'summary',
-        content: "# spring 2004\n\n## spring 2004 header2 \n\nwhy _spring_.",
-        cmsid: 1,
+        [
+          instance_double(Artist, studio: instance_double(Studio, name: 'studio')),
+          instance_double(Artist, studio: instance_double(Studio, name: 'axe')),
+          instance_double(Artist, studio: nil, address: 'mission', lastname: 'Rogers'),
+          instance_double(Artist, studio: nil, address: 'mission', lastname: 'Jill'),
+        ],
       )
-    allow(CmsDocument).to receive(:packaged)
-      .with('main_openstudios', 'preview_reception')
-      .and_return(
-        page: 'main_openstudios',
-        section: 'preview_reception',
-        content: '# pr header\n\n## pr header2\n\ncome out to the *preview* receiption',
-        cmsid: 1,
-      )
+  end
 
-    allow(OpenStudiosEventService).to receive_message_chain(
-      :current, :artists, :in_the_mission
-    ).and_return([
-                   instance_double(Artist, studio: instance_double(Studio, name: 'studio')),
-                   instance_double(Artist, studio: instance_double(Studio, name: 'studio2')),
-                   instance_double(Artist, studio: nil, address: 'mission', lastname: 'Rogers'),
-                 ])
+  describe '#packaged_summary' do
+    it 'returns the cms data ready to render' do
+      expect(subject.packaged_summary).to eq({
+                                               cmsid: summary.id,
+                                               page: summary.page,
+                                               section: summary.section,
+                                               content: MarkdownService.markdown(summary.article),
+                                             })
+    end
+  end
+
+  describe '#packaged_preview_reception' do
+    it 'returns the cms data ready to render' do
+      expect(subject.packaged_preview_reception).to eq({
+                                                         cmsid: preview_reception.id,
+                                                         page: preview_reception.page,
+                                                         section: preview_reception.section,
+                                                         content: MarkdownService.markdown(preview_reception.article),
+                                                       })
+    end
   end
 
   describe '#participating_studios' do
     it 'has 2 studios' do
       expect(presenter.participating_studios.size).to eq(2)
     end
-  end
-
-  describe '#participating_indies' do
-    it 'has 1 artist' do
-      expect(presenter.participating_indies.size).to eq(1)
+    it 'are in order by studio name' do
+      expect(subject.participating_studios.map(&:name)).to be_monotonically_increasing
     end
   end
 
-  describe '#preview_reception' do
-    subject { super().preview_reception }
-    it { is_expected.to include 'pr header' }
-  end
-
-  describe '#summary' do
-    subject { super().summary }
-    it { is_expected.to include 'spring 2004' }
-  end
-
-  describe '#preview_reception_data' do
-    subject { super().preview_reception_data }
-    it { is_expected.to have_key 'data-cmsid' }
-  end
-
-  describe '#preview_reception_data' do
-    subject { super().preview_reception_data }
-    it { is_expected.to have_key 'data-page' }
-  end
-
-  describe '#preview_reception_data' do
-    subject { super().preview_reception_data }
-    it { is_expected.to have_key 'data-section' }
-  end
-
-  describe '#summary_data' do
-    subject { super().summary_data }
-    it { is_expected.to have_key 'data-cmsid' }
-  end
-
-  describe '#summary_data' do
-    subject { super().summary_data }
-    it { is_expected.to have_key 'data-page' }
-  end
-
-  describe '#summary_data' do
-    subject { super().summary_data }
-    it { is_expected.to have_key 'data-section' }
-  end
-
-  it 'participating studios by name' do
-    expect(subject.participating_studios.map(&:name)).to be_monotonically_increasing
-  end
-
-  it 'participating indys by artist last name' do
-    expect(subject.participating_indies.map(&:lastname).map(&:downcase)).to be_monotonically_increasing
+  describe '#participating_indies' do
+    it 'has 2 artists' do
+      expect(presenter.participating_indies.size).to eq(2)
+    end
+    it 'in order by artist last name' do
+      expect(subject.participating_indies.map(&:lastname).map(&:downcase)).to be_monotonically_increasing
+    end
   end
 end


### PR DESCRIPTION
Problem
--------

If the current open studios should not be promoted, we should turn off
the 'register to participate' CTA button that we have on the open
studios page.

Solution
--------

Show register to participate CTA button only when the current open
studios is promotable.