### PR TITLE
Precompile assets locally and rsync for deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,9 +6,11 @@ require 'capistrano/setup'
 # Includes default deployment tasks
 require 'capistrano/deploy'
 require 'capistrano/rbenv'
-require 'capistrano/rails'
+require 'capistrano/bundler'
+require 'capistrano/rails/migrations'
 require 'capistrano/scm/git'
 require 'capistrano3/unicorn'
+require 'capistrano/local_precompile'
 
 install_plugin Capistrano::SCM::Git
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'authlogic', '~> 5.x'
 gem 'aws-sdk-s3'
 gem 'browser'
 gem 'browserslist_useragent'
-gem 'capistrano'
-gem 'capistrano-bundler'
-gem 'capistrano-rails'
-gem 'capistrano-rbenv'
 gem 'dalli'
 gem 'dotenv-rails'
 gem 'elasticsearch'
@@ -69,6 +65,11 @@ group :development do
   gem 'awesome_print'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'capistrano', require: false
+  gem 'capistrano-bundler', require: false
+  gem 'capistrano-rails', require: false
+  gem 'capistrano-rbenv', require: false
+  gem "capistrano-local-precompile", "~> 1.2", require: false
   gem 'capistrano3-unicorn'
   gem 'letter_opener'
   gem 'rails_best_practices'
@@ -96,4 +97,5 @@ group :test, :development do
   gem 'simplecov'
   gem 'test-prof'
 end
+
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (1.6.0)
       capistrano (~> 3.1)
+    capistrano-local-precompile (1.2.0)
+      capistrano (>= 3.8)
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -499,6 +501,7 @@ DEPENDENCIES
   byebug
   capistrano
   capistrano-bundler
+  capistrano-local-precompile (~> 1.2)
   capistrano-rails
   capistrano-rbenv
   capistrano3-unicorn

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,11 +26,10 @@ test: &test
   database: mau_test
   pool: 5
 
+# we need these for cap tasks and other things that might run in acceptance
+# or production environments locally and need to think their ok
 acceptance:
   <<: *dev
 
-design:
+production:
   <<: *dev
-
-cucumber:
-  <<: *test

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,7 +7,7 @@ lock '~> 3.12.0'
 set :stages, %w[production acceptance]
 
 set :rbenv_type, :user # or :system, depends on your rbenv setup
-set :rbenv_ruby, '2.6.5'
+set :rbenv_ruby, File.read('.ruby-version').strip
 set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 set :rbenv_map_bins, %w[rake gem bundle ruby rails]
 set :rbenv_roles, :all # default value

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,13 +13,16 @@
 development:
   secret_key_base: ee7f51e4216df38f6677a6cccb2d0007f17580d62511d5a589143ca2f8b4205bda64399d6e4a105acf5d36cb2e4300a0881559cc125504430a4ae601befcc212
 
-acceptance:
-  secret_key_base: fe7f51e4216df38f6677a6cccb2d0007f17580d62511d5a589143ca2f8b4205bda64399d6e4a105acf5d36cb2e4300a0881559cc125504430a4ae601befcc212
-
 test:
   secret_key_base: a7c4d8ca542295e3fc2130dea40c515a676b5c9493284273fb4b1882381b8671cf702f00cfce7483ea72fb62efe03697c29630fcc2dcfbc07abd6f248f8647e6
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
+#
+# These are unused on deployed machines where there are individual
+# config files with hard coded secrets
+acceptance:
+  secret_key_base: 'acceptance-secret-key'
+
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: 'production-secret-key'

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -3,4 +3,6 @@
 namespace :assets do
   task precompile: ['webpacker:compile', :environment]
   task clobber: ['webpacker:clobber', :environment]
+  # for Capistrano local precompile gem
+  task clean: ['webpacker:clobber', :environment]
 end


### PR DESCRIPTION
Problem
-------

Deployments with capistrano were recompiling assets on the deployed
server which was taking up resources that the server did not have and
causing ElasticSearch to fall over during deployment or causing the
asset compilation to fail because there wasn't enough memory.

Solution
--------

Precompile assets on the deploy*ing* machine and then sync them to the
deployed machine.