### PR TITLE
Add validation on art_piece content size. max 4MB

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -11,6 +11,7 @@ class ArtPiece < ApplicationRecord
   validates_attachment_content_type :photo,
                                     content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'],
                                     message: 'Only JPEG, PNG, and GIF images are allowed'
+  validates_attachment_size :photo, less_than: 4.megabytes
   validates :artist_id, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0.01 }, allow_nil: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,8 +77,12 @@ class User < ApplicationRecord
     Favorite.artists.where(favoritable_id: id).delete_all
   end
 
-  %i[studionumber studionumber=].each do |delegat|
-    delegate delegat, to: :artist_info, allow_nil: true
+  def studionumber
+    artist_info&.studionumber
+  end
+
+  def studionumber=(val)
+    artist_info && artist_info.studionumber = val
   end
 
   SORT_BY_LASTNAME = lambda do |a, b|

--- a/app/views/common/_form_errors.html.slim
+++ b/app/views/common/_form_errors.html.slim
@@ -1,4 +1,9 @@
 - if form.try(:object).try(:errors).present?
   .error-msg
-    - form.object.errors.full_messages.each do |msg|
-      .err = msg
+    - form.object.errors.each do |err|
+      - # filtering out detail errors from paperclip.
+      - # more reason to get off paperclip
+      - # https://www.pivotaltracker.com/story/show/172394498
+      - # https://github.com/thoughtbot/paperclip/commit/2aeb491fa79df886a39c35911603fad053a201c0
+      - next if (/_file_size/ =~ err.attribute) || /_content_type/ =~ err.attribute
+      .err = err.full_message

--- a/features/support/fixture_file_helpers.rb
+++ b/features/support/fixture_file_helpers.rb
@@ -1,7 +1,2 @@
-module FixtureFileHelpers
-  def fixture_file(file)
-    Rails.root.join("spec/fixtures/#{file}")
-  end
-end
-
+require_relative '../../spec/support/fixture_file_helpers'
 World FixtureFileHelpers

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -5,10 +5,12 @@ describe ArtPiece do
   let(:artist) { FactoryBot.create(:artist, :active, :with_art) }
   let(:art_piece) { artist.art_pieces.first }
 
-  it { should validate_presence_of(:title) }
-  it { should validate_length_of(:title).is_at_least(2).is_at_most(80) }
-  it { should validate_numericality_of(:price).allow_nil.is_greater_than_or_equal_to(0.01) }
-
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_least(2).is_at_most(80) }
+    it { is_expected.to validate_numericality_of(:price).allow_nil.is_greater_than_or_equal_to(0.01) }
+    it { is_expected.to validate_attachment_size(:photo).less_than(4.megabytes) }
+  end
   describe 'new' do
     it 'allows quotes' do
       p = valid_attrs.merge(title: 'what"ever')

--- a/spec/support/fixture_file_helpers.rb
+++ b/spec/support/fixture_file_helpers.rb
@@ -1,0 +1,9 @@
+module FixtureFileHelpers
+  def fixture_file(file)
+    Rails.root.join("spec/fixtures/#{file}")
+  end
+end
+
+RSpec.configure do |config|
+  config.include FixtureFileHelpers
+end

--- a/spec/support/paperclip.rb
+++ b/spec/support/paperclip.rb
@@ -1,0 +1,5 @@
+require 'paperclip/matchers'
+
+RSpec.configure do |config|
+  config.include Paperclip::Shoulda::Matchers
+end


### PR DESCRIPTION
Problem
--------

Uploading big files that lead to web timeouts leads to the error page
which is no good for users.

Solution
---------

For now, we're going to put a 4M limit on it and hope that saves most
folks from trouble.  A better long term solution would be client-side
file uploaders with a progress bar.  Hopefully this will help as a
bandaid until we get to that point.

Changes
-------

* Add content size validation on ArtPiece.

Note
----

We have 2 other image upload opportunities - studio image (which is
admin only so it doesn't really matter) but the artist profile image
also might want this treatment.  Currently it has a slightly different
validation scheme so we should probably roll that out with care which is
why I didn't do that work here.