### PR TITLE
Fix react-component templates

### DIFF
--- a/lib/generators/react_component/templates/component.test.tsx.erb
+++ b/lib/generators/react_component/templates/component.test.tsx.erb
@@ -1,4 +1,5 @@
 import { <%= class_name %> } from "./<%= file_name %>";
+import React from 'react'
 
 describe("<%= class_name %>", () => {
   it("works", () => {

--- a/lib/generators/react_component/templates/component.tsx.erb
+++ b/lib/generators/react_component/templates/component.tsx.erb
@@ -1,6 +1,6 @@
 import React, {FC} from 'react'
 
-type <%= class_name %>Props = {};
+interface <%= class_name %>Props {};
 
 export const <%= class_name %>:FC<<%= class_name %>Props> = (props) => {
   return <div></div>;


### PR DESCRIPTION
Explanation
-----------
With the first round of templates, there were a couple misses.

1. after some reading, we should prefer interface over type for react
   props
1. The test file was not including `React` which we need for `.tsx` to
   work and for that file to allow `tsx` syntax

Further Reading
---------------

https://blog.logrocket.com/types-vs-interfaces-in-typescript/

This post suggests:

> Interfaces are basically a way to describe data shapes, for example, an object.
>
> Type is a definition of a type of data, for example, a union, primitive, intersection, tuple, or any other type.

Since we are trying to define the shape of the data expected for a
component, an interface seems more appropriate.