### PR TITLE
Add single artist open studio show page with no details

### DIFF
--- a/app/controllers/open_studios_controller.rb
+++ b/app/controllers/open_studios_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OpenStudiosController < ApplicationController
-  def show
+  def index
     @page_title = PageInfoService.title('Open Studios')
     @os_only = true
     cur_page = (params[:p] || 0).to_i
@@ -16,6 +16,11 @@ class OpenStudiosController < ApplicationController
     end
   end
 
+  def show
+    artist = active_artist_from_params
+    @artist = ArtistPresenter.new(artist) if artist&.doing_open_studios?
+  end
+
   def register
     if current_user
       redirect_to register_for_current_open_studios_artists_path
@@ -23,5 +28,17 @@ class OpenStudiosController < ApplicationController
       store_location(register_for_current_open_studios_artists_path)
       redirect_to sign_in_path
     end
+  end
+
+  private
+
+  def active_artist_from_params
+    artist = begin
+      Artist.active.joins(:open_studios_events).friendly.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+    flash.now[:error] = "We couldn't find who you were looking for" unless artist
+    artist
   end
 end

--- a/app/views/artists/show.html.slim
+++ b/app/views/artists/show.html.slim
@@ -5,7 +5,7 @@
       span.artist__name< #{@artist.get_name}
       - if @artist.doing_open_studios?
         a href="/open_studios" title="I'm doing Open Studios"
-          .os-violator
+          .os-violator.os-violator--title
 .pure-g.alpha.omega
   .pure-u-1-1.pure-u-sm-1-3.pure-u-md-1-2.pure-u-lg-2-5#about
     = render "/artists/about", artist: @artist

--- a/app/views/open_studios/_art.html.slim
+++ b/app/views/open_studios/_art.html.slim
@@ -1,0 +1,13 @@
+/ expects art_piece as art_piece_presenter
+- show_os_violator ||= false
+- class_overrides ||= %w(pure-u-1-1 pure-u-sm-1-2 pure-u-md-1-3 pure-u-lg-1-4 pure-u-xl-1-5).join(" ")
+.art-card class=class_overrides
+  .art-piece
+    .image style=background_image_style(art_piece.path)
+    .desc
+      .name
+        = art_piece.title
+      .name
+        span.byline> by
+        '
+        = art_piece.artist_name

--- a/app/views/open_studios/index.html.slim
+++ b/app/views/open_studios/index.html.slim
@@ -1,0 +1,51 @@
+.pure-g.sticky-header
+  .pure-u-1-1.header.padded-content.with-action-button.bordered-header
+    h2.title #{open_studios_page_title}
+    - if @presenter.promote?
+      .action-button
+        = link_to "Register to Participate", register_open_studios_path, class: "pure-button-primary pure-button"
+
+- if @gallery.items.any?
+  .pure-g
+    .pure-u-1-1.padded-content
+      ul.js-tabs.tabs.tabs__horizontal.open-studios-content-tabs
+        li.active
+          a href="#about" data-toggle="tab" about
+        li
+          a href="#participants" data-toggle="tab" participants
+        li
+          a href="#map" data-toggle="tab" map
+.pure-g.tab-content
+  .pure-u-1-1#about.tab-pane.active
+    .pure-g
+      .pure-u-1-1.pure-u-md-2-3.pure-u-lg-3-5.padded-content
+        = render_cms_content @presenter.packaged_summary
+        = render_cms_content @presenter.packaged_preview_reception
+        .section
+          h4 Participating Group Studios
+          ul.participant_list
+            - @presenter.participating_studios.each do |s|
+              li
+                = link_to(s.name,s)
+                '
+                = "(#{pluralize(s.artists.to_a.count(&:doing_open_studios?), 'artist')})"
+        .section
+          h4 Participating Independent Artists
+          ul.participant_list
+            - @presenter.participating_indies.each do |a|
+              li
+                = link_to(a.get_name, a)
+                '
+                = a.street
+          = render :partial => '/main/info_footer'
+  - if @gallery.items.any?
+    .pure-u-1-1.tab-pane.padded-content#participants
+      .pure-g.js-artists-scroll-wrapper.artists-scroll
+        = render '/artists/artist_list', gallery: @gallery
+    .pure-u-1-1.tab-pane.padded-content#map
+      = render 'map', map_info: @map_info
+
+javascript:
+  $(function() {
+    new MAU.ArtistListInfiniteScroller('/open_studios');
+  });

