### PR TITLE
Extract service code from angular service code

### DIFF
--- a/app/webpack/angularjs/services/mailer.service.js
+++ b/app/webpack/angularjs/services/mailer.service.js
@@ -1,20 +1,5 @@
-import ngInject from "@angularjs/ng-inject";
+import { mailToLink } from "@js/services/mailer.service";
 import angular from "angular";
-
-const mailerService = ngInject(function () {
-  return {
-    mailToLink: function (subject, user, domain) {
-      if (!user || ["www", "info", "feedback", "mau"].indexOf(user) === -1) {
-        user = "www";
-      }
-      domain = domain || "missionartists.org";
-      var lnk = "mailto:" + user + "@" + domain;
-      if (subject && subject.length > -1) {
-        lnk += "?subject=" + escape(subject);
-      }
-      return lnk;
-    },
-  };
-});
+const mailerService = () => ({ mailToLink });
 
 angular.module("mau.services").factory("mailerService", mailerService);

--- a/app/webpack/angularjs/services/search.service.js
+++ b/app/webpack/angularjs/services/search.service.js
@@ -1,18 +1,3 @@
-import { omit } from "@js/app/helpers";
-import { api } from "@js/services/api";
+import { query } from "@js/services/search.service";
 import angular from "angular";
-
-const searchService = function () {
-  return {
-    query: async function (searchParams) {
-      if (!searchParams.query) {
-        return Promise.resolve([]);
-      }
-      const params = omit(searchParams, "query");
-      params.q = searchParams.query;
-      return api.search.query(params);
-    },
-  };
-};
-
-angular.module("mau.services").factory("searchService", searchService);
+angular.module("mau.services").factory("searchService", () => ({ query }));

--- a/app/webpack/js/services/mailer.service.test.ts
+++ b/app/webpack/js/services/mailer.service.test.ts
@@ -1,44 +1,35 @@
-import "angular-mocks";
-import "./mailer.service";
+import { mailToLink } from "./mailer.service";
 
