### PR TITLE
Add data to OpenStudiosParticipant

### DIFF
--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -6,8 +6,8 @@ module Api
 
     def register_for_open_studios
       if current_artist.can_register_for_open_studios?
-        participation = UpdateArtistService.new(current_artist, os_participation: params[:participation]).update_os_status
-        render json: { success: true, participating: participation }
+        participant = UpdateArtistService.new(current_artist, os_participation: params[:participation]).update_os_status
+        render json: { success: true, participating: params[:participation] == '1', participant: participant }
       else
         render json: { success: false, participating: false }, status: :bad_request
       end

--- a/app/controllers/api/open_studios_participants_controller.rb
+++ b/app/controllers/api/open_studios_participants_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  class OpenStudiosParticipantsController < ApiController
+    include UserControllerHelpers
+
+    before_action :artist_required
+
+    def update
+      @participant = OpenStudiosParticipant.find(params[:id])
+      head :unauthorized if @participant.user != current_artist
+
+      render json: {}, status: :unauthorized if (current_artist.id != @participant.user_id) && return
+
+      if @participant&.update(open_studios_participant_params)
+        render json: @participant
+      else
+        render json: { errors: @participant.errors }, status: :bad_request
+      end
+    end
+
+    private
+
+    def open_studios_participant_params
+      params.require(:open_studios_participant).permit(
+        :shop_url,
+        :video_conference_url,
+        :show_email,
+        :show_phone_number,
+      )
+    end
+  end
+end

--- a/app/models/open_studios_participant.rb
+++ b/app/models/open_studios_participant.rb
@@ -3,4 +3,7 @@ class OpenStudiosParticipant < ApplicationRecord
   belongs_to :open_studios_event
 
   validates :user, uniqueness: { scope: :open_studios_event }
+
+  validates :shop_url, url: true
+  validates :video_conference_url, url: true
 end

--- a/app/services/update_artist_service.rb
+++ b/app/services/update_artist_service.rb
@@ -28,6 +28,7 @@ class UpdateArtistService
   end
 
   def update_os_status
+    participation_record = nil
     participating = to_boolean(@params[:os_participation])
     unless @artist.can_register_for_open_studios?
       Rails.logger.info("#{@artist.login} isn't eligible to register to #{@current_os}")
@@ -35,7 +36,7 @@ class UpdateArtistService
     end
     if participating != @artist.doing_open_studios?
       if participating
-        OpenStudiosParticipationService.participate(@artist, @current_os)
+        participation_record = OpenStudiosParticipationService.participate(@artist, @current_os)
       else
         OpenStudiosParticipationService.refrain(@artist, @current_os)
       end
@@ -43,7 +44,7 @@ class UpdateArtistService
       refresh_in_search_index
       ArtistMailer.welcome_to_open_studios(@artist, @current_os).deliver_later if participating
     end
-    participating
+    participation_record
   end
 
   private

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,13 @@
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    # test for presence separately
+    return true if value.blank?
+
+    valid = begin
+      URI.parse(value).is_a?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+    end
+    record.errors.add(attribute, options[:message] || 'is not a valid URL') unless valid
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,10 +169,15 @@ Mau::Application.routes.draw do
   namespace :api do
     resources :notes, only: [:create]
     resources :artists, only: [] do
+      resources :open_studios_participants, only: [:update]
       member do
         post :register_for_open_studios
       end
     end
+
+    # these routes were originally designed for 1890 bryant's consumption.
+    # which is why they are in `v2`  This could likely be removed now
+    # because there are no more external consumers.
     namespace :v2 do
       resources :studios, only: [:show]
       resources :artists, only: %i[index show] do

