### PR TITLE
Revamp Elasticsearch indexing and querying to clear up deprecations

### DIFF
--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -9,10 +9,16 @@ class Studio < ApplicationRecord
 
   __elasticsearch__.client = Search::EsClient.root_es_client
 
-  settings(analysis: Search::Indexer::ANALYZERS_TOKENIZERS, index: { number_of_shards: 2 }) do
-    mappings(_all: { analyzer: :mau_snowball_analyzer }) do
-      indexes :name, analyzer: :mau_snowball_analyzer
-      indexes :address, analyzer: :mau_snowball_analyzer
+  index_name name.underscore.pluralize
+  document_type name.underscore
+
+  settings(
+    analysis: Search::Indexer::ANALYZERS_TOKENIZERS,
+    index: Search::Indexer::INDEX_SETTINGS,
+  ) do
+    mappings(dynamic: false) do
+      indexes :"studio.name", analyzer: :mau_ngram_analyzer
+      indexes :"studio.address", analyzer: :mau_ngram_analyzer
     end
   end
 

--- a/app/services/search/indexer.rb
+++ b/app/services/search/indexer.rb
@@ -2,20 +2,22 @@
 
 module Search
   class Indexer
+    INDEX_SETTINGS = {
+      max_ngram_diff: 13,
+      number_of_shards: 1,
+    }.freeze
+
     ANALYZERS = {
-      mau_snowball_analyzer: {
-        type: 'snowball',
-        language: 'English',
-      },
       mau_ngram_analyzer: {
         tokenizer: :mau_ngram_tokenizer,
+        filter: ['lowercase'],
       },
     }.freeze
     TOKENIZERS = {
       mau_ngram_tokenizer: {
-        type: 'nGram',
-        min_gram: 4,
-        max_gram: 10,
+        type: 'edge_ngram',
+        min_gram: 3,
+        max_gram: 12,
         token_chars: %i[letter digit],
       },
     }.freeze

--- a/app/services/search/query_runner.rb
+++ b/app/services/search/query_runner.rb
@@ -18,22 +18,23 @@ module Search
         query: {
           multi_match: {
             query: @query,
-            fields: ['_all', 'studio.name^5', 'artist.artist_name^5', 'art_piece.title^3', 'art_piece.artist_name^3'],
+            fields: ['studio.name^5', 'artist.artist_name^5', 'art_piece.title^5', 'art_piece.title_ngram^3', 'art_piece.artist_name^3'],
             type: 'most_fields',
-            fuzziness: 1,
+            fuzziness: 0,
           },
         },
         size: 100,
-        highlight: {
-          fields: {
-            'name' => {},
-            'tags' => {},
-            'title' => {},
-            'artist_name' => {},
-            'artist_bio' => {},
-            'bio' => {},
-          },
-        },
+        # highlight: {
+        #   fields: {
+        #     'studio.name' => {},
+        #     'artist.artist_name' => {},
+        #     'art_piece.title' => {},
+        #     'art_piece.tags' => {},
+        #     'art_piece.medium' => {},
+        #     'art_piece.title' => {},
+        #     'artist.artist_name' => {},
+        #   },
+        # },
       }
       EsClient.client.search(
         index: %i[art_pieces studios artists].join(','),

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -6,3 +6,4 @@ if (File.exist? "./.env.test")
 end
 std_opts += " " + data %>
 default: <%= std_opts %> features
+rerun: "--format rerun --out failed-feature-examples.txt"

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -4,25 +4,24 @@ namespace :es do
   desc 'reindex models'
   task reindex: [:environment] do
     [Artist, Studio, ArtPiece].each do |model|
+      puts "Reindexing #{model}"
       Search::Indexer.reindex_all(model)
     end
   end
 
-  desc 'delete indeces'
-  task delete_indeces: [:environment] do
+  desc 'delete indices'
+  task delete_indices: [:environment] do
     [Artist, Studio, ArtPiece].each do |model|
-      model.indices.delete index: model.index_name
-    rescue StandardError
-      nil
+      puts "Deleting index: #{model.index_name}"
+      Search::EsClient.client.indices.delete index: model.index_name
     end
   end
 
-  desc 'create indeces'
-  task create_indeces: [:environment] do
+  desc 'create indices'
+  task create_indices: [:environment] do
     [Artist, Studio, ArtPiece].each do |model|
-      model.indices.create index: model.index_name
-    rescue StandardError
-      nil
+      puts "Creating index: #{model.index_name}"
+      Search::EsClient.indices.create index: model.index_name
     end
   end
 end

--- a/spec/services/search/search_service_spec.rb
+++ b/spec/services/search/search_service_spec.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-describe Search::Indexer, elasticsearch: :stub do
-end


### PR DESCRIPTION
Problem
-------

We get a huge pile of deprecation warnings from ES because of the way
we have the ngram min/max stuff setup.

Solution
--------

Revamp the way we index so we're more inline for ES 7 and stop getting
deprecation warnings (and maybe do a little better on the way we index
and search).

Indexes will need to be rebuilt after this goes out.