### PR TITLE
Fix icons for search (after font awesome upgrade)

### DIFF
--- a/app/webpack/components/search_results/index.html
+++ b/app/webpack/components/search_results/index.html
@@ -18,7 +18,7 @@
             <div class="score">
               {{::hit.score}}
             </div>
-            <div class="icon fa" ng-class="hit.icon_class"></div>
+            <i class="icon" ng-class="hit.icon_class"></i>
             <div class="name">
               <div class="os-violator" ng-if="hit.osParticipant"></div>
               <div ng-bind-html="::hit.name"></div>

--- a/app/webpack/components/search_results/search_hit.js
+++ b/app/webpack/components/search_results/search_hit.js
@@ -4,9 +4,9 @@ import ngInject from "@js/ng-inject";
 
 const SearchHit = ngInject(function (objectRoutingService) {
   return function (hit) {
-    var obj, ref, src;
+    var ref;
     this.hit = hit;
-    src = this.hit._source;
+    const src = this.hit._source;
     this.id = this.hit._id;
     this.type = this.hit._type;
     // the `type` field was mapped to the ruby model in the past
@@ -15,14 +15,14 @@ const SearchHit = ngInject(function (objectRoutingService) {
       this.type = Object.keys(src)[0];
     }
     this.score = this.hit._score;
-    obj = src[this.type];
+    const obj = src[this.type];
     this.image = (ref = obj.images) != null ? ref.small : void 0;
     obj.id = this.id;
     this.osParticipant = obj.os_participant;
     switch (this.type) {
       case "artist":
         this.name = obj.artist_name;
-        this.icon_class = "fa-user";
+        this.icon_class = "fa fa-user";
         if (obj.bio != null) {
           this.description = ellipsize(obj.bio);
         }
@@ -30,7 +30,7 @@ const SearchHit = ngInject(function (objectRoutingService) {
         break;
       case "studio":
         this.name = obj.name;
-        this.icon_class = "fa-building-o";
+        this.icon_class = "far fa-building";
         this.description = obj.address;
         this.link = objectRoutingService.studioPath(obj);
         break;
@@ -40,7 +40,7 @@ const SearchHit = ngInject(function (objectRoutingService) {
           (" <span class='byline-conjunction'>by</span> <span class='artist-name'>" +
             obj.artist_name +
             "</span>");
-        this.icon_class = "fa-picture-o";
+        this.icon_class = "far fa-image";
         this.link = objectRoutingService.artPiecePath(obj);
         this.tags = obj.tags;
         this.tagsForDisplay = function () {};

--- a/app/webpack/components/search_results/search_results.scss
+++ b/app/webpack/components/search_results/search_results.scss
@@ -69,7 +69,8 @@ search-results {
     border-bottom: 1px dotted $medium-gray;
     font-size: 12px;
   }
-  .fa {
+  .fa,
+  .far {
     color: $gto-yellow;
   }
   .icon {


### PR DESCRIPTION
Problem
-------

After our font awesome upgrade (which came with webpacker upgrade),
we lost the icons in the search

We need to update the fa-* classes so we get the right icons.

Solution
--------

Update icons we choose for the search hit and update scss to accomodate
both `fa` and `far` icons for color.