### PR TITLE
More perf tunin'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'friendly_id'
 gem 'geokit'
 gem 'geokit-rails'
 gem 'gibbon' # mailchimp connect
-gem 'hashie'
 gem 'htmlentities'
 gem 'jbuilder' # non-html output (rss, atom)
 gem 'listen'
@@ -36,15 +35,14 @@ gem 'postmark-rails'
 gem 'qr4r'
 gem 'racc'
 gem 'rack-cors', require: 'rack/cors'
-gem 'rails', '~> 6.0.x'
+gem 'rails', require: false
 gem 'rdiscount' # markdown processor
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'responders'
-gem 'rosie'
 gem 'slim-rails'
 gem 'unicorn' # webserver
 gem "webpacker"
-gem 'xmlrpc' # after ruby 2.4 upgrade
+#gem 'xmlrpc' # after ruby 2.4 upgrade
 
 group :test do
   gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'aws-sdk-s3'
 gem 'browser'
 gem 'browserslist_useragent'
 gem 'dalli'
-gem 'dotenv-rails'
 gem 'elasticsearch'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
@@ -42,7 +41,6 @@ gem 'responders'
 gem 'slim-rails'
 gem 'unicorn' # webserver
 gem "webpacker"
-#gem 'xmlrpc' # after ruby 2.4 upgrade
 
 group :test do
   gem 'capybara'
@@ -81,6 +79,7 @@ group :test, :development do
   gem 'bundle-audit'
   gem 'byebug'
   gem 'database_cleaner'
+  gem 'dotenv-rails'
   gem 'elasticsearch-extensions', require: nil
   gem 'factory_bot', require: false
   gem 'factory_bot_rails', require: false
@@ -100,6 +99,6 @@ end
 
 
 
-#gem "derailed", "~> 0.1.0"
-#gem "stackprof", "~> 0.2.15"
-#gem "derailed_benchmarks", "~> 1.7"
+# gem "derailed", "~> 0.1.0"
+# gem "stackprof", "~> 0.2.15"
+# gem "derailed_benchmarks", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
-    rosie (0.0.9)
     rqrcode (1.1.2)
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.1)
@@ -484,7 +483,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xmlrpc (0.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
@@ -532,7 +530,6 @@ DEPENDENCIES
   geokit
   geokit-rails
   gibbon
-  hashie
   htmlentities
   jbuilder
   launchy
@@ -551,13 +548,12 @@ DEPENDENCIES
   racc
   rack-cors
   rack-handlers
-  rails (~> 6.0.x)
+  rails
   rails-controller-testing
   rails_best_practices
   rdiscount
   recaptcha
   responders
-  rosie
   rspec-collection_matchers
   rspec-its
   rspec-rails
@@ -579,7 +575,6 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker
-  xmlrpc
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationJob < ActiveJob::Base
-end

--- a/app/lib/image_info.rb
+++ b/app/lib/image_info.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ImageInfo < Hashie::Mash
-end

--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+DATE_FORMAT = '%Y %b'
+REVERSE_START_DATE_FORMAT = '%b %-d-'
+END_DATE_WITHIN_MONTH_FORMAT = '%-d %Y'
+END_DATE_OUTSIDE_MONTH_FORMAT = '%b %-d %Y'
+
 class OpenStudiosEvent < ApplicationRecord
   validates :key, presence: true, uniqueness: { case_sensitive: true }
   validates :start_date, presence: true
@@ -11,13 +16,13 @@ class OpenStudiosEvent < ApplicationRecord
 
   def for_display(reverse = false)
     if !reverse
-      start_date.strftime('%Y %b')
+      start_date.strftime(DATE_FORMAT)
     else
-      date = start_date.strftime('%b %-d-')
+      date = start_date.strftime(REVERSE_START_DATE_FORMAT)
       if start_date.month == end_date.month
-        date + end_date.strftime('%-d %Y')
+        date + end_date.strftime(END_DATE_WITHIN_MONTH_FORMAT)
       else
-        date + end_date.strftime('%b %-d %Y')
+        date + end_date.strftime(END_DATE_OUTSIDE_MONTH_FORMAT)
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,6 @@ end
 # you've limited to :test, :development, or :production.
 
 Bundler.require(*Rails.groups)
-require 'webpacker/helper'
 require_relative '../app/lib/app_config'
 
 c = AppConfig.new

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,13 +10,13 @@ require 'rails'
 
 [
   'active_record/railtie',
-  'active_storage/engine',
+  # 'active_storage/engine',
   'action_controller/railtie',
   'action_view/railtie',
   'action_mailer/railtie',
-  'action_mailbox/engine',
+  # 'action_mailbox/engine',
   'action_text/engine',
-  'rails/test_unit/railtie',
+  # 'rails/test_unit/railtie',
   #  "active_job/railtie",
   #  "action_cable/engine",
   #  "sprockets/railtie",
@@ -31,8 +31,9 @@ end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
 
+Bundler.require(*Rails.groups)
+require 'webpacker/helper'
 require_relative '../app/lib/app_config'
 
 c = AppConfig.new

--- a/spec/lib/enumerable_spec.rb
+++ b/spec/lib/enumerable_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'ostruct'
 
 describe Enumerable do
   describe '#uniq_by' do
-    let(:testdata) { Array.new(4) { |n| Hashie::Mash.new(name: 'obj', idx: n) } }
+    let(:testdata) { Array.new(4) { |n| OpenStruct.new(name: 'obj', idx: n) } }
     it 'returns a uniq list of objects uniq\'d by a proc like name' do
       expect(testdata.uniq_by(&:name).size).to eq(1)
     end


### PR DESCRIPTION
Problem
-------
the app keeps causing issues because it eats up memory over time and pushes
elasticsearch which falls over.

We'd really like it to be more memory efficient.

Solution
--------

Though we were picking out rails gems in `application.rb` we forgot that
Bundler.require just pulls everything in.

This PR fixes that so `require: false` is added to the rails gem in the
Gemfile.  Then we use the pick and choose unrolled `require rails/all` in
`application.rb` to not include all the rails crap we're not using.

Using `derailed` this appears to have a slower leak than before.  So
I think this is an improvement.