### PR TITLE
Add X-Robots-Tag header to api calls

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,9 +2,13 @@
 
 module Api
   class ApiController < ApplicationController
-    before_action :require_authorization
+    before_action :require_authorization, :add_x_robots_header
 
     helper_method :current_user_session, :current_user
+
+    def add_x_robots_header
+      response.set_header('X-Robots-Tag', 'noindex')
+    end
 
     def current_user_session
       return @current_user_session if defined? @current_user_session

--- a/spec/controllers/api/v2/art_pieces_controller_spec.rb
+++ b/spec/controllers/api/v2/art_pieces_controller_spec.rb
@@ -15,5 +15,10 @@ describe Api::V2::ArtPiecesController do
       expect(response).to be_successful
       expect(response.body).to eq '{}'
     end
+
+    it 'includes no robot headers' do
+      get :index, params: { artist_id: 123, format: :json }
+      expect(response.headers['X-Robots-Tag']).to eq('noindex')
+    end
   end
 end


### PR DESCRIPTION
Problem
-------

It looks like google *might* be crawling the API/json endpoints.
We don't need that.

Solution
--------

Add a `X-Robots-Tag:noindex` to api endpoints. as per https://support.google.com/webmasters/answer/93710?hl=en