--- a/db/migrate/20210221173938_add_fields_to_open_studios_participant.rb
+++ b/db/migrate/20210221173938_add_fields_to_open_studios_participant.rb
@@ -1,0 +1,8 @@
+class AddFieldsToOpenStudiosParticipant < ActiveRecord::Migration[6.1]
+  def change
+    add_column :open_studios_participants, :shop_url, :string
+    add_column :open_studios_participants, :video_conference_url, :string
+    add_column :open_studios_participants, :show_email, :boolean
+    add_column :open_studios_participants, :show_phone_number, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_063625) do
+ActiveRecord::Schema.define(version: 2021_02_21_173938) do
 
   create_table "application_events", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -174,6 +174,10 @@ ActiveRecord::Schema.define(version: 2021_02_11_063625) do
   create_table "open_studios_participants", charset: "utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "open_studios_event_id"
+    t.string "shop_url"
+    t.string "video_conference_url"
+    t.boolean "show_email"
+    t.boolean "show_phone_number"
     t.index ["open_studios_event_id"], name: "index_open_studios_participants_on_open_studios_event_id"
     t.index ["user_id", "open_studios_event_id"], name: "idx_os_participants_on_user_and_open_studios_event", unique: true
     t.index ["user_id"], name: "index_open_studios_participants_on_user_id"

--- a/spec/controllers/api/artists_controller_spec.rb
+++ b/spec/controllers/api/artists_controller_spec.rb
@@ -37,7 +37,10 @@ describe Api::ArtistsController, elasticsearch: false do
           get :register_for_open_studios, params: { id: artist.id, participation: '1' }
           expect(artist.reload).to_not be_doing_open_studios
           expect(response).to be_bad_request
-          expect(JSON.parse(response.body)).to eq('success' => false, 'participating' => false)
+          expect(JSON.parse(response.body)).to eq({
+                                                    'success' => false,
+                                                    'participating' => false,
+                                                  })
         end
       end
 
@@ -48,14 +51,23 @@ describe Api::ArtistsController, elasticsearch: false do
           get :register_for_open_studios, params: { id: artist.id, participation: '1' }
           expect(artist.reload).to be_doing_open_studios
           expect(response).to be_successful
-          expect(JSON.parse(response.body)).to eq('success' => true, 'participating' => true)
+          expect(JSON.parse(response.body)).to eq(
+            'success' => true,
+            'participating' => true,
+            'participant' => OpenStudiosParticipant.find_by(user: artist,
+                                                            open_studios_event: OpenStudiosEvent.current).as_json,
+          )
         end
 
         it "updates your os status to false and redirects to your edit page if you're logged in" do
           get :register_for_open_studios, params: { id: artist.id, participation: '0' }
           expect(artist.reload).not_to be_doing_open_studios
           expect(response).to be_successful
-          expect(JSON.parse(response.body)).to eq('success' => true, 'participating' => false)
+          expect(JSON.parse(response.body)).to eq(
+            'success' => true,
+            'participant' => nil,
+            'participating' => false,
+          )
         end
       end
     end

--- a/spec/controllers/api/open_studios_participants_controller_spec.rb
+++ b/spec/controllers/api/open_studios_participants_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Api::OpenStudiosParticipantsController do
+  describe 'update' do
+    let!(:os_event) { create(:open_studios_event) }
+    let(:artist) { create(:artist, doing_open_studios: true) }
+    let(:participant) do
+      artist.open_studios_participants.first
+    end
+    let(:new_attrs) do
+      FactoryBot.attributes_for(:open_studios_participant, user: artist, open_studios_event: os_event).except(:user_id, :id)
+    end
+    before do
+      request.env['HTTP_REFERER'] = 'http://test.host/'
+    end
+
+    context 'when not logged in' do
+      before do
+        os_event
+      end
+
+      it 'refuses service' do
+        put :update, params: { artist_id: artist, id: participant.id, open_studios_participant: new_attrs }
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'when logged as the wrong artist' do
+      let(:other_artist) { create(:artist) }
+
+      before do
+        login_as(other_artist)
+      end
+      it 'refuses service' do
+        put :update, params: { artist_id: artist, id: participant.id, open_studios_participant: new_attrs }
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'when logged in as the artist' do
+      before do
+        login_as artist
+      end
+
+      it 'updates the entry with good data' do
+        participant = artist.open_studios_participants.first
+        put :update, params: { artist_id: artist.id, id: participant.id, open_studios_participant: new_attrs }
+        participant.reload
+
+        expect(response).to be_ok
+        expect(participant.shop_url).to eq(new_attrs[:shop_url])
+      end
+      it 'returns json errors if data is bad' do
+        bad_attrs = new_attrs.merge(shop_url: 'httwhatever')
+        participant = artist.open_studios_participants.first
+        put :update, params: { artist_id: artist.id, id: participant.id, open_studios_participant: bad_attrs }
+
+        expect(response).to be_bad_request
+        expect(JSON.parse(response.body)).to eq({ 'errors' => { 'shop_url' => ['is not a valid URL'] } })
+      end
+    end
+  end
+end

