### PR TITLE
Handle errors for artists personal os page

### DIFF
--- a/app/controllers/open_studios_controller.rb
+++ b/app/controllers/open_studios_controller.rb
@@ -17,8 +17,11 @@ class OpenStudiosController < ApplicationController
   end
 
   def show
-    artist = active_artist_from_params
+    artist = Artist.active.joins(:open_studios_events).friendly.find(params[:id])
     @artist = ArtistPresenter.new(artist) if artist&.doing_open_studios?
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = "It doesn't look like that artist is doing open studios" unless artist
+    redirect_to open_studios_path
   end
 
   def register
@@ -28,17 +31,5 @@ class OpenStudiosController < ApplicationController
       store_location(register_for_current_open_studios_artists_path)
       redirect_to sign_in_path
     end
-  end
-
-  private
-
-  def active_artist_from_params
-    artist = begin
-      Artist.active.joins(:open_studios_events).friendly.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      nil
-    end
-    flash.now[:error] = "We couldn't find who you were looking for" unless artist
-    artist
   end
 end

--- a/spec/controllers/open_studios_controller_spec.rb
+++ b/spec/controllers/open_studios_controller_spec.rb
@@ -3,8 +3,40 @@
 require 'rails_helper'
 
 describe OpenStudiosController do
+  let(:artist) { create(:artist) }
+  let(:active_artist_doing_open_studios) do
+    current_os
+    create(:artist, :active, doing_open_studios: true)
+  end
+  let(:current_os) { create(:open_studios_event) }
+
+  describe '#show' do
+    it 'renders successfully if the artist is active and doing open studios' do
+      get :show, params: { id: active_artist_doing_open_studios }
+      expect(response).to be_ok
+    end
+
+    it 'redirects to open_studios_path if the artist is not doing open studios' do
+      get :show, params: { id: artist }
+      expect(response).to redirect_to(open_studios_path)
+      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+    end
+
+    it 'redirects to open_studios_path if the artist is unknown' do
+      get :show, params: { id: 'nobody-we-know' }
+      expect(response).to redirect_to(open_studios_path)
+      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+    end
+
+    it 'redirects to open_studios_path if the artist is not active' do
+      artist.update(state: :pending)
+      get :show, params: { id: artist }
+      expect(response).to redirect_to(open_studios_path)
+      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+    end
+  end
+
   describe '#register' do
-    let(:artist) { create(:artist) }
     it 'sends you to your edit page if you are logged in' do
       login_as artist
       get :register


### PR DESCRIPTION
Problem
--------

The first cut of a personal OS page didn't have any error checking.

Solution
--------

For the open studios page for an artist, redirect to /open_studios if we
can't find the artist and surface a sane error message.