### PR TITLE
Performance Memory Tuning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
 
-  before_action :append_view_paths
   before_action :init_body_classes, :set_controller_and_action_names
   before_action :check_browser, unless: :format_json?
   before_action :set_version
@@ -20,10 +19,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_open_studios
   helper_method :current_open_studios_key, :available_open_studios_keys # from OpenStudiosEventShim
   helper_method :supported_browser?
-
-  def append_view_paths
-    append_view_path 'app/views/common'
-  end
 
   def store_location(location = nil)
     return unless request.format == 'text/html'
@@ -125,14 +120,6 @@ class ApplicationController < ActionController::Base
   end
 
   def supported_browser?
-    browsers_json_file = Rails.root.join('browsers.json')
-    return true if !File.exist?(browsers_json_file) || Rails.env.test?
-
-    @supported_browser ||=
-      begin
-        browsers ||= JSON.parse(File.open(browsers_json_file).read)
-        matcher = BrowserslistUseragent::Match.new(browsers, request.user_agent)
-        (matcher.browser? && matcher.version?(allow_higher: true))
-      end
+    SupportedBrowserService.supported?(request.user_agent)
   end
 end

--- a/app/services/supported_browser_service.rb
+++ b/app/services/supported_browser_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SupportedBrowserService
+  @browsers_json_file = Rails.root.join('browsers.json')
+
+  def self.supported?(user_agent)
+    return true if supported_browsers.blank?
+
+    matcher = BrowserslistUseragent::Match.new(supported_browsers, user_agent)
+    (matcher.browser? && matcher.version?(allow_higher: true))
+  end
+
+  def self.supported_browsers
+    @supported_browsers ||=
+      begin
+        return [] if !File.exist?(@browsers_json_file) || Rails.env.test?
+
+        JSON.parse(File.open(@browsers_json_file).read)
+      end
+  end
+
+  # primarily for use in testing
+  def self._reset
+    @supported_browsers = nil
+  end
+end

--- a/app/views/art_pieces/_form.html.slim
+++ b/app/views/art_pieces/_form.html.slim
@@ -1,6 +1,6 @@
 = semantic_form_for [artist, art_piece], html: { multipart: true } do |f|
   #spinner
-  = render "/form_errors", form: f
+  = render "/common/form_errors", form: f
   = render "/flash_notice_error"
   = f.inputs do
     = f.input :photo, required: true, hint: "This should be a JPG, GIF, or PNG and should be less than 4MB.  Ideal images are at least 800px on their longest dimension."
@@ -17,4 +17,3 @@ javascript:
   jQuery(function () {
     new MAU.ArtPieceForm(".art_piece.formtastic");
   })
-

--- a/app/views/artists/_about.html.slim
+++ b/app/views/artists/_about.html.slim
@@ -4,7 +4,7 @@
     .pure-g
       .pure-u-1-1
         section.artist__image
-          = render '/artist_profile_image', artist: artist
+          = render '/common/artist_profile_image', artist: artist
           - if artist.doing_open_studios?
             = link_to open_studios_path do
               .os-violator

--- a/app/views/artists/edit.slim
+++ b/app/views/artists/edit.slim
@@ -5,7 +5,7 @@
 
 .pure-g
   .pure-u-1-1.pure-u-lg-4-5.padded-content
-    = render '/paypal_donation_form'
+    = render '/common/paypal_donation_form'
     #user-accordion.panel-group
       = semantic_form_for @user.model, html: { class: 'js-edit-artist-form primary-form', multipart: true } do |form|
         .panel.panel-default

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,7 +26,7 @@ html
         .sidenav__main
           a.brand href=root_path title="Mission Artists"
             .sidebar-logo title="Mission Artists" class="#{Date.today.month == 6 ? 'sidebar-logo--pride' : ''}"
-          = render '/navigation'
+          = render '/common/navigation'
           .push
         .sidenav__footer
           .back-to-top title="Back to top"
@@ -46,5 +46,5 @@ html
         });
       })
 
-  = render '/ganalytics'
-  = render '/footer_javascripts'
+  = render '/common/ganalytics'
+  = render '/common/footer_javascripts'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -3,7 +3,7 @@
     .header
       h2.title Sign In
     = semantic_form_for @user_session, name: "Sign In", url: user_session_path do |f|
-      = render '/form_errors', form: f
+      = render '/common/form_errors', form: f
       = f.inputs do
         = f.input :login, placeholder: 'username or email', label: 'Username/Email', input_html: { required: true, autofocus: true }
         = f.input :password, placeholder: 'password', input_html: { required: true }

--- a/app/views/users/_about.html.slim
+++ b/app/views/users/_about.html.slim
@@ -4,7 +4,7 @@
     .pure-g
       .pure-u-1-1
         section.artist__image
-          = render '/artist_profile_image', artist: user
+          = render '/common/artist_profile_image', artist: user
         section.links
           .header Links
           .artist__links

--- a/app/views/users/edit/_profile_picture.html.slim
+++ b/app/views/users/edit/_profile_picture.html.slim
@@ -5,7 +5,7 @@
 
 .panel-collapse.collapse#profile_picture role="tabpanel"
   .panel-body
-    = render '/artist_profile_image', artist: UserPresenter.new(form.object)
+    = render '/common/artist_profile_image', artist: UserPresenter.new(form.object)
     = form.inputs do
       .pure-g
         .pure-u-1-1.pure-u-sm-1-2

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,6 +18,8 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.cache_classes = true
+
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
@@ -56,6 +58,9 @@ Rails.application.configure do
   config.action_mailer.asset_host = ENVIRONMENT_HOST
 
   #  config.middleware.use DisableAnimations
+  #
+
+  config.hosts << 'example.org'
 end
 
 Rails.application.routes.default_url_options[:host] = ENVIRONMENT_HOST

--- a/spec/services/supported_browser_service_spec.rb
+++ b/spec/services/supported_browser_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SupportedBrowserService do
+  describe "when we're not in test mode" do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+      allow(JSON).to receive(:parse).and_call_original
+    end
+    it 'returns the contents of the supported browser json' do
+      expect(described_class.supported_browsers).to be_kind_of(Array)
+      expect(described_class.supported_browsers).not_to be_empty
+    end
+    it 'memoizes the supported browser json' do
+      described_class._reset
+      described_class.supported_browsers
+      described_class.supported_browsers
+      described_class.supported_browsers
+
+      expect(JSON).to have_received(:parse).once
+    end
+  end
+end


### PR DESCRIPTION
Problem
-------

After noticing that `bundle` is taking 2G on our deployed boxes
and digging in with `derailed` (and other reading), it appears
that the `append_view_path` is causing memory issues.  My suspicion
is that the path continues to get appended to with each request
making a global array that grows for the lifetime of the app.

Solution
--------

Don't use append view path at all and just specify the partials
with a full path.

Additionally, we were doing a lot of extra file reading to check
for the supported browser, so I put that in a service and memo-ized
what I could.