### PR TITLE
Redo - file size validation

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -11,7 +11,7 @@ class ArtPiece < ApplicationRecord
   validates_attachment_content_type :photo,
                                     content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'],
                                     message: 'Only JPEG, PNG, and GIF images are allowed'
-  validates_attachment_size :photo, less_than: 5.megabytes
+  validates_attachment_size :photo, less_than: 8.megabytes
   validates :artist_id, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0.01 }, allow_nil: true
 

--- a/app/webpack/js/app/art_piece_form.js
+++ b/app/webpack/js/app/art_piece_form.js
@@ -2,7 +2,7 @@ import Flash from "@js/app/jquery/flash";
 import Spinner from "@js/app/spinner";
 import jQuery from "jquery";
 
-const MAX_FILE_SIZE_MB = 4;
+const MAX_FILE_SIZE_MB = 6;
 
 const validateFileSize = (event) => {
   const fileInput = event.currentTarget;
@@ -16,7 +16,9 @@ const validateFileSize = (event) => {
     const sizeMb = Math.round(size / (1024 * 1024));
     if (sizeMb > MAX_FILE_SIZE_MB) {
       const flash = new Flash();
-      flash.show({ error: "Files should be no larger than 4MB." });
+      flash.show({
+        error: "That file is a little too big. 4MB or smaller is ideal.",
+      });
     }
   }
 };

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -9,7 +9,7 @@ describe ArtPiece do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_least(2).is_at_most(80) }
     it { is_expected.to validate_numericality_of(:price).allow_nil.is_greater_than_or_equal_to(0.01) }
-    it { is_expected.to validate_attachment_size(:photo).less_than(5.megabytes) }
+    it { is_expected.to validate_attachment_size(:photo).less_than(8.megabytes) }
   end
   describe 'new' do
     it 'allows quotes' do


### PR DESCRIPTION
Problem
-------

We're trying to give users clear messaging when they upload a big file
and it times out.

https://www.pivotaltracker.com/story/show/176916834

Solution
--------

Add frontend validation that says "this file is likely too large, try 4M
or smaller".  Then add real backend validation at a larger size (8M) cuz
that might actually go through.  Finally, we leverage #119 so if things
do error out at least we have a sane message