### PR TITLE
Artist can mark an art piece Sold [176853928]

### DIFF
--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -100,8 +100,19 @@ class ArtPiecesController < ApplicationController
   end
 
   def art_piece_params
-    params.require(:art_piece).permit(:title, :dimensions,
-                                      :year, :medium, :medium_id, :price,
-                                      :description, :position, :photo, :tags, tag_ids: [])
+    params.require(:art_piece).permit(
+      :description,
+      :dimensions,
+      :medium,
+      :medium_id,
+      :photo,
+      :position,
+      :price,
+      :sold,
+      :tags,
+      :title,
+      :year,
+      tag_ids: [],
+    )
   end
 end

--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -18,6 +18,8 @@ class ArtPiece < ApplicationRecord
 
   include Elasticsearch::Model
 
+  attr_accessor :sold
+
   # after_destroy :remove_images
   after_destroy :clear_tags_and_favorites
   after_save :clear_caches
@@ -25,6 +27,10 @@ class ArtPiece < ApplicationRecord
   after_commit :add_to_search_index, on: :create
   after_commit :refresh_in_search_index, on: :update
   after_commit :remove_from_search_index, on: :destroy
+
+  before_save do
+    self.sold_at = sold ? Time.current : nil
+  end
 
   def add_to_search_index
     Search::Indexer.index(self)

--- a/app/serializers/art_piece_serializer.rb
+++ b/app/serializers/art_piece_serializer.rb
@@ -2,7 +2,7 @@
 
 class ArtPieceSerializer < MauSerializer
   attributes :artist_name, :favorites_count, :price, :display_price,
-             :year, :dimensions, :title, :artist_id, :image_urls
+             :year, :dimensions, :title, :artist_id, :image_urls, :sold_at
   # NOTE: image_urls used by angular photo browser
   include ImageFileHelpers
   include Rails.application.routes.url_helpers

--- a/app/views/art_pieces/edit.html.slim
+++ b/app/views/art_pieces/edit.html.slim
@@ -16,6 +16,7 @@
         = f.input :medium, as: :select, collection: [['None', 0]] + @media.map{|u| [u.name,u.id]}
         = f.input :tags, input_html: { value: tags_to_s(@art_piece.tags) }, multiple: true
         = f.input :price
+        = f.input :sold, as: :boolean, input_html: { checked: @art_piece.sold_at.present? }
       = f.actions do
         = f.submit 'Update', class: 'pure-button button-large pure-button-primary'
         = f.submit 'Cancel', class: 'pure-button button-large'

