### PR TITLE
Add a React Component scaffolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ As we move to React (from angular/jquery), here is the way to add a new componen
 * If you need styles, add a scss file under `stylesheets/gto/components/ with the same name as the component, then add that import to `stylesheets/gto/components/index.scss` (we don't have scss globs setup)
 * If it's shareable, add it to the `react_styleguide.slim` page under `/admin/tests/`
 
+We have a simple `scaffold` task that can help to get things rolling faster and to help keep us consistent.
+
+```
+rails g react_component ComponentName
+```
+
+Will create the `ComponentName.tsx` file and it's corresponding test file in the `reactjs/components` directory.
+
+If you plan to use this component in a slim file and want it to be automounted, don't froget to add it to 
+the `reactjs/components/index.ts` so it'll be in the registry used by the `react_component` rails helper.
+
 ### Webpack
 
 We've moved off sprockets and are using webpack exclusively.

--- a/app/webpack/reactjs/components/index.ts
+++ b/app/webpack/reactjs/components/index.ts
@@ -18,7 +18,6 @@ export const reactComponents = {
   CreditsModal,
   Mailer,
   Welcome,
-
 };
 
 export const lookup = (componentName: string): FC<any> => {

--- a/lib/generators/react_component/USAGE
+++ b/lib/generators/react_component/USAGE
@@ -1,0 +1,14 @@
+Description:
+    Creates a React component file and test file in the app/webpack/reactjs/components directory.
+
+Example:
+    bin/rails generate react_component Thing
+
+    This will create:
+         app/webpack/reactjs/components/thing.tsx
+         app/webpack/reactjs/components/thing.test.tsx
+
+    You must add it manually to the `react/components/index.ts` if you need it
+    to be automounted from a `.slim` file.  If it is only used within other
+    React components, it doesn't need to be registered there because it can
+    be included with webpack `imports`.

--- a/lib/generators/react_component/react_component_generator.rb
+++ b/lib/generators/react_component/react_component_generator.rb
@@ -1,0 +1,10 @@
+DESTINATION_DIR = Rails.root.join('app/webpack/reactjs/components')
+
+class ReactComponentGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  def create_react_component
+    template 'component.tsx.erb', DESTINATION_DIR.join("#{file_name}.tsx")
+    template 'component.test.tsx.erb', DESTINATION_DIR.join("#{file_name}.test.tsx")
+  end
+end

--- a/lib/generators/react_component/templates/component.test.tsx.erb
+++ b/lib/generators/react_component/templates/component.test.tsx.erb
@@ -1,0 +1,7 @@
+import { <%= class_name %> } from "./<%= file_name %>";
+
+describe("<%= class_name %>", () => {
+  it("works", () => {
+    expect(true).toEqual(false);
+  })
+});

--- a/lib/generators/react_component/templates/component.tsx.erb
+++ b/lib/generators/react_component/templates/component.tsx.erb
@@ -1,0 +1,7 @@
+import React, {FC} from 'react'
+
+type <%= class_name %>Props = {};
+
+export const <%= class_name %>:FC<<%= class_name %>Props> = (props) => {
+  return <div></div>;
+}


### PR DESCRIPTION
Problem
--------

React component templates should be consistent for the team.  Until the
team knows the structure, this can help make things more consistent.

Solution
---------

Build a custom rails generator that will generate a simple react
component in the right place along with a test file.

Example:
```
rails g react_component Whatever
```

Generates
```
==> app/webpack/reactjs/components/whatever.test.tsx <==
import { Whatever } from "./whatever";

describe("Whatever", () => {
  it("works", () => {
    expect(true).toEqual(false);
  })
});
```

```
==> app/webpack/reactjs/components/whatever.tsx <==
import React, {FC} from 'react'

type WhateverProps = {};

export const Whatever:FC<WhateverProps> = (props) => {
  return <div></div>;
}
```