### PR TITLE
bump nokogiri rc4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'mime-types'
 gem 'mojo_magick'
 gem 'mysql2'
 gem 'newrelic_rpm' # moitoring
-gem 'nokogiri'
+gem 'nokogiri', '1.11.0.rc4'
 gem 'paperclip'
 gem 'postmark'
 gem 'postmark-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
     mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     mojo_magick (0.5.7)
     multi_json (1.15.0)
@@ -281,8 +281,9 @@ GEM
     net-ssh (6.1.0)
     newrelic_rpm (6.12.0.367)
     nio4r (2.5.4)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0.rc4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -534,7 +535,7 @@ DEPENDENCIES
   mojo_magick
   mysql2
   newrelic_rpm
-  nokogiri
+  nokogiri (= 1.11.0.rc4)
   paperclip
   postmark
   postmark-rails


### PR DESCRIPTION
We should keep an eye out because right now we're pinned to `.rc4` of this
library because of the versioning.  Once they have a proper non `rc` release
we should be able to use `~>1.11.x` or something similar