### PR TITLE
Studios are mis tagged with OS start

### DIFF
--- a/app/presenters/studio_presenter.rb
+++ b/app/presenters/studio_presenter.rb
@@ -35,15 +35,15 @@ class StudioPresenter < ViewPresenter
   end
 
   def profile_image?
-    @studio.get_profile_image(:small).present?
+    studio.get_profile_image(:small).present?
   end
 
   def image(size = 'small')
-    @studio.get_profile_image(size) || '/images/default-studio.png'
+    studio.get_profile_image(size) || '/images/default-studio.png'
   end
 
   def street_with_cross
-    [@studio.street, ("(@ #{studio.cross_street})" if @studio.cross_street?)].compact.join(' ')
+    [studio.street, ("(@ #{studio.cross_street})" if studio.cross_street?)].compact.join(' ')
   end
 
   def artists_count_label
@@ -66,7 +66,7 @@ class StudioPresenter < ViewPresenter
   def open_studios_artists
     return Artist.none if OpenStudiosEventService.current.blank?
 
-    OpenStudiosEventService.current.artists
+    OpenStudiosEventService.current.artists.where(studio: studio)
   end
 
   def artists_with_art?

--- a/spec/presenters/studio_presenter_spec.rb
+++ b/spec/presenters/studio_presenter_spec.rb
@@ -28,4 +28,22 @@ describe StudioPresenter do
       expect(presenter.formatted_phone).to eql '(415) 617-1234'
     end
   end
+
+  describe 'open_studios_artists' do
+    let(:all_os_artists) do
+      [
+        create(:artist, doing_open_studios: true),
+        create(:artist, studio: studio, doing_open_studios: true),
+      ]
+    end
+    before do
+      create(:open_studios_event, :future)
+      all_os_artists
+    end
+    it 'returns all open studios artists in this studio' do
+      expect(Artist.count).to eq 5
+      expect(presenter.artists.count).to eq 2
+      expect(presenter.open_studios_artists).to eq [all_os_artists[1]]
+    end
+  end
 end


### PR DESCRIPTION
Problem
--------

We were not showing open studios stars on Studio cards properly.

https://www.pivotaltracker.com/story/show/176730215

Solution
--------

It appears that with a recent efficiency change, we ended up showing
stars on studios if *anyone* was doing open studios instead of if anyone
*in this studio* was doing open studios.

Solved this with a small fix in the StudioPresenter and added a test to
confirm.