### PR TITLE
Efficiency improvements around artist representative piece and os

### DIFF
--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -99,7 +99,7 @@ class ArtPiecesController < ApplicationController
   end
 
   def safe_find_art_piece(id)
-    ArtPiece.where(id: id).first
+    ArtPiece.find_by(id: id)
   end
 
   def build_page_description(art_piece)

--- a/app/presenters/artists_presenter.rb
+++ b/app/presenters/artists_presenter.rb
@@ -14,10 +14,11 @@ class ArtistsPresenter < ViewPresenter
   def artists
     @artists ||=
       begin
+        base_artists = Artist.active.includes(:studio, :artist_info, :art_pieces, :open_studios_events)
         if os_only
-          OpenStudiosEventService.current.artists.in_the_mission
+          base_artists.in_the_mission.select(&:doing_open_studios?)
         else
-          Artist.active.includes(:studio, :artist_info, :art_pieces, :open_studios_events)
+          base_artists
         end.sort_by(&:sortable_name)
       end.map { |artist| ArtistPresenter.new(artist) }
   end

--- a/app/presenters/studio_presenter.rb
+++ b/app/presenters/studio_presenter.rb
@@ -65,7 +65,7 @@ class StudioPresenter < ViewPresenter
   def open_studios_artists
     return Artist.none if OpenStudiosEventService.current.blank?
 
-    artists.where(id: OpenStudiosEventService.current.artists.map(&:id))
+    OpenStudiosEventService.current.artists
   end
 
   def artists_with_art?
@@ -75,7 +75,7 @@ class StudioPresenter < ViewPresenter
   def artists_with_art
     @artists_with_art ||=
       begin
-        artists.select { |a| a.art_pieces.present? }.map { |artist| ArtistPresenter.new(artist) }
+        artists.joins(:art_pieces).map { |artist| ArtistPresenter.new(artist) }
       end
   end
 
@@ -96,7 +96,7 @@ class StudioPresenter < ViewPresenter
   end
 
   def artists
-    @artists ||= @studio.artists.active
+    @artists ||= @studio.artists.active.includes(:artist_info, :art_pieces, :open_studios_events)
   end
 
   def indy?

--- a/app/services/open_studios_event_service.rb
+++ b/app/services/open_studios_event_service.rb
@@ -107,6 +107,21 @@ class OpenStudiosEventService
     SafeCache.delete(event_cache_key(event.key))
   end
 
+  # tally up today's open studios count
+  def self.tally_os
+    return unless current
+
+    today = Time.zone.now.to_date
+    count = current.try(:artists).count
+
+    o = OpenStudiosTally.find_by(recorded_on: today)
+    if o
+      o.update(oskey: current.key, count: count)
+    else
+      OpenStudiosTally.create!(oskey: current.key, count: count, recorded_on: today)
+    end
+  end
+
   def self.event_cache_key(id)
     "os_event_#{id}"
   end

--- a/app/services/studio_service.rb
+++ b/app/services/studio_service.rb
@@ -9,7 +9,7 @@ class StudioService
   MIN_ARTISTS_PER_STUDIO = (Conf.min_artists_per_studio || 3)
 
   def self.all
-    Studio.by_position.all
+    Studio.by_position.all.includes({ artists: :art_pieces })
   end
 
   def self.all_studios
@@ -28,7 +28,7 @@ class StudioService
         Studio.indy
       else
         begin
-          Studio.friendly.find(id)
+          Studio.friendly.includes({ artists: :art_pieces }).find(id)
         rescue StandardError
           nil
         end

--- a/lib/tasks/mau.rake
+++ b/lib/tasks/mau.rake
@@ -106,7 +106,7 @@ namespace :mau do
 
   desc 'record todays OS count'
   task daily_os_signup: [:environment] do
-    Artist.tally_os
+    OpenStudiosEventService.tally_os
   end
 
   desc 'import scammer emails from FASO'

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -224,29 +224,6 @@ describe Artist do
     end
   end
 
-  describe '#tally_os' do
-    before do
-      artist
-    end
-    it 'tallies today\'s os participants' do
-      expect { Artist.tally_os }.to change(OpenStudiosTally, :count).by(1)
-    end
-    it 'only records 1 entry per day' do
-      expect do
-        2.times { Artist.tally_os }
-      end.to change(OpenStudiosTally, :count).by(1)
-    end
-
-    it 'updates the record if it runs more than once 1 entry per day' do
-      Artist.tally_os
-      a = Artist.all.reject(&:doing_open_studios?).first
-      t = OpenStudiosTally.last
-      a.open_studios_events << open_studios_event
-      Artist.tally_os
-      expect(OpenStudiosTally.last.count).to eql(t.count + 1)
-    end
-  end
-
   describe 'doing_open_studios?' do
     let(:past_artist) { create(:artist) }
     before do


### PR DESCRIPTION
This PR improves some cases where we're looking into the artist's 
representative piece and the open studios events.

Changes
-------
* move Artist.tally_os method to OpenStudiosEventService
* make representative piece start with art_pieces which (if included) 
should be more efficient.
* improvements around studio page fetches