--- a/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.js
+++ b/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.js
@@ -96,6 +96,10 @@ const controller = ngInject(function (
   $scope.hasPrice = function () {
     return Boolean($scope.artPiece && $scope.artPiece.displayPrice);
   };
+  $scope.wasSold = function () {
+    return Boolean($scope.artPiece && $scope.artPiece.soldAt);
+  };
+
   const init = function () {
     var artPieceId, artistId;
     artistId = $attrs.artistId;

--- a/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.scss
+++ b/app/webpack/angularjs/components/art_pieces_browser/art_pieces_browser.scss
@@ -1,5 +1,6 @@
 @import "mau-mixins";
 @import "gto/gto-mixins";
+@import "colors";
 
 art-pieces-browser {
   .art-piece,
@@ -76,6 +77,19 @@ art-pieces-browser {
   .card__controls,
   .desc {
     flex: 1;
+  }
+  .desc__item--sold {
+    text-decoration: line-through;
+    position: relative;
+    &:after {
+      color: $gto-yellow;
+      content: "SOLD";
+      font-size: 0.8rem;
+      font-weight: bold;
+      position: absolute;
+      top: 1px;
+      right: 1px;
+    }
   }
   .studio,
   .studio-address,

--- a/app/webpack/angularjs/components/art_pieces_browser/index.html
+++ b/app/webpack/angularjs/components/art_pieces_browser/index.html
@@ -84,11 +84,11 @@
           </span>
         </div>
       </div>
-      <div class="desc__item ngwrapper" ng-if="hasPrice()">
+      <div ng-class="{'desc__item': true, ngwrapper: true, 'desc__item--sold': wasSold()}" ng-if="hasPrice() || wasSold()">
         <h4 class="art-piece__info-title">
           Price
         </h4>
-        <div class="price" ng-bind-html="artPiece.displayPrice">div>
+        <div class="price" ng-bind-html="artPiece.displayPrice"/>
       </div>
     </section>
     <div class="push">

--- a/db/migrate/20210211063625_add_sold_at_to_art_piece.rb
+++ b/db/migrate/20210211063625_add_sold_at_to_art_piece.rb
@@ -1,0 +1,5 @@
+class AddSoldAtToArtPiece < ActiveRecord::Migration[6.1]
+  def change
+    add_column :art_pieces, :sold_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_033016) do
+ActiveRecord::Schema.define(version: 2021_02_11_063625) do
 
   create_table "application_events", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2021_02_09_033016) do
     t.integer "photo_file_size"
     t.datetime "photo_updated_at"
     t.float "price"
+    t.datetime "sold_at"
     t.index ["artist_id"], name: "index_art_pieces_on_artist_id"
     t.index ["medium_id"], name: "index_art_pieces_on_medium_id"
   end

--- a/features/artists/add_and_edit_art.feature
+++ b/features/artists/add_and_edit_art.feature
@@ -34,3 +34,15 @@ Scenario: "Editing Art"
   And I see that my art tags are:
     | new tag | other tag |
   And I see a flash notice "art has been updated"
+
+  When I click on "My Art" in the sidebar menu
+  And I click on "edit"
+  And I click on the first "edit this art" button
+  And I check "Sold"
+  And I click "Update"
+  Then I see that my art is marked sold
+
+  When I click on "My Art" in the sidebar menu
+  And I click on "edit"
+  And I click on the first "edit this art" button
+  Then I see the sold checkmark is checked

--- a/features/step_definitions/artist_steps.rb
+++ b/features/step_definitions/artist_steps.rb
@@ -46,6 +46,16 @@ Then(/^I see that my art tags are:$/) do |data|
   end
 end
 
+Then('I see that my art is marked sold') do
+  expect(page).to have_css('.desc__item--sold')
+end
+
+Then('I see the sold checkmark is checked') do
+  within 'form' do
+    expect(page).to have_css('#art_piece_sold[checked]')
+  end
+end
+
 When(/^I fill out the add art form$/) do
   @medium = Medium.first
   attach_file 'Photo', Rails.root.join('spec/fixtures/files/art.png')

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -40,4 +40,24 @@ describe ArtPiece do
       expect(escaped).to eq(HtmlEncoder.encode(ap.get_name))
     end
   end
+
+  describe 'sold' do
+    it 'sets sold_at to now if true when you save' do
+      freeze_time do
+        now = Time.current
+        art_piece.sold = true
+        art_piece.save
+        art_piece.reload
+        expect(art_piece.sold_at).to eq now
+      end
+    end
+
+    it 'sets sold_at to nil if it was set and then sold is marked false' do
+      art_piece.update({ sold_at: Time.current })
+      art_piece.sold = false
+      art_piece.save
+      art_piece.reload
+      expect(art_piece.sold_at).to be_nil
+    end
+  end
 end

--- a/spec/serializers/art_piece_serializer_spec.rb
+++ b/spec/serializers/art_piece_serializer_spec.rb
@@ -13,7 +13,7 @@ describe ArtPieceSerializer do
 
   describe 'to_json' do
     it 'includes the fields we care about' do
-      %i[title artist_id year image_urls artist_name].each do |expected|
+      %i[title artist_id year image_urls artist_name price sold_at].each do |expected|
         expect(parsed_art_piece).to have_key expected
       end
     end


### PR DESCRIPTION
Problem
--------

As an artist
i would like to have the ability to show what pieces have been sold
on my profile page and my open studios page
so that my virtual open studios visitors will know what is still available to buy and also may feel a sense of urgency to pull the trigger on their purchase

https://www.pivotaltracker.com/story/show/176853928

Solution
---------

Add a `sold_at` column on art piece and allow artists to "edit" their
art piece and mark it "sold".

After this, `sold` will show up on the art piece detail page next to
price.

Screenshots
-------------
<img width="680" alt="Screen Shot 2021-02-10 at 11 43 28 PM" src="https://user-images.githubusercontent.com/427380/107611872-d5078280-6bf9-11eb-83c4-5c23954143f7.png">


<img width="788" alt="Screen Shot 2021-02-10 at 11 25 01 PM" src="https://user-images.githubusercontent.com/427380/107611868-d0db6500-6bf9-11eb-9bbb-023e353378e3.png">