--- a/app/views/open_studios/show.html.slim
+++ b/app/views/open_studios/show.html.slim
@@ -1,51 +1,17 @@
 .pure-g.sticky-header
-  .pure-u-1-1.header.padded-content.with-action-button.bordered-header
-    h2.title #{open_studios_page_title}
-    - if @presenter.promote?
-      .action-button
-        = link_to "Register to Participate", register_open_studios_path, class: "pure-button-primary pure-button"
-
-- if @gallery.items.any?
-  .pure-g
-    .pure-u-1-1.padded-content
-      ul.js-tabs.tabs.tabs__horizontal.open-studios-content-tabs
-        li.active
-          a href="#about" data-toggle="tab" about
-        li
-          a href="#participants" data-toggle="tab" participants
-        li
-          a href="#map" data-toggle="tab" map
-.pure-g.tab-content
-  .pure-u-1-1#about.tab-pane.active
+  .pure-u-1-1.header.padded-content
+    h2.title
+      | Artist:
+      span.artist__name< #{@artist.get_name}
+      - if @artist.doing_open_studios?
+        a href="/open_studios" title="I'm doing Open Studios"
+          .os-violator
+.pure-g.alpha.omega
+  .pure-u-1-1.pure-u-sm-2-3.pure-u-md-1-2.pure-u-lg-3-5#art
     .pure-g
-      .pure-u-1-1.pure-u-md-2-3.pure-u-lg-3-5.padded-content
-        = render_cms_content @presenter.packaged_summary
-        = render_cms_content @presenter.packaged_preview_reception
-        .section
-          h4 Participating Group Studios
-          ul.participant_list
-            - @presenter.participating_studios.each do |s|
-              li
-                = link_to(s.name,s)
-                '
-                = "(#{pluralize(s.artists.to_a.count(&:doing_open_studios?), 'artist')})"
-        .section
-          h4 Participating Independent Artists
-          ul.participant_list
-            - @presenter.participating_indies.each do |a|
-              li
-                = link_to(a.get_name, a)
-                '
-                = a.street
-          = render :partial => '/main/info_footer'
-  - if @gallery.items.any?
-    .pure-u-1-1.tab-pane.padded-content#participants
-      .pure-g.js-artists-scroll-wrapper.artists-scroll
-        = render '/artists/artist_list', gallery: @gallery
-    .pure-u-1-1.tab-pane.padded-content#map
-      = render 'map', map_info: @map_info
-
-javascript:
-  $(function() {
-    new MAU.ArtistListInfiniteScroller('/open_studios');
-  });
+      .pure-u-1-1
+      - if @artist.art_pieces.present?
+        = render partial: "/open_studios/art", collection: @artist.art_pieces, as: :art_piece, locals: { class_overrides: "pure-u-1-1 pure-u-lg-1-2 pure-u-xl-1-3"}
+      - else
+        .pure-u-1-1.empty
+          h4 This artist has no art to show.

--- a/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.scss
+++ b/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.scss
@@ -1,4 +1,5 @@
 @import "mau-mixins";
