### PR TITLE
Don't show os info if os is not promoted (in new art email)

### DIFF
--- a/spec/factories/open_studios_events.rb
+++ b/spec/factories/open_studios_events.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     start_time { 'noon' }
     end_time { '6p' }
     key { start_date.strftime('%Y%m') }
+    promote { true }
     trait :future do
       start_date { Time.zone.now + 1.week }
     end


### PR DESCRIPTION
Problem
-------

If we have no open studios to promote (but it's present) we should not
include that info in the new art email

Solution
--------

Update the `NewArtPiecePresenter` to know about promoted and non
promoted OS events and only show os info when it's appropriate.