### PR TITLE
Remove Timecop as a dependency, use Rails TimesHelper instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,5 +107,4 @@ group :test, :development do
   gem 'spring-commands-teaspoon'
   gem 'teaspoon-jasmine'
   gem 'test-prof'
-  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.1)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -607,7 +606,6 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   teaspoon-jasmine
   test-prof
-  timecop
   uglifier
   unicorn
   unicorn-rails

--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -23,7 +23,7 @@ class OpenStudiosEvent < ApplicationRecord
   end
 
   # define future/past not as scopes because we want Time.zone.now() to be evaluated at query time
-  # Also, this allows us to test with Timecop as opposed to using database NOW() method
+  # Also, this allows us to test with TimesHelper as opposed to using database NOW() method
   def self.past
     where('start_date < ?', Time.zone.now).order(:start_date)
   end

--- a/spec/controllers/admin/stats_controller_spec.rb
+++ b/spec/controllers/admin/stats_controller_spec.rb
@@ -25,15 +25,12 @@ describe Admin::StatsController do
     let(:art_pieces_per_day) { Admin::StatsController.new.send(:compute_art_pieces_per_day) }
     let(:artists_per_day) { Admin::StatsController.new.send(:compute_artists_per_day) }
     before do
-      Timecop.freeze
+      freeze_time
       FactoryBot.create(:artist, :active, :with_art, number_of_art_pieces: 2)
       3.times.each do |n|
-        Timecop.travel((1 + n).days.ago)
+        travel_to((1 + n).days.ago)
         FactoryBot.create(:artist, :active, :with_art, number_of_art_pieces: 2)
       end
-    end
-    after do
-      Timecop.return
     end
 
     describe '#compute_artists_per_day' do

--- a/spec/controllers/admin/tests_controller_spec.rb
+++ b/spec/controllers/admin/tests_controller_spec.rb
@@ -32,13 +32,11 @@ describe Admin::TestsController do
     describe '#qr' do
       before do
         @t = Time.zone.now
-        Timecop.freeze(@t)
+        travel_to(@t)
         expect(FileUtils).to receive(:mkdir_p).with %r{/public/images/tmp$}
         allow(Qr4r).to receive(:encode)
       end
-      after do
-        Timecop.return
-      end
+
       it 'builds a qr image' do
         post :qr, params: { string_to_encode: 'this string', pixel_size: '10' }
         expect(assigns(:qrfile)).to eql "/images/tmp/qrtest_#{@t.to_i}.png"

--- a/spec/forms/application_event_query_spec.rb
+++ b/spec/forms/application_event_query_spec.rb
@@ -36,7 +36,7 @@ describe ApplicationEventQuery do
 
   describe '.to_s' do
     before do
-      Timecop.freeze
+      freeze_time
     end
     it 'renders the query as a string with the date' do
       query = described_class.new(since: '2018-10-20')

--- a/spec/models/open_studios_event_spec.rb
+++ b/spec/models/open_studios_event_spec.rb
@@ -22,12 +22,8 @@ describe OpenStudiosEvent do
 
   before do
     # allow_any_instance_of(OpenStudiosEvent).to receive(:save_attached_files).and_return(true)
-    Timecop.freeze
+    freeze_time
     [past_oses, current_os, future_oses].flatten
-  end
-
-  after do
-    Timecop.return
   end
 
   describe '#for_display' do
@@ -75,7 +71,7 @@ describe OpenStudiosEvent do
     end
 
     it 'shows the first future event if today is monday after the last event' do
-      Timecop.travel(current_os.end_date + 1.day)
+      travel_to(current_os.end_date + 1.day)
 
       expect(OpenStudiosEvent.current).to eql future_oses.first
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,10 +20,7 @@ describe User, elasticsearch: :stub do
   subject(:user) { FactoryBot.build(:user, :active) }
 
   before do
-    Timecop.freeze
-  end
-  after do
-    Timecop.return
+    freeze_time
   end
 
   it 'allows unicode characters for name fields' do
@@ -262,7 +259,7 @@ describe User, elasticsearch: :stub do
   describe 'forgot password methods' do
     context 'artfan' do
       before do
-        Timecop.travel(1.hour.since)
+        travel_to(1.hour.since)
       end
       it 'create_reset_code creates a reset code' do
         ActiveJob::Base.queue_adapter = :test

--- a/spec/presenters/art_sampler_spec.rb
+++ b/spec/presenters/art_sampler_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 
 describe ArtSampler do
   before do
-    Timecop.freeze
-  end
-
-  after do
-    Timecop.return
+    freeze_time
   end
 
   describe 'initialization' do
@@ -19,7 +15,7 @@ describe ArtSampler do
       expect((ArtSampler.new offset: 2).offset).to eql 2
     end
     it 'defaults the seed to the time' do
-      Timecop.freeze
+      freeze_time
       expect(ArtSampler.new.seed).to eql Time.zone.now.to_i
     end
     it 'defaults the offset to 0' do

--- a/spec/presenters/new_art_piece_presenter_spec.rb
+++ b/spec/presenters/new_art_piece_presenter_spec.rb
@@ -19,10 +19,7 @@ describe NewArtPiecePresenter do
   let(:current_time) do
   end
   before do
-    Timecop.freeze(current_time ? Time.zone.parse(current_time) : Time.current)
-  end
-  after do
-    Timecop.return
+    travel_to(current_time ? Time.zone.parse(current_time) : Time.current)
   end
 
   describe '#open_studios_info' do

--- a/spec/services/open_studios_event_service_spec.rb
+++ b/spec/services/open_studios_event_service_spec.rb
@@ -20,12 +20,8 @@ describe OpenStudiosEventService do
 
   before do
     # allow_any_instance_of(OpenStudiosEvent).to receive(:save_attached_files).and_return(true)
-    Timecop.freeze
+    freeze_time
     [past_oses, current_os, future_oses].flatten
-  end
-
-  after do
-    Timecop.return
   end
 
   describe '.for_display' do

--- a/spec/services/site_statistics_spec.rb
+++ b/spec/services/site_statistics_spec.rb
@@ -5,17 +5,17 @@ require 'rails_helper'
 describe SiteStatistics do
   subject(:stats) { SiteStatistics.new }
   let!(:models) do
-    Timecop.freeze do
+    freeze_time do
       FactoryBot.create_list(:studio, 2)
 
-      Timecop.travel(16.hours.ago)
+      travel_to(16.hours.ago)
       FactoryBot.create(:artist, :active)
 
-      Timecop.travel(4.days.ago)
+      travel_to(4.days.ago)
       FactoryBot.create_list(:artist, 2, :active, :with_art, :with_links)
       FactoryBot.create_list(:artist, 3)
 
-      Timecop.travel(10.days.ago)
+      travel_to(10.days.ago)
       FactoryBot.create_list(:artist, 2, :active)
       FactoryBot.create_list(:artist, 3)
     end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
**Problem:**
Rails offers TimesHelper for time stubbing since version 4.2. We are eliminating TimeCop gem and to use TimesHelper instead.

**Solutions:**
1. updated Gemfile and removed gem `timecop`
1. replaced all timecop appearances with TimesHelper methods

resources: https://api.rubyonrails.org/v5.2.4.1/classes/ActiveSupport/Testing/TimeHelpers.html

**note: Rails TimesHelper does automatic unstub of all time stubs within a test.
[see source code here](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activesupport/lib/active_support/testing/time_helpers.rb#L155)