--- a/spec/factories/open_studios_participants.rb
+++ b/spec/factories/open_studios_participants.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :open_studios_participant do
+    user
+    open_studios_event
+
+    shop_url { Faker::Internet.url }
+    video_conference_url { Faker::Internet.url }
+    show_email { [true, false].sample }
+    show_phone_number { [true, false].sample }
+  end
+end

--- a/spec/services/update_artist_service_spec.rb
+++ b/spec/services/update_artist_service_spec.rb
@@ -154,9 +154,13 @@ describe UpdateArtistService do
           update_os
           expect(ArtistMailer).to have_received(:welcome_to_open_studios).with(artist, current_os)
         end
-
         it 'saves an open studios sign up event' do
           expect { update_os }.to change(OpenStudiosSignupEvent, :count).by(1)
+        end
+        it 'returns the new OpenStudiosParticipant record' do
+          participant = update_os
+          # this find forces the artist_info reload
+          expect(participant).to eq OpenStudiosParticipant.where(user: artist, open_studios_event: current_os).take
         end
       end
 
@@ -175,6 +179,10 @@ describe UpdateArtistService do
 
         it 'does not save the open studios sign up event' do
           expect { update_os }.to change(OpenStudiosSignupEvent, :count).by(0)
+        end
+
+        it 'returns nil' do
+          expect(update_os).to be_nil
         end
       end
     end

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe UrlValidator do
+  subject do
+    Class.new do
+      def self.name
+        'UrlValidatorTestModel'
+      end
+      include ActiveModel::Validations
+      attr_accessor :url
+
+      validates :url, url: true
+    end.new
+  end
+
+  valid_urls = [
+    'http://google.com',
+    'https://abc.def.com/here-we-go',
+    'https://abc.def.com/here-we-go?this#that',
+    'https://username:password@abc.def.com/here-we-go?this#that',
+  ]
+  valid_urls.each do |test|
+    it "should allow valid url like #{test}" do
+      subject.url = test
+      subject.validate
+      expect(subject.errors).to have(0).errors, "#{test} is invalid #{subject.errors.full_messages}"
+    end
+  end
+
+  it 'should allow empty' do
+    valid_urls = [
+      '',
+      nil,
+      '       ',
+    ]
+    valid_urls.each do |test|
+      subject.url = test
+      subject.validate
+      expect(subject.errors).to have(0).errors, "#{test} is invalid #{subject.errors.full_messages}"
+    end
+  end
+
+  invalid_urls = [
+    '1  AAA   5551212',
+    'httpccc',
+    'httpx://ccc.com',
+    'https://username@password:abc.def.com/here-we-go?this#that',
+  ]
+  invalid_urls.each do |test|
+    it "should not allow invalid urls like #{test}" do
+      subject.url = test
+      subject.validate
+      expect(subject.errors[:url]).to include('is not a valid URL')
+    end
+  end
+end


### PR DESCRIPTION
Problem
-------

we need to store some stuff on the open studios connection between
artist and os event.

This partially solves 
https://www.pivotaltracker.com/story/show/176835284
and should unblock
https://www.pivotaltracker.com/story/show/176881854
which can be worked on independently once the data is available in the db.

Solution
--------

Add some attributes on the through table `OpenStudiosParticipant`.
Add a controller method to allow updating of those
attributes.
Add some tests
Add a route to put new data there (in preparation for the frontend)