### PR TITLE
Add Youtube Video to OpenStudiosParticipant.

### DIFF
--- a/app/controllers/api/open_studios_participants_controller.rb
+++ b/app/controllers/api/open_studios_participants_controller.rb
@@ -26,6 +26,7 @@ module Api
         :video_conference_url,
         :show_email,
         :show_phone_number,
+        :youtube_url,
       )
     end
   end

--- a/app/models/open_studios_participant.rb
+++ b/app/models/open_studios_participant.rb
@@ -6,4 +6,5 @@ class OpenStudiosParticipant < ApplicationRecord
 
   validates :shop_url, url: true
   validates :video_conference_url, url: true
+  validates :youtube_url, youtube_url: true
 end

--- a/app/validators/youtube_url_validator.rb
+++ b/app/validators/youtube_url_validator.rb
@@ -1,0 +1,27 @@
+class YoutubeUrlValidator < ActiveModel::EachValidator
+  YOUTUBE_URL_REGEX = %r{^((?:https?:)?//)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(/(?:[\w\-]+\?v=|embed/|v/)?)([\w\-]+)(\S+)?$}
+
+  def validate_each(record, attribute, value)
+    # test for presence separately
+    return true if value.blank?
+
+    unless is_a_valid_url(value)
+      record.errors.add(attribute,
+                        options[:message] || 'is not a valid URL. Did you remember including http:// or https:// at the beginning?')
+      return
+    end
+
+    unless YOUTUBE_URL_REGEX.match?(value)
+      record.errors.add(attribute,
+                        options[:message] || 'does not look like a Youtube link.')
+    end
+  end
+
+  private
+
+  def is_a_valid_url(value)
+    URI.parse(value).is_a?(URI::HTTP)
+  rescue URI::InvalidURIError => e
+    false
+  end
+end

--- a/app/validators/youtube_url_validator.rb
+++ b/app/validators/youtube_url_validator.rb
@@ -1,27 +1,27 @@
 class YoutubeUrlValidator < ActiveModel::EachValidator
-  YOUTUBE_URL_REGEX = %r{^((?:https?:)?//)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(/(?:[\w\-]+\?v=|embed/|v/)?)([\w\-]+)(\S+)?$}
+  YOUTUBE_URL_REGEX = %r{^((?:https?:)?//)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(/(?:[\w\-]+\?v=|embed/|v/)?)([\w\-]+)(\S+)?$}.freeze
 
   def validate_each(record, attribute, value)
     # test for presence separately
     return true if value.blank?
 
-    unless is_a_valid_url(value)
+    unless valid_url?(value)
       record.errors.add(attribute,
                         options[:message] || 'is not a valid URL. Did you remember including http:// or https:// at the beginning?')
       return
     end
 
-    unless YOUTUBE_URL_REGEX.match?(value)
-      record.errors.add(attribute,
-                        options[:message] || 'does not look like a Youtube link.')
-    end
+    return if YOUTUBE_URL_REGEX.match?(value)
+
+    record.errors.add(attribute,
+                      options[:message] || 'does not look like a Youtube link.')
   end
 
   private
 
-  def is_a_valid_url(value)
+  def valid_url?(value)
     URI.parse(value).is_a?(URI::HTTP)
-  rescue URI::InvalidURIError => e
+  rescue URI::InvalidURIError
     false
   end
 end

--- a/app/webpack/reactjs/components/__snapshots__/mau_text_field.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/mau_text_field.test.tsx.snap
@@ -17,13 +17,13 @@ exports[`MauTextField matches the snapshot 1`] = `
       type="text"
       value=""
     />
-    <div
+    <p
       class="inline-hints"
     >
       <span>
         here is a clue
       </span>
-    </div>
+    </p>
   </div>
 </div>
 `;
@@ -45,13 +45,13 @@ exports[`MauTextField matches the snapshot if id is provided 1`] = `
       type="text"
       value=""
     />
-    <div
+    <p
       class="inline-hints"
     >
       <span>
         here is a clue
       </span>
-    </div>
+    </p>
   </div>
 </div>
 `;

--- a/app/webpack/reactjs/components/mau_hint.test.tsx
+++ b/app/webpack/reactjs/components/mau_hint.test.tsx
@@ -11,14 +11,14 @@ describe("MauHint", () => {
     );
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <div
+        <p
           class="inline-hints"
         >
           <span>
             stuff
           </span>
            here
-        </div>
+        </p>
       </div>
     `);
   });

--- a/app/webpack/reactjs/components/mau_hint.tsx
+++ b/app/webpack/reactjs/components/mau_hint.tsx
@@ -4,7 +4,7 @@ interface MauHintProps {}
 
 export const MauHint: FC<MauHintProps> = ({ children }) => {
   if (children) {
-    return <div className="inline-hints">{children}</div>;
+    return <p className="inline-hints">{children}</p>;
   }
   return null;
 };

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -55,6 +55,7 @@ describe("OpenStudiosInfoForm", () => {
     it("shows a form", () => {
       expect(findField("Shopping Cart Link")).toBeInTheDocument();
       expect(findField("Meeting Link (Zoom or other)")).toBeInTheDocument();
+      expect(findField("Youtube Video Link")).toBeInTheDocument();
       expect(findField("Show my e-mail")).toBeInTheDocument();
       expect(findField("Show my phone number")).toBeInTheDocument();
       expect(findButton("Update my details")).toBeInTheDocument();
@@ -75,6 +76,9 @@ describe("OpenStudiosInfoForm", () => {
       act(() => {
         const shopUrl = findField("Shopping Cart Link");
         fillIn(shopUrl, "http://www.whatever.com");
+
+        const youtubeUrl = findField("Youtube Video Link");
+        fillIn(youtubeUrl, "http://www.youtube.com/watch?v=the-video");
       });
       await waitFor(() => {
         button = findButton("Update my details");
@@ -90,6 +94,7 @@ describe("OpenStudiosInfoForm", () => {
           openStudiosParticipant: {
             ...participant,
             shopUrl: "http://www.whatever.com",
+            youtubeUrl: "http://www.youtube.com/watch?v=the-video",
           },
         });
         expect(mockOnUpdateParticipant).toHaveBeenCalledWith(participant);

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -18,9 +18,10 @@ interface OpenStudiosInfoFormProps {
   onUpdateParticipant: (participant: OpenStudiosParticipant) => void;
 }
 
+// Seems to help with proving the controlled v uncontrolled inputs and Formik
 function denullify(participant) {
   const result = { ...participant };
-  ["shopUrl", "videoConferenceUrl"].forEach(
+  ["shopUrl", "videoConferenceUrl", "youtubeUrl"].forEach(
     (field) => (result[field] = participant[field] ?? "")
   );
   ["showPhoneNumber", "showEmail"].forEach(
@@ -111,12 +112,20 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
                       hint="This link should point to your shopping cart or online store"
                     />
                   </div>
-                  <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--video-url">
+                  <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--video-conference-url">
                     <MauTextField
                       label="Meeting Link (Zoom or other)"
                       name="videoConferenceUrl"
                       placeholder="e.g. https://my.zoom.room.com/me"
                       hint="This link will connect folks to your video conference that you'd be on during Open Studios"
+                    />
+                  </div>
+                  <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--youtube-url">
+                    <MauTextField
+                      label="Youtube Video Link"
+                      name="youtubeUrl"
+                      placeholder="e.g. https://www.youtube.com/watch?v=abc123"
+                      hint="This could be a studio tour, or art demo or..."
                     />
                   </div>
                   <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--checkbox open-studios-info-form__input--show-email">

--- a/app/webpack/reactjs/types/modelTypes.ts
+++ b/app/webpack/reactjs/types/modelTypes.ts
@@ -9,6 +9,7 @@ export interface OpenStudiosParticipant {
   showPhoneNumber: Nullable<boolean>;
   shopUrl: Nullable<string>;
   videoConferenceUrl: Nullable<string>;
+  youtubeUrl: Nullable<string>;
 }
 
 // Note: this does *not* match the Ruby model OpenStudiosEvent but

--- a/app/webpack/test/factories/open_studios_participant.factory.ts
+++ b/app/webpack/test/factories/open_studios_participant.factory.ts
@@ -12,4 +12,5 @@ export const openStudiosParticipantFactory = Factory.define<types.OpenStudiosPar
   .attr("showEmail", randomBoolean)
   .attr("showPhoneNumber", randomBoolean)
   .attr("shopUrl", faker.internet.url)
-  .attr("videoConferenceUrl", faker.internet.url);
+  .attr("videoConferenceUrl", faker.internet.url)
+  .attr("youtubeUrl", `http://www.youtube.com/watch?${faker.lorem.word()}`);

--- a/db/migrate/20210228191150_add_youtube_video_to_open_studios_participant.rb
+++ b/db/migrate/20210228191150_add_youtube_video_to_open_studios_participant.rb
@@ -1,0 +1,5 @@
+class AddYoutubeVideoToOpenStudiosParticipant < ActiveRecord::Migration[6.1]
+  def change
+    add_column :open_studios_participants, :youtube_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_21_173938) do
+ActiveRecord::Schema.define(version: 2021_02_28_191150) do
 
   create_table "application_events", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 2021_02_21_173938) do
     t.string "video_conference_url"
     t.boolean "show_email"
     t.boolean "show_phone_number"
+    t.string "youtube_url"
     t.index ["open_studios_event_id"], name: "index_open_studios_participants_on_open_studios_event_id"
     t.index ["user_id", "open_studios_event_id"], name: "idx_os_participants_on_user_and_open_studios_event", unique: true
     t.index ["user_id"], name: "index_open_studios_participants_on_user_id"

--- a/spec/controllers/api/open_studios_participants_controller_spec.rb
+++ b/spec/controllers/api/open_studios_participants_controller_spec.rb
@@ -50,7 +50,12 @@ describe Api::OpenStudiosParticipantsController do
 
         expect(response).to be_ok
         expect(participant.shop_url).to eq(new_attrs[:shop_url])
+        expect(participant.youtube_url).to eq(new_attrs[:youtube_url])
+        expect(participant.video_conference_url).to eq(new_attrs[:video_conference_url])
+        expect(participant.show_email).to eq(new_attrs[:show_email])
+        expect(participant.show_phone_number).to eq(new_attrs[:show_phone_number])
       end
+
       it 'returns json errors if data is bad' do
         bad_attrs = new_attrs.merge(shop_url: 'httwhatever')
         participant = artist.open_studios_participants.first

--- a/spec/factories/open_studios_participants.rb
+++ b/spec/factories/open_studios_participants.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     shop_url { Faker::Internet.url }
     video_conference_url { Faker::Internet.url }
+    youtube_url { 'http://m.youtube.com/watch?v=abcdefg' }
     show_email { [true, false].sample }
     show_phone_number { [true, false].sample }
   end

--- a/spec/models/open_studios_participant_spec.rb
+++ b/spec/models/open_studios_participant_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe OpenStudiosParticipant do
+  it 'validates youtube url looks like youtube if present' do
+    subject.youtube_url = 'whatever'
+    subject.valid?
+    expect(subject.errors[:youtube_url]).not_to be_empty
+
+    subject.youtube_url = 'https://www.youtube.com/watch?v=23ihawJKZcE'
+    subject.valid?
+    expect(subject.errors[:youtube_url]).to be_empty
+  end
+end

--- a/spec/validators/youtube_url_validator_spec.rb
+++ b/spec/validators/youtube_url_validator_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe YoutubeUrlValidator do
+  subject do
+    Class.new do
+      def self.name
+        'UrlValidatorTestModel'
+      end
+      include ActiveModel::Validations
+      attr_accessor :video_url
+
+      validates :video_url, youtube_url: true
+    end.new
+  end
+
+  describe 'for a valid youtube url' do
+    valid_youtube_urls = [
+      'https://www.youtube.com/watch?v=23ihawJKZcE&feature=featured',
+      'https://www.youtube.com/watch?v=23ihawJKZcE',
+      'http://www.youtube.com/watch?v=23ihawJKZcE',
+      'https://youtube.com/watch?v=23ihawJKZcE',
+      'http://youtube.com/watch?v=23ihawJKZcE',
+      'https://m.youtube.com/watch?v=23ihawJKZcE',
+      'http://m.youtube.com/watch?v=23ihawJKZcE',
+      'https://www.youtube.com/watch?v=T1j1_aeK6WA',
+    ]
+
+    valid_youtube_urls.each do |test|
+      it "should be valid for url like #{test}" do
+        subject.video_url = test
+        subject.validate
+        expect(subject.errors).to have(0).errors, "#{test} is not a valid youtube url #{subject.errors.full_messages}"
+      end
+    end
+  end
+
+  describe 'for valid urls that are *not* youtube urls' do
+    invalid_youtube_urls = [
+      'http://google.com',
+      'https://abc.def.com/here-we-go',
+      'https://abc.def.com/here-we-go?this#that',
+      'https://username:password@abc.def.com/here-we-go?this#that',
+    ]
+    invalid_youtube_urls.each do |test|
+      it "should not allow valid urls that are not youtube urls like #{test}" do
+        subject.video_url = test
+        subject.validate
+        expect(subject.errors[:video_url]).to include('does not look like a Youtube link.')
+      end
+    end
+  end
+
+  describe 'for empty values' do
+    it 'should allow empty' do
+      valid_urls = [
+        '',
+        nil,
+        '       ',
+      ]
+      valid_urls.each do |test|
+        subject.video_url = test
+        subject.validate
+        expect(subject.errors).to have(0).errors, "#{test} is invalid #{subject.errors.full_messages}"
+      end
+    end
+  end
+
+  describe 'for invalid urls' do
+    invalid_urls = [
+      '1  AAA   5551212',
+      'httpccc',
+      'httpx://ccc.com',
+      'https://username@password:abc.def.com/here-we-go?this#that',
+    ]
+    invalid_urls.each do |test|
+      it "should not allow invalid urls like #{test}" do
+        subject.video_url = test
+        subject.validate
+        expect(subject.errors[:video_url]).to include('is not a valid URL. Did you remember including http:// or https:// at the beginning?')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem
---------

as an artist doing open studios
I can add a video link to my open studios info
so that people can get a studio tour or whatever
even if i'm not present to share that.

Solution
--------

Add `youtube_url` to the OpenStudiosParticipant model and allow users to
update that information in their `OpenStudiosInfoForm`.

Changes
-------

* Add new field on OpenStudiosParticipant model
* Add `YoutubeUrlValidator` to validate that it looks like a youtube link
* Add the field to the OpenStudiosInfoForm
* Move MauHint to use `p` over `div` for proper spacing