### PR TITLE
Fix issue with files that have single quotes in them

### DIFF
--- a/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.js
+++ b/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.js
@@ -14,11 +14,12 @@ const controller = ngInject(function (
   objectRoutingService
 ) {
   const initializeCurrent = function () {
-    if ($scope.artPieces && $scope.initialArtPiece) {
-      return ($scope.current = map($scope.artPieces, "id").indexOf(
-        $scope.initialArtPiece.id
-      ));
+    if (!($scope.artPieces && $scope.initialArtPiece)) {
+      return -1;
     }
+    return ($scope.current = map($scope.artPieces, "id").indexOf(
+      $scope.initialArtPiece.id
+    ));
   };
   const updateUrl = function () {
     return $location.hash($scope.artPiece.id);
@@ -51,9 +52,9 @@ const controller = ngInject(function (
     return objectRoutingService.artPiecePath($scope.artPiece);
   };
   $scope.currentArtistPath = function () {
-    if ($scope.artist) {
-      return objectRoutingService.artistPath($scope.artist);
-    }
+    return $scope.artist
+      ? objectRoutingService.artistPath($scope.artist)
+      : null;
   };
   $scope.hasArtistProfile = function () {
     var ref, ref1;
@@ -64,11 +65,8 @@ const controller = ngInject(function (
       : void 0);
   };
   $scope.profilePath = function (size) {
-    var ref;
-    if (size == null) {
-      size = "medium";
-    }
-    return (ref = $scope.artist) != null ? ref.profile_images[size] : void 0;
+    size = size || "medium";
+    return $scope.artist && $scope.artist.profile_images[size];
   };
   $scope.onKeyDown = function (ev) {
     if (ev.which === 37) {

--- a/app/webpack/angularjs/components/art_pieces_browser/index.html
+++ b/app/webpack/angularjs/components/art_pieces_browser/index.html
@@ -123,7 +123,7 @@
         >
           <div
             class="image"
-            ng-style='{backgroundImage: &#39;url(\"{{piece.image_urls.small}}\")&#39;}'
+            background-img="{{piece.image_urls.small}}"
           ></div>
         </a>
       </div>


### PR DESCRIPTION
Problem
-------

Files that include `'` in the name screws up Angular because of the way
we were setting the background image.

Solution
--------

Leverage our `background-img` component which is smarter about the
escaping of things.

Screenshots
-------------

Both these "dumb" files have 'dumb' in the filename.

![Screen Shot 2020-08-22 at 5 06 40 PM](https://user-images.githubusercontent.com/427380/90967858-02207700-e49a-11ea-9787-9347d0fb8bd9.png)
![Screen Shot 2020-08-22 at 5 06 45 PM](https://user-images.githubusercontent.com/427380/90967860-051b6780-e49a-11ea-9eb7-5d4bdcb074c9.png)
![Screen Shot 2020-08-22 at 5 06 52 PM](https://user-images.githubusercontent.com/427380/90967861-05b3fe00-e49a-11ea-9c10-ac49d33f82ae.png)
