### PR TITLE
Artist map page is broken

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,8 +4,6 @@ class Address
   attr_reader :lat, :lng, :street, :city, :state, :zipcode
 
   def initialize(model)
-    model = with_studio?(model) ? model.studio : model
-
     @lat = model.lat
     @lng = model.lng
     @street = model.street
@@ -43,10 +41,6 @@ class Address
   end
 
   private
-
-  def with_studio?(model)
-    model.respond_to?(:studio_id) && model.studio
-  end
 
   def get_state(model)
     return model.addr_state if model.respond_to?(:addr_state)

--- a/app/presenters/admin_artist_list.rb
+++ b/app/presenters/admin_artist_list.rb
@@ -48,8 +48,8 @@ class AdminArtistList < ViewPresenter
       csv_safe(artist.firstname),
       csv_safe(artist.lastname),
       artist.get_name,
-      artist.studio ? artist.studio.name : '',
-      artist.address.street,
+      artist.studio&.name || '',
+      artist.address&.street || '',
       artist.studionumber,
       artist.email,
     ]

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -14,7 +14,6 @@ class ArtistPresenter < UserPresenter
            :==,
            :active?,
            :address,
-           :address?,
            :artist?,
            :artist_info,
            :at_art_piece_limit?,
@@ -116,11 +115,7 @@ class ArtistPresenter < UserPresenter
   end
 
   def map_url
-    if model.studio
-      model.studio.map_link
-    else
-      model.map_link
-    end
+    @map_url ||= model.map_link
   end
 
   def map_info

