### PR TITLE
Art Piece Medium Not Updating Bug

### DIFF
--- a/app/webpack/angularjs/components/medium/medium.js
+++ b/app/webpack/angularjs/components/medium/medium.js
@@ -13,6 +13,17 @@ const medium = ngInject(function (objectRoutingService) {
 
       $scope.path = objectRoutingService.urlForModel("medium", medium);
       $scope.name = medium.name;
+
+      $scope.$watch(
+        "medium",
+        function (newMedium, oldMedium) {
+          if (newMedium.id !== oldMedium.id) {
+            $scope.name = newMedium.name;
+            $scope.path = objectRoutingService.urlForModel("medium", newMedium);
+          }
+        },
+        true
+      );
     },
   };
 });

--- a/app/webpack/angularjs/components/medium/medium.test.js
+++ b/app/webpack/angularjs/components/medium/medium.test.js
@@ -2,7 +2,6 @@ import "angular-mocks";
 import "./medium";
 import "@services/object_routing.service";
 
-import { compileTemplate } from "@support/angular_helpers";
 import angular from "angular";
 import expect from "expect";
 
@@ -12,12 +11,20 @@ describe("mau.directives.medium", function () {
   beforeEach(angular.mock.module("ngSanitize"));
 
   describe("with name and id", function () {
+    let scope;
+    let compile;
     let element;
+    let medium = { name: "my medium", id: 12, slug: "my-tag" };
 
     beforeEach(function () {
-      element = compileTemplate('<medium medium="medium"/>', {
-        medium: { name: "my medium", id: 12, slug: "my-tag" },
+      angular.mock.inject(function ($compile, $rootScope) {
+        compile = $compile;
+        scope = $rootScope;
       });
+      scope.medium = medium;
+
+      element = compile('<medium medium="medium"/>')(scope);
+      scope.$digest();
     });
 
     it("uses id for the medium path", function () {
@@ -26,6 +33,21 @@ describe("mau.directives.medium", function () {
 
     it("renders the medium name", function () {
       expect(element.text()).toEqual("my medium");
+    });
+
+    describe("medium ID change watching", () => {
+      beforeEach(function () {
+        scope.medium = { name: "new medium", id: 23, slug: "new-tag" };
+        scope.$digest();
+      });
+
+      it("uses new id for the medium path", function () {
+        expect(element.find("a").attr("href")).toEqual("/media/new-tag");
+      });
+
+      it("renders the new medium name", function () {
+        expect(element.text()).toEqual("new medium");
+      });
     });
   });
 });


### PR DESCRIPTION
**Problem**
On Artists' single art presentation page, the left column should update the `medium` field as the user selects different art piece to view. Right now it's stuck on the first medium shown.

[Tracker](https://www.pivotaltracker.com/story/show/172752979)

**Solution**
* Added `$watch` method to update `medium` directive's `$scope`. When `medium` object changes, it should update the scope automatically.
* Added `true` as the last argument for the same method to do a deep comparison. This is added to be on the safe side even though the feature seems to work without it.
* Changed the test structure a bit to use `compile` and `scope` method from angular testing instead of `compileTemplate`. It is to be able to test `medium` object changes on scope.
