### PR TITLE
Fix art piece getting set sold with any edits

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -28,8 +28,9 @@ class ArtPiece < ApplicationRecord
   after_commit :refresh_in_search_index, on: :update
   after_commit :remove_from_search_index, on: :destroy
 
-  before_save do
-    self.sold_at = sold ? Time.current : nil
+  before_validation do
+    # checkbox from formastic uses '1' for true
+    self.sold_at = sold == '1' ? Time.current : nil
   end
 
   def add_to_search_index

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -42,10 +42,10 @@ describe ArtPiece do
   end
 
   describe 'sold' do
-    it 'sets sold_at to now if true when you save' do
+    it 'sets sold_at to now if sold = "1" when you save' do
       freeze_time do
         now = Time.current
-        art_piece.sold = true
+        art_piece.sold = '1'
         art_piece.save
         art_piece.reload
         expect(art_piece.sold_at).to eq now
@@ -55,6 +55,14 @@ describe ArtPiece do
     it 'sets sold_at to nil if it was set and then sold is marked false' do
       art_piece.update({ sold_at: Time.current })
       art_piece.sold = false
+      art_piece.save
+      art_piece.reload
+      expect(art_piece.sold_at).to be_nil
+    end
+
+    it 'sets sold_at to nil if sold is not "1"' do
+      art_piece.update({ sold_at: Time.current })
+      art_piece.sold = '0'
       art_piece.save
       art_piece.reload
       expect(art_piece.sold_at).to be_nil


### PR DESCRIPTION
problem
--------

With https://www.pivotaltracker.com/story/show/176853928, we were
mistakenly marking an art piece sold with *every* edit.

solution
--------

Don't assume the form data comes back as a boolean.  Instead only
toggle 'sold_at' if the `sold` param is `1`.