### PR TITLE
Don't build sourcemaps for production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,9 @@ process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
 const environment = require("./environment");
 
-module.exports = environment.toWebpackConfig();
+const config = environment.toWebpackConfig();
+
+// Don't build sourcemaps
+delete config.devtool;
+
+module.exports = config;


### PR DESCRIPTION
Problem
-------

source map building is slow and expensive and buys us almost nothing so
let's skip it for acceptance/production builds.

Solution
--------

Update webpack config to not build source maps in production