-import angular from "angular";
+import { describe, it } from '@jest/globals'
 import expect from "expect";
 
 describe("mau.services.mailerService", () => {
-  let svc;
-
-  beforeEach(angular.mock.module("mau.services"));
-  beforeEach(
-    angular.mock.inject(function (mailerService) {
-      svc = mailerService;
-    })
-  );
 
   describe("#mailToLink", () => {
     it("returns the right email link with all things specified", () => {
       expect(
-        svc.mailToLink("the subject", "email_user", "email_domain")
+        mailToLink("the subject", "email_user", "email_domain")
       ).toEqual("mailto:www@email_domain?subject=the%20subject");
     });
     it("falls back to missionartists.org if no domain is specified", () => {
-      expect(svc.mailToLink("the subject", "email_user")).toEqual(
+      expect(mailToLink("the subject", "email_user")).toEqual(
         "mailto:www@missionartists.org?subject=the%20subject"
       );
     });
     it("falls back to www if the user is not info, www, feedback, or mau", () => {
-      expect(svc.mailToLink("the subject", "email_user")).toEqual(
+      expect(mailToLink("the subject", "email_user")).toEqual(
         "mailto:www@missionartists.org?subject=the%20subject"
       );
-      expect(svc.mailToLink("the subject", "info")).toEqual(
+      expect(mailToLink("the subject", "info")).toEqual(
         "mailto:info@missionartists.org?subject=the%20subject"
       );
-      expect(svc.mailToLink("the subject", "feedback")).toEqual(
+      expect(mailToLink("the subject", "feedback")).toEqual(
         "mailto:feedback@missionartists.org?subject=the%20subject"
       );
-      expect(svc.mailToLink("the subject", "mau")).toEqual(
+      expect(mailToLink("the subject", "mau")).toEqual(
         "mailto:mau@missionartists.org?subject=the%20subject"
       );
-      expect(svc.mailToLink("the subject", "www")).toEqual(
+      expect(mailToLink("the subject", "www")).toEqual(
         "mailto:www@missionartists.org?subject=the%20subject"
       );
     });

--- a/app/webpack/js/services/mailer.service.ts
+++ b/app/webpack/js/services/mailer.service.ts
@@ -1,0 +1,16 @@
+const ALLOWED_EMAILS = ["www", "info", "feedback", "mau"]
+export const mailToLink = function(
+  subject: string,
+  user?: string,
+  domain?: string
+) {
+  if (!user || (ALLOWED_EMAILS.indexOf(user) == -1)) {
+    user = "www";
+  }
+  domain = domain || "missionartists.org";
+  const lnk = `mailto:${user}@${domain}`;
+  if (!subject) {
+    return lnk
+  }
+  return lnk + `?subject=${escape(subject)}`;
+};

--- a/app/webpack/js/services/search.service.test.ts
+++ b/app/webpack/js/services/search.service.test.ts
@@ -1,31 +1,24 @@
-import "angular-mocks";
-import "./search.service";
+import * as searchService from "./search.service";
 
 import { api } from "@js/services/api";
+import { describe, it } from "@jest/globals";
 import expect from "expect";
 
 jest.mock("@js/services/api");
 
-describe("mau.services.searchService", function () {
-  let service;
+describe("mau.services.searchService", function() {
   const successPayload = ["search_results"];
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
-  beforeEach(angular.mock.module("mau.services"));
-  beforeEach(
-    angular.mock.inject(function (searchService) {
-      service = searchService;
-    })
-  );
-  describe(".query", function () {
-    it("calls the apps search endpoint", function () {
+  describe(".query", function() {
+    it("calls the apps search endpoint", function() {
       api.search.query = jest.fn().mockResolvedValue(successPayload);
       const query = "the query string";
       const extras = { whatever: "man" };
       const expectedParams = { q: query, ...extras };
-      const response = service.query({
+      const response = searchService.query({
         query,
         ...extras,
       });
@@ -35,25 +28,25 @@ describe("mau.services.searchService", function () {
       });
     });
 
-    it("returns empty array if there is no query", function () {
+    it("returns empty array if there is no query", function() {
       const query = "";
       const extras = { whatever: "man" };
-      const response = service.query({
+      const response = searchService.query({
         query,
         ...extras,
       });
-      response.then(function (data) {
+      response.then(function(data) {
         expect(api.search.query).not.toHaveBeenCalled();
         expect(data).toEqual([]);
       });
     });
 
-    it("when there is an error it raises", function () {
+    it("when there is an error it raises", function() {
       const query = "the query string";
       const extras = { whatever: "man" };
       const expectedParams = { q: query, ...extras };
       api.search.query = jest.fn().mockRejectedValue(new Error("oops"));
-      const response = service.query({
+      const response = searchService.query({
         query,
         ...extras,
       });
@@ -62,7 +55,7 @@ describe("mau.services.searchService", function () {
           // should not end up here
           expect(true).toEqual(false);
         })
-        .catch(function (_data) {
+        .catch(function(_data) {
           expect(api.search.query).toHaveBeenCalledWith(expectedParams);
           expect(_data).toEqual(new Error("oops"));
         });

--- a/app/webpack/js/services/search.service.ts
+++ b/app/webpack/js/services/search.service.ts
@@ -1,0 +1,12 @@
+import { omit } from "@js/app/helpers";
+import { api } from "@js/services/api";
+
+type SearchQueryParams = Record<string, any>;
+export const query = async function(searchParams: SearchQueryParams): Promise<any> {
+  if (!searchParams.query) {
+    return Promise.resolve([]);
+  }
+  const params = omit(searchParams, "query");
+  params.q = searchParams.query;
+  return api.search.query(params);
+}

--- a/package.json
+++ b/package.json
@@ -79,11 +79,14 @@
   },
   "jest": {
     "moduleFileExtensions": [
+      "ts",
+      "tsx",
       "js",
       "html"
     ],
     "transform": {
-      "^.+\\.js$": "babel-jest",
+      "^.+\\.jsx?$": "babel-jest",
+      "^.+\\.tsx?$": "babel-jest",
       "^.+\\.html$": "<rootDir>/jest/support/html_loader.js"
     },
     "transformIgnorePatterns": [


### PR DESCRIPTION
Move `search.service` and `mailer.service` from angular/services to
typescript files under `js/services` and then use them in angular.

This is another small step in unwinding angular service wrappers from our
actual service code.

This was motivated by the fact that our first story to move to react is to
move the `mailer` angular component which uses the corresponding service.

Changes
-------

* move `mailer.service` to `js/services` and to typescript
* move `search.service` to `js/services` and to typescript
* move tests
* update angular services to import these new services
* add jest support for typescript