+@import "gto/gto-mixins";
 
 art-pieces-browser {
   .art-piece,
@@ -22,15 +23,9 @@ art-pieces-browser {
     .artist__image {
       position: relative;
       .os-violator {
-        position: absolute;
+        @include artist-image-os-violator;
         bottom: 2px;
         right: 2px;
-        display: inline-block;
-        background-image: url("../../../images/os_violator.svg");
-        background-color: rgba(245, 245, 245, 0.95);
-        width: 75px;
-        height: 80px;
-        background-size: contain;
       }
       @media screen and (max-width: $screen-xs-max) {
         display: none;

--- a/app/webpack/angularjs/components/art_pieces_browser/index.html
+++ b/app/webpack/angularjs/components/art_pieces_browser/index.html
@@ -10,7 +10,7 @@
         ng-show="artist.doingOpenStudios"
         title="I&#39;m doing Open Studios"
       >
-        <div class="os-violator"></div>
+        <div class="os-violator os-violator--title"></div>
       </a>
     </h2>
   </div>

--- a/app/webpack/stylesheets/gto/artists/_artists.scss
+++ b/app/webpack/stylesheets/gto/artists/_artists.scss
@@ -89,6 +89,16 @@
   }
 }
 
+.os-violator--title {
+  background-size: 25px 25px;
+  margin-left: 4px;
+  display: inline-block;
+  vertical-align: middle;
+  height: 28px;
+  width: 28px;
+  background-color: transparent;
+}
+
 .favorites.index,
 .users.show,
 .search-results,
@@ -100,17 +110,6 @@
   @include search-filter;
   .title .letter {
     text-transform: uppercase;
-  }
-  .header .title {
-    .os-violator {
-      background-size: 25px 25px;
-      margin-left: 4px;
-      display: inline-block;
-      vertical-align: middle;
-      height: 28px;
-      width: 28px;
-      background-color: transparent;
-    }
   }
 
   #about,
@@ -385,15 +384,9 @@
       text-align: right;
     }
     .os-violator {
-      position: absolute;
+      @include artist-image-os-violator;
       bottom: 37px;
       right: 2px;
-      display: inline-block;
-      background-image: url("../../../images/os_violator.svg");
-      background-color: rgba(245, 245, 245, 0.95);
-      width: 75px;
-      height: 80px;
-      background-size: contain;
     }
   }
   .artist-profile__image {

--- a/app/webpack/stylesheets/gto/artists/_artists_map.scss
+++ b/app/webpack/stylesheets/gto/artists/_artists_map.scss
@@ -1,5 +1,7 @@
 @import "mau-mixins";
 @import "gto/gto-mixins";
+
+.open_studios.index,
 .open_studios.show,
 .artists.map_page {
   #map-canvas {
@@ -9,12 +11,6 @@
   .map__artist {
     @include ellipsis;
   }
-  /* offset for cluster count */
-  /* .cluster { */
-  /*   > div[aria-label] { */
-  /*     top: 10px; */
-  /*   } */
-  /* } */
   .gm-style-iw {
     min-width: 260px !important;
     overflow: visible !important;

--- a/app/webpack/stylesheets/gto/gto-mixins.scss
+++ b/app/webpack/stylesheets/gto/gto-mixins.scss
@@ -198,7 +198,7 @@ $sampler-thumbnail-size: 250px;
 
 @mixin os-violator {
   background-image: url("../../images/os_violator_tiny.svg");
-  background-color: rgba(245, 245, 245, 0.85);
+  background-color: rgba(245, 245, 245, 0.75);
   background-repeat: no-repeat;
   background-size: 40px 40px;
   background-position: center;
@@ -208,4 +208,14 @@ $sampler-thumbnail-size: 250px;
   &.with-image {
     background: none;
   }
+}
+
+@mixin artist-image-os-violator {
+  position: absolute;
+  display: inline-block;
+  background-image: url("../../images/os_violator.svg");
+  background-color: rgba(245, 245, 245, 0.75);
+  width: 75px;
+  height: 80px;
+  background-size: contain;
 }

--- a/app/webpack/stylesheets/gto/main/_open_studios.scss
+++ b/app/webpack/stylesheets/gto/main/_open_studios.scss
@@ -1,6 +1,6 @@
 @import "gto/variables";
 @import "gto/gto-mixins";
-.open_studios.show {
+.open_studios.index {
   .padded-content > .js-tabs {
     margin-top: -10px;
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Mau::Application.routes.draw do
 
   resources :studios, only: %i[index show]
 
-  resource :open_studios, only: [:show] do
+  resources :open_studios, only: [:index] do
     collection do
       get :register
     end
@@ -76,6 +76,7 @@ Mau::Application.routes.draw do
       get :manage_art
       post :notify_featured
       post :update
+      resource :open_studios, only: [:show], as: :artist_open_studios
       # get :qrcode
     end
   end

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -142,3 +142,14 @@ Then(/^I see stars for all open studios participants$/) do
   participants = OpenStudiosParticipant.count
   expect(page).to have_css('.fa.fa-star', count: participants)
 end
+
+When('I visit the first artist\'s open studios page') do
+  @artist = Artist.active.joins(:open_studios_events).first
+  visit artist_open_studios_path(@artist)
+end
+
+Then('I see that artist\'s open studios pieces') do
+  expect(page).to have_content(@artist.name)
+  expect(@artist.art_pieces).to have_at_least(1).art_piece
+  expect(page).to have_css('.art-piece', count: @artist.art_pieces.count)
+end


### PR DESCRIPTION
Problem
-------

we need an open studios page for an artist

https://www.pivotaltracker.com/story/show/176835287

Solution
--------

Re route `/open_studios` to make room for `artists/<theartist>/open_studios`
and build a show page for artists open studios which is a simplified
version of the artist's show page with no extra info - just art with no
links