### PR TITLE
Add feature flag for virtual open studios

### DIFF
--- a/app/controllers/open_studios_controller.rb
+++ b/app/controllers/open_studios_controller.rb
@@ -15,6 +15,8 @@ class OpenStudiosController < ApplicationController
   end
 
   def show
+    (redirect_to '/error' and return) unless FeatureFlags.virtual_open_studios?
+
     artist = Artist.active.joins(:open_studios_events).friendly.find(params[:id])
     @artist = ArtistPresenter.new(artist) if artist&.doing_open_studios?
   rescue ActiveRecord::RecordNotFound

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -1,0 +1,7 @@
+class FeatureNotAvailableError < StandardError; end
+
+class FeatureFlags
+  def self.virtual_open_studios?
+    Conf.features['virtual_open_studios']
+  end
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,8 @@
 test:
   mailchimp_api_key: bogus-key
   min_artists_per_studio: 1
+  features:
+    virtual_open_studios: true
   pagination:
     media:
       per_page: 12
@@ -13,12 +15,13 @@ test:
       per_page: 12
 
 development:
+  features:
+    virtual_open_studios: true
   cache_expiry:
     feed: 300
     search: 20
     objects: 0
     new_art: 300
-  oslive: 201404
   pagination:
     artists:
       per_page: 5
@@ -28,6 +31,8 @@ development:
       per_page: 12
 
 acceptance:
+  features:
+    virtual_open_studios: true
   S3_DOMAIN: 'us-west-1'
 
 production:
@@ -38,6 +43,8 @@ production:
     new_art: 86400
 
 common:
+  features:
+    virtual_open_studios: false
   pagination:
     media:
       per_page: 24
@@ -53,9 +60,6 @@ common:
 
   cache_server: localhost:11211
   signup_secret_word: eat-shit-hackers
-  feedback_emails:
-    - feedback@missionartists.org
-    - maufeedback@bunnymatic.com
   cache_expiry:
     feed: 300
     search: 20

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,8 +192,5 @@ Mau::Application.routes.draw do
 
   get '*path' => 'error#index'
 
-  # march 2014 - we should try to get rid of this route
-  # match '/:controller(/:action(/:id))'
-
   root to: 'main#index'
 end

--- a/spec/controllers/open_studios_controller_spec.rb
+++ b/spec/controllers/open_studios_controller_spec.rb
@@ -9,28 +9,44 @@ describe OpenStudiosController do
   let(:current_os) { create(:open_studios_event) }
 
   describe '#show' do
-    it 'renders successfully if the artist is active and doing open studios' do
-      get :show, params: { id: active_artist_doing_open_studios }
-      expect(response).to be_ok
+    context 'with virtual_open_studios flag on' do
+      before do
+        mock_app_config(:features, { virtual_open_studios: true })
+      end
+
+      it 'renders successfully if the artist is active and doing open studios' do
+        get :show, params: { id: active_artist_doing_open_studios }
+        expect(response).to be_ok
+      end
+
+      it 'redirects to open_studios_path if the artist is not doing open studios' do
+        get :show, params: { id: artist }
+        expect(response).to redirect_to(open_studios_path)
+        expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+      end
+
+      it 'redirects to open_studios_path if the artist is unknown' do
+        get :show, params: { id: 'nobody-we-know' }
+        expect(response).to redirect_to(open_studios_path)
+        expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+      end
+
+      it 'redirects to open_studios_path if the artist is not active' do
+        artist.update(state: :pending)
+        get :show, params: { id: artist }
+        expect(response).to redirect_to(open_studios_path)
+        expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+      end
     end
 
-    it 'redirects to open_studios_path if the artist is not doing open studios' do
-      get :show, params: { id: artist }
-      expect(response).to redirect_to(open_studios_path)
-      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
-    end
-
-    it 'redirects to open_studios_path if the artist is unknown' do
-      get :show, params: { id: 'nobody-we-know' }
-      expect(response).to redirect_to(open_studios_path)
-      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
-    end
-
-    it 'redirects to open_studios_path if the artist is not active' do
-      artist.update(state: :pending)
-      get :show, params: { id: artist }
-      expect(response).to redirect_to(open_studios_path)
-      expect(flash[:error]).to eq "It doesn't look like that artist is doing open studios"
+    context 'with virtual open studios flag off' do
+      before do
+        mock_app_config(:features, { virtual_open_studios: false })
+      end
+      it 'renders error page' do
+        get :show, params: { id: active_artist_doing_open_studios }
+        expect(response).to redirect_to('/error')
+      end
     end
   end
 

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe FeatureFlags do
+  context 'when config.features.virtual_open_studios is false' do
+    before do
+      mock_app_config(:features, { virtual_open_studios: false })
+    end
+    it 'gets virtual open studios flag from config.features.virtual_open_studios' do
+      expect(FeatureFlags.virtual_open_studios?).to eq false
+    end
+  end
+  context 'when config.features.virtual_open_studios is true' do
+    before do
+      mock_app_config(:features, { virtual_open_studios: true })
+    end
+    it 'gets virtual open studios flag from config.features.virtual_open_studios' do
+      expect(FeatureFlags.virtual_open_studios?).to eq true
+    end
+  end
+end

--- a/spec/support/app_config.rb
+++ b/spec/support/app_config.rb
@@ -1,0 +1,10 @@
+module MockAppConfig
+  def mock_app_config(key, value)
+    value.stringify_keys! if value.is_a? Hash
+    allow(Conf).to receive(:method_missing).with(key.to_sym).and_return(value)
+  end
+end
+
+RSpec.configure do |config|
+  config.include MockAppConfig
+end


### PR DESCRIPTION
Problem
--------

We need to control when we release virtual open studios features.

Solution
--------

Add a feature flag in `Conf` and use it to guard against accesss on the
open studios controller #show page.

Changes
--------

* Add flags to `Conf`
* Add `FeatureFlags` wrapper for flags
* Add mock_app_config to spec for easy flipping of settings
* Clean up conf flags that are unused
* Clean up comments in routes.rb
* Set virtual_open_studios on for test env - so cucumber has all
  features on always.