### PR TITLE
Handle bug with editing artist with bad info

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -156,15 +156,7 @@ class ArtistsController < ApplicationController
 
   def update
     if request.xhr?
-      open_studios_event = OpenStudiosEvent.current
-      os_status = UpdateArtistService.new(current_artist, os_status_params).update_os_status
-      message = update_os_status_message(os_status, current_artist, open_studios_event)
-      render json: {
-        success: true,
-        os_status: os_status,
-        current_os: OpenStudiosEventService.current,
-        message: message,
-      }
+      handle_xhr_update
     else
       if commit_is_cancel
         redirect_to user_path(current_user)
@@ -177,12 +169,26 @@ class ArtistsController < ApplicationController
       else
         @user = ArtistPresenter.new(current_artist.reload)
         @studios = StudioService.all
+        @artist_info = current_artist.artist_info
+        @open_studios_event = OpenStudiosEventPresenter.new(OpenStudiosEvent.current)
         render :edit
       end
     end
   end
 
   protected
+
+  def handle_xhr_update
+    open_studios_event = OpenStudiosEvent.current
+    os_status = UpdateArtistService.new(current_artist, os_status_params).update_os_status
+    message = update_os_status_message(os_status, current_artist, open_studios_event)
+    render json: {
+      success: true,
+      os_status: os_status,
+      current_os: OpenStudiosEventService.current,
+      message: message,
+    }
+  end
 
   def safe_find_artist(id)
     Artist.friendly.find id

--- a/app/views/artists/edit.slim
+++ b/app/views/artists/edit.slim
@@ -31,4 +31,5 @@ javascript:
   $(function () {
     new MAU.PaypalDonateForm("#donate_for_openstudios", "#paypal_donate_openstudios")
     new MAU.AccordionShowSectionGivenHash();
+    new MAU.AccordionShowSectionWithErrors();
   })

--- a/app/webpack/js/app/accordion_show_section_with_errors.js
+++ b/app/webpack/js/app/accordion_show_section_with_errors.js
@@ -1,0 +1,9 @@
+import jQuery from "jquery";
+
+class AccordionShowSectionWithErrors {
+  constructor() {
+    jQuery(".error").closest(".collapse").collapse("show");
+  }
+}
+
+export default AccordionShowSectionWithErrors;

--- a/app/webpack/js/globals.js
+++ b/app/webpack/js/globals.js
@@ -1,4 +1,5 @@
 import AccordionShowSectionGivenHash from "./app/accordion_show_section_given_hash";
+import AccordionShowSectionWithErrors from "./app/accordion_show_section_with_errors";
 import AccountTypeChooser from "./app/account_type_chooser";
 import ArrangeArtForm from "./app/arrange_art_form";
 import ArtPieceForm from "./app/art_piece_form";
@@ -14,6 +15,7 @@ import WhatsThisPopup from "./app/whats_this_popup";
 
 const globals = {
   AccordionShowSectionGivenHash,
+  AccordionShowSectionWithErrors,
   AccountTypeChooser,
   ArrangeArtForm,
   ArtistBioToggler,

--- a/features/artists/my_mau_after_open_studios.feature
+++ b/features/artists/my_mau_after_open_studios.feature
@@ -1,0 +1,20 @@
+@javascript
+Feature: Artists Account
+  As an artist
+  I can see my page with my art and a menu of useful actions
+
+Background:
+  Given there are past open studios events
+  And I login as an artist
+
+Scenario: I can edit my profile even if i make a mistake
+  When I visit my artist profile edit page
+  Then I see my profile edit form
+
+  When I click on "Personal Info"
+  And I update my personal information with:
+  | artist_email   |
+  |                |
+  And I click on "Save Changes"
+
+  Then I see an error in the form "can't be blank"

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -136,7 +136,7 @@ Then(/^I see that the studio "(.*?)" has an artist called "(.*?)"$/) do |studio_
 end
 
 Then(/^I see an error in the form "(.*?)"$/) do |msg|
-  within 'form' do
+  within first('form', minimum: 1) do
     expect(page).to have_selector '.error', text: msg
   end
 end


### PR DESCRIPTION
Problem
--------

We were blowing up on editing artist if you had validation errors
because we were not getting all the data setup for the view - in the
failure case.  And we had no tests around that.

Additionally, we were doing a bad job of surfacing errors if you edited your artist
info but there were errors in the data (like blank email).  The section
that contained the error would remain closed and there was no flash to
tell you something went wrong.

Solution
--------

If we hit an error during `update` and we decide to `render :edit`, lets
get all the data ready for the view.

Then in the view, we add some Javascript to check for any sections that
have `.error` and if there are any, open that accordion up.

Finally, added a cucumber test to prove it.