### PR TITLE
Fix dev pagination config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -22,6 +22,10 @@ development:
   pagination:
     artists:
       per_page: 5
+    media:
+      per_page: 12
+    tags:
+      per_page: 12
 
 acceptance:
   S3_DOMAIN: 'us-west-1'


### PR DESCRIPTION
Problem
-------

Dev pagination config did not have enough data so it failed
on the media/tags pages.

Solution
--------

Give the dev pagination config override a full set of values