### PR TITLE
Improve open studios page performance [176729371]

### DIFF
--- a/app/presenters/artists_presenter.rb
+++ b/app/presenters/artists_presenter.rb
@@ -15,7 +15,8 @@ class ArtistsPresenter < ViewPresenter
       begin
         base_artists = Artist.active.includes(:studio, :artist_info, :art_pieces, :open_studios_events)
         if os_only
-          base_artists.in_the_mission.select(&:doing_open_studios?)
+          OpenStudiosEvent.current.artists.active.in_the_mission
+          # base_artists.in_the_mission.select(&:doing_open_studios?)
         else
           base_artists
         end.sort_by(&:sortable_name)


### PR DESCRIPTION
Problem
-------

The OpenStudios page is really slow.

Solution
--------

We were making a pretty inefficient query to figure out which artists
were in open studios when we actually can get it more efficiently by
instead of getting all artists and then filtering by `doing_open_studios?`
we can leverage the new `OpenStudiosEvent` to get the list of artists
first which will be more efficient in a DB sense