--- a/app/presenters/artists_map.rb
+++ b/app/presenters/artists_map.rb
@@ -33,8 +33,8 @@ class ArtistsMap < ArtistsPresenter
 
   def map_marker(artist)
     {
-      lat: artist.lat,
-      lng: artist.lng,
+      lat: artist.address.lat,
+      lng: artist.address.lng,
       infowindow: artist.map_info,
       artistId: artist.id,
       artistName: artist.full_name,

--- a/app/services/admin_artist_update_service.rb
+++ b/app/services/admin_artist_update_service.rb
@@ -43,7 +43,7 @@ class AdminArtistUpdateService
 
     # return ternary - nil if the artist was skipped, else true if the artist setting was changed, false if not
     def update_artist_os_standing(artist, current_os, doing_it)
-      return nil unless artist.address?
+      return nil if artist.address.blank?
       return false if artist.doing_open_studios? == doing_it
 
       if doing_it

--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -58,9 +58,9 @@
                   .tooltip-content
                     = a.reset_password_link
 
-            td data-order=(a.address? ? a.doing_open_studios?.to_s : -1)
+            td data-order=(a.address.present? ? a.doing_open_studios?.to_s : -1)
               / this make sure that all os settings are sent to the controller
-              - if a.address? && a.active?
+              - if a.address.present? && a.active?
                 - checked = a.doing_open_studios?
                 - name = "os[#{a.id}]"
                 = hidden_field_tag name, "0"

--- a/app/views/artists/_about.html.slim
+++ b/app/views/artists/_about.html.slim
@@ -27,7 +27,7 @@
                 = link_to artist.studio_name, artist.studio
               .studio-address
                 | #{artist.address.street} #{artist.studio_number}
-                - if artist.address?
+                - if artist.address.present?
                   = link_to artist.map_url, title: :map, class: 'map-link' do
                     i.fa.fa-map-marker
                 .studio-city #{artist.studio.city}
@@ -35,7 +35,7 @@
               .studio-name #{IndependentStudio.new.name.singularize}
               .studio-address
                 | #{artist.address.street}
-                - if artist.address?
+                - if artist.address.present?
                   = link_to artist.map_url, title: :map, class: 'map-link' do
                     i.fa.fa-map-marker
                   .studio-city #{artist.address.city}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -140,6 +140,7 @@ FactoryBot.define do
       after(:create) do |artist|
         studio = Studio.first || FactoryBot.create(:studio)
         artist.update studio: studio
+        artist.update artist_info_attributes: { lat: nil, lng: nil }
       end
     end
   end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,35 +3,27 @@
 require 'rails_helper'
 
 describe Address do
-  let(:artist) { create :artist }
+  let(:artist_info) { create(:artist).artist_info }
   let(:studio) { create :studio }
-  let(:model) { Artist.new }
+  let(:model) { ArtistInfo.new }
   subject(:address) { described_class.new(model) }
 
-  describe 'for an artist' do
+  describe 'for an artist_info' do
     context 'with an address' do
-      let(:model) { artist }
+      let(:model) { artist_info }
 
       its(:geocoded?) { is_expected.to eq true }
-      its(:street) { is_expected.to eq artist.street }
-      its(:city) { is_expected.to eq artist.city }
-      its(:state) { is_expected.to eq artist.addr_state }
-      its(:lat) { is_expected.to eq artist.lat }
-      its(:lng) { is_expected.to eq artist.lng }
-      its(:to_s) { is_expected.to eq([artist.street, '94110'].join(' ')) }
+      its(:street) { is_expected.to eq artist_info.street }
+      its(:city) { is_expected.to eq artist_info.city }
+      its(:state) { is_expected.to eq artist_info.addr_state }
+      its(:lat) { is_expected.to eq artist_info.lat }
+      its(:lng) { is_expected.to eq artist_info.lng }
+      its(:to_s) { is_expected.to eq([artist_info.street, '94110'].join(' ')) }
       its(:present?) { is_expected.to eq true }
       its(:empty?) { is_expected.to eq false }
-
-      context 'who is in a studio' do
-        let(:model) { create :artist, studio: studio }
-
-        it 'returns the address information of the studio' do
-          expect(address).to eq studio.address
-        end
-      end
     end
     context 'without an address' do
-      let(:model) { create :artist, :without_address }
+      let(:model) { create(:artist, :without_address).artist_info }
 
       its(:geocoded?) { is_expected.to eq false }
       its(:street) { is_expected.to be_blank }

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -90,7 +90,7 @@ describe Artist do
       it 'returns empty for address' do
         expect(nobody.send(:address)).to be_empty
       end
-      it { expect(nobody).to_not be_address }
+      it { expect(nobody.address).to be_empty }
     end
   end
   describe 'in_the_mission?' do
@@ -100,7 +100,6 @@ describe Artist do
         allow(artist_without_studio.artist_info).to receive(:lng).and_return(-122.41)
       end
       it 'returns true' do
-        expect(artist_without_studio).to be_address
         expect(artist_without_studio).to be_in_the_mission
       end
     end
@@ -112,24 +111,22 @@ describe Artist do
         allow(artist.studio).to receive(:lng).and_return(-122.41)
       end
       it 'returns true' do
-        expect(artist).to be_address
         expect(artist).to be_in_the_mission
       end
     end
     it 'returns false for artist with wayout address' do
-      expect(wayout_artist).to be_address
+      expect(wayout_artist.address).to be_present
       expect(wayout_artist).to_not be_in_the_mission
     end
     context 'for artist not in the mission but in a studio in the mission' do
       before do
         studio = FactoryBot.create(:studio)
+        # don't update lat in factory because `compute_geocode` takes over
+        studio.update(lat: 37.75, lng: -122.41)
         wayout_artist.update studio: studio
         wayout_artist.reload
-        allow(wayout_artist.studio).to receive(:lat).and_return(37.75)
-        allow(wayout_artist.studio).to receive(:lng).and_return(-122.41)
       end
       it 'returns true' do
-        expect(wayout_artist).to be_address
         expect(wayout_artist).to be_in_the_mission
       end
     end
@@ -144,10 +141,10 @@ describe Artist do
       let(:artist_info) { artist_without_studio.artist_info }
 
       it 'returns correct street' do
-        expect(artist_info.street).to eql artist.street
+        expect(artist_info.street).to eql artist_without_studio.address.street
       end
       it 'returns correct address' do
-        expect(artist_without_studio.address.to_s).to include artist.street
+        expect(artist_without_studio.address.to_s).to include artist_without_studio.address.street
       end
       it 'returns correct lat/lng' do
         expect(artist_info.lat).to be
@@ -162,8 +159,8 @@ describe Artist do
         expect(artist.address.to_s).to eql studio.address.to_s
       end
       it 'returns correct lat/lng' do
-        expect(artist.lat).to be_within(0.001).of(studio.lat)
-        expect(artist.lng).to be_within(0.001).of(studio.lng)
+        expect(artist.address.lat).to be_within(0.001).of(studio.lat)
+        expect(artist.address.lng).to be_within(0.001).of(studio.lng)
       end
     end
   end

--- a/spec/presenters/artists_map_spec.rb
+++ b/spec/presenters/artists_map_spec.rb
@@ -28,8 +28,8 @@ describe ArtistsMap do
       expect(map_data).to have(2).items
       expected_data = artists.map do |a|
         {
-          'lat' => a.lat,
-          'lng' => a.lng,
+          'lat' => a.address.lat,
+          'lng' => a.address.lng,
           'artistId' => a.id,
           'artistName' => a.full_name,
           'infowindow' => ArtistPresenter.new(a).map_info,
@@ -43,7 +43,7 @@ describe ArtistsMap do
     describe '#grouped_by_address' do
       it 'returns artists grouped by address' do
         expected = map.artists.map do |a|
-          a.address.to_s if a.address?
+          a.address.to_s if a.address.present?
         end.compact.uniq
         expect(subject.grouped_by_address.size).to eq(expected.count)
       end
@@ -51,7 +51,7 @@ describe ArtistsMap do
 
     describe '#with_addresses' do
       it 'returns all artists with addresses' do
-        expect(subject.with_addresses.count).to eq map.artists.count(&:address?)
+        expect(subject.with_addresses.count).to eq(map.artists.count { |a| a.address.present? })
       end
     end
 

--- a/spec/serializers/artist_serializer_spec.rb
+++ b/spec/serializers/artist_serializer_spec.rb
@@ -18,7 +18,7 @@ describe ArtistSerializer do
     it 'includes a bunch of default attributes' do
       expect(parsed_artist[:firstname]).to eql artist.firstname
       expect(parsed_artist[:full_name]).to eql artist.full_name
-      expect(parsed_artist[:street_address]).to eql artist.street
+      expect(parsed_artist[:street_address]).to eql artist.address.street
       expect(parsed_artist[:city]).to eql artist.address.city
       expect(parsed_artist[:map_url]).to eql artist.map_link
     end


### PR DESCRIPTION
Problem
-------

Something recently changed with delegates making our strange delegation
strategy to get the address for an artist doesn't work as well as it
used to.  Not sure what changed.  I suspect a rails upgrade.  Basically
what was starting to happen was that `artists.lat` was no longer
`artist.studio.lat` in cases where it should have been.

https://www.pivotaltracker.com/story/show/176730160

Solution
--------

Rethink the way we handle address.

Instead of letting the `Address` model figure out how to find the
address stuff, we let the artist decide which model it should get the
address from and let `Address` simply be a decorator/presenter for
either a studio or artist_info - both which contain real address
information.

The rest of this code is to push that change through consuming
components and update specs