### PR TITLE
Zeitwerk shouldn't autoload webpack dir

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,3 +81,5 @@ module Mau
     config.active_support.test_order = :random
   end
 end
+
+Rails.autoloaders.main.ignore(Rails.root.join('app/webpack'))


### PR DESCRIPTION
Rails6 now has this `zeitwerk` thing which does some autoloading stuff
but only non dev enviroment so this didn't come up until I tried to
deploy.  It was trying to autoload files in `app/webpack` and complained
that

```bash
/home/deploy/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
/home/deploy/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
E, [2020-03-24T19:04:41.637539 #3748] ERROR -- : wrong constant name Background-img inferred by Module from directory

  /home/deploy/deployed/mau/releases/20200324185041/app/webpack/components/background-img

Possible ways to address this:

  * Tell Zeitwerk to ignore this particular directory.
  * Tell Zeitwerk to ignore one of its parent directories.
  * Rename the directory to comply with the naming conventions.
  * Modify the inflector to handle this case.
 (Zeitwerk::NameError)
/home/deploy/deployed/mau/shared/bundle/ruby/2.6.0/gems/zeitwerk-2.3.0/lib/zeitwerk/loader.rb:535:in `rescue in block in set_autoloads_in_dir'
```

So this commit adds code to ignore webpack dir.