### PR TITLE
Add special event time and date to the open studios event model 

### DIFF
--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -46,7 +46,11 @@ module Admin
     private
 
     def open_studios_event_params
-      params.require(:open_studios_event).permit(:title, :start_date, :end_date, :start_time, :end_time, :key, :promote)
+      params.require(:open_studios_event).permit(:title, :start_date, :end_date, :start_time, :end_time, :key, :promote,
+                                                 :special_event_start_date,
+                                                 :special_event_start_time,
+                                                 :special_event_end_date,
+                                                 :special_event_end_date)
     end
   end
 end

--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -7,7 +7,10 @@ class OpenStudiosEvent < ApplicationRecord
   validates :key, presence: true, uniqueness: { case_sensitive: true }
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validate :end_date_is_after_start_date
+  validate :dates_are_in_order
+  validate :special_event_dates_are_in_order
+  validate :special_event_dates_are_both_present_or_both_empty
+  validate :special_event_dates_are_within_event_dates
 
   has_many :open_studios_participants, inverse_of: :open_studios_event, dependent: :destroy
   has_many :artists, through: :open_studios_participants, class_name: 'Artist', source: :user
@@ -39,9 +42,38 @@ class OpenStudiosEvent < ApplicationRecord
     future.first || past.last
   end
 
-  def end_date_is_after_start_date
-    return unless end_date && start_date
+  private
 
-    errors.add(:end_date, 'should be after start date.') unless end_date >= start_date
+  def dates_are_in_order
+    date_fields_are_in_order(:start_date, :end_date)
+  end
+
+  def special_event_dates_are_in_order
+    date_fields_are_in_order(:special_event_start_date, :special_event_end_date)
+  end
+
+  def date_fields_are_in_order(start_field, end_field)
+    start_val = send(start_field)
+    end_val = send(end_field)
+    return unless end_val && start_val
+
+    errors.add(end_field, 'should be after start date') unless end_val >= start_val
+  end
+
+  def special_event_dates_are_both_present_or_both_empty
+    return if special_event_end_date && special_event_start_date
+
+    return unless special_event_end_date || special_event_start_date
+
+    errors.add(:special_event_start_date, 'must be present if special event end date is present') if special_event_end_date
+    errors.add(:special_event_end_date, 'must be present if special event start date is present') if special_event_start_date
+  end
+
+  def special_event_dates_are_within_event_dates
+    return unless special_event_end_date && special_event_start_date
+
+    event_range = (start_date..end_date)
+    errors.add(:special_event_start_date, 'must be during the main event dates') unless event_range.cover?(special_event_start_date)
+    errors.add(:special_event_end_date, 'must be during the main event dates') unless event_range.cover?(special_event_end_date)
   end
 end

--- a/app/views/admin/open_studios_events/_form.html.slim
+++ b/app/views/admin/open_studios_events/_form.html.slim
@@ -17,6 +17,20 @@
             = f.input :end_time, as: :string, placeholder: 'choose a time', hint: "Something like 6p.  This is used for display only (not for date/time math)"
         = f.input :key, placeholder: 'e.g. YYYYMM'
         = f.input :promote, as: :boolean, inline_label: true, label: false, hint: "If true, we'll remind artists in navigation to register when we're near (in time) this event."
+
+        .pure-g
+          .pure-u-1-1
+            h4 Optional Special Event Times
+        .pure-g
+          .pure-u-1-2
+            = f.input :special_event_start_date, as: :date_picker, placeholder: 'yyyy-mm-dd', input_html: { value: os_event.special_event_start_date.try(:to_s,:admin_date_only) }
+          .pure-u-1-2
+            = f.input :special_event_end_date, as: :date_picker, placeholder: 'yyyy-mm-dd', input_html: { value: os_event.special_event_end_date.try(:to_s,:admin_date_only) }
+        .pure-g
+          .pure-u-1-2
+            = f.input :special_event_start_time, as: :string, placeholder: 'hh:mm {am|pm}', hint: "We will use (and validate) these as time strings in the 12hr time format e.g. '1:00pm',  '9:45 am'"
+          .pure-u-1-2
+            = f.input :special_event_end_time, as: :string, placeholder: 'hh:mm {am|pm}', hint: "We will use (and validate) these as time strings in the 12hr time format e.g. '1:00pm',  '9:45 am'"
       = f.actions do
         .form-controls
           = f.submit class: 'pure-button pure-button-primary'

--- a/app/views/admin/open_studios_events/index.html.slim
+++ b/app/views/admin/open_studios_events/index.html.slim
@@ -15,9 +15,8 @@
         tr
           th key
           th title
-          th start date
-          th end date
-          th time
+          th dates
+          th special event dates
           th promoted
           th participants
           th data-orderable="false"
@@ -26,9 +25,19 @@
           tr.os-events__table-row
             td.os-events__table-item.os-events__table-item--key = os_event.key
             td.os-events__table-item.os-events__table-item--title = os_event.title
-            td.os-events__table-item.os-events__table-item--start = os_event.start_date
-            td.os-events__table-item.os-events__table-item--end = os_event.end_date
-            td.os-events__table-item.os-events__table-item--time = os_event.time_range
+            td.os-events__table-item.os-events__table-item--dates
+              .os-events__table-item--dates--item
+                = os_event.date_range
+              .os-events__table-item--dates--item
+                = os_event.time_range
+            td.os-events__table-item.os-events__table-item--special-event-dates
+              - if os_event.with_special_event?
+                .os-events__table-item--dates--item
+                  = os_event.special_event_date_range
+                .os-events__table-item--dates--item
+                  = os_event.special_event_time_range
+              - else
+                | n/a
             td.os-events__table-item.os-events__table-item--promoted = boolean_as_checkmark(os_event.promote?)
             td.os-events__table-item.os-events__table-item--participants = os_event.num_participants
             td.admin-controls

--- a/app/views/artists/edit/_open_studios_status.html.slim
+++ b/app/views/artists/edit/_open_studios_status.html.slim
@@ -24,6 +24,13 @@
             date_range: current_open_studios.date_range_with_year, \
             start_time: current_open_studios.start_time, \
             end_time: current_open_studios.end_time, \
+            special_event: { \
+              date_range: current_open_studios.special_event_date_range_with_year,\
+              start_date: current_open_studios.special_event_start_date, \
+              end_date: current_open_studios.special_event_end_date, \
+              start_time: current_open_studios.special_event_start_time, \
+              end_time: current_open_studios.special_event_end_time, \
+            } \
           }\
         }
 

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -39,27 +39,70 @@ describe("OpenStudiosInfoForm", () => {
   const mockSubmitRegStatus = api.openStudios.submitRegistrationStatus;
 
   describe("without interaction", () => {
-    beforeEach(() => {
-      mockUpdate.mockResolvedValue({});
-      renderComponent();
-    });
+    describe("when there is no special event", () => {
+      beforeEach(() => {
+        mockUpdate.mockResolvedValue({});
+        renderComponent();
+      });
 
-    it("shows instructions", () => {
-      expect(
-        screen.queryByText("You pick how you want to participate", {
+      it("shows instructions", () => {
+        expect(
+          screen.queryByText("You pick how you want to participate", {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+      });
+
+      it("shows 2 dates for the event in fields *and* in the instructions", () => {
+        const dateRanges = screen.queryAllByText(defaultOsEvent.dateRange, {
           exact: false,
-        })
-      ).toBeInTheDocument();
+        });
+
+        expect(dateRanges).toHaveLength(3);
+      });
+
+      it("shows a form", () => {
+        expect(findField("Shopping Cart Link")).toBeInTheDocument();
+        expect(findField("Meeting Link (Zoom or other)")).toBeInTheDocument();
+        expect(findField("Youtube Video Link")).toBeInTheDocument();
+        expect(findField("Show my e-mail")).toBeInTheDocument();
+        expect(findField("Show my phone number")).toBeInTheDocument();
+        expect(findButton("Update my details")).toBeInTheDocument();
+        expect(findButton("Nope - not this time")).toBeInTheDocument();
+      });
     });
 
-    it("shows a form", () => {
-      expect(findField("Shopping Cart Link")).toBeInTheDocument();
-      expect(findField("Meeting Link (Zoom or other)")).toBeInTheDocument();
-      expect(findField("Youtube Video Link")).toBeInTheDocument();
-      expect(findField("Show my e-mail")).toBeInTheDocument();
-      expect(findField("Show my phone number")).toBeInTheDocument();
-      expect(findButton("Update my details")).toBeInTheDocument();
-      expect(findButton("Nope - not this time")).toBeInTheDocument();
+    describe("when there is a special event", () => {
+      beforeEach(() => {
+        const openStudiosEvent = openStudiosEventFactory.build({
+          specialEvent: {
+            dateRange: "some other dates that are important",
+          },
+        });
+        mockUpdate.mockResolvedValue({});
+        renderComponent({ openStudiosEvent });
+      });
+
+      it("shows instructions with the special event date range", () => {
+        expect(
+          screen.queryByText("You pick how you want to participate", {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText("some other dates that are important", {
+            exact: false,
+          })
+        ).toBeInTheDocument();
+      });
+
+      it("shows main dates for the events in 2 fields", () => {
+        const dateRanges = screen.queryAllByText(defaultOsEvent.dateRange, {
+          exact: false,
+        });
+
+        expect(dateRanges).toHaveLength(2);
+      });
     });
   });
 

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -52,9 +52,13 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
         flash.show({
           error:
             "We had problems updating your open studios status.  Please try again later",
+          s,
         });
       });
   };
+
+  const specialEventDateRange =
+    event.specialEvent?.dateRange || event.dateRange;
 
   const handleSubmit = (values, actions) => {
     new Flash().clear();
@@ -94,9 +98,9 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
               <p>
                 INSTRUCTIONS: You pick how you want to participate in Virtual
                 Open Studios. Do you have an online shop? Do you want to
-                participate in the Live Video Event May 8-9? Do you have a
-                YouTube video of your studio or your art? Do you want us to
-                display your contact info? For more details,{" "}
+                participate in the Live Video Event {specialEventDateRange}? Do
+                you have a YouTube video of your studio or your art? Do you want
+                us to display your contact info? For more details,{" "}
                 <a href="https://bit.ly/v-openstudios" target="_blank">
                   click here.
                 </a>

--- a/app/webpack/reactjs/types/modelTypes.ts
+++ b/app/webpack/reactjs/types/modelTypes.ts
@@ -19,4 +19,11 @@ export interface OpenStudiosEvent {
   dateRange: string;
   startTime: string;
   endTime: string;
+  specialEvent: {
+    dateRange: string;
+    startTime: string;
+    endTime: string;
+    startDate: string;
+    endDate: string;
+  };
 }

--- a/app/webpack/stylesheets/gto_admin/os_events.scss
+++ b/app/webpack/stylesheets/gto_admin/os_events.scss
@@ -1,3 +1,6 @@
 .os-events__table-item--time {
   white-space: nowrap;
 }
+.os-events__table-item--dates--item + .os-events__table-item--dates--item {
+  margin-top: 6px;
+}

--- a/db/migrate/20210302033543_add_special_event_time_to_open_studios_event.rb
+++ b/db/migrate/20210302033543_add_special_event_time_to_open_studios_event.rb
@@ -1,0 +1,8 @@
+class AddSpecialEventTimeToOpenStudiosEvent < ActiveRecord::Migration[6.1]
+  def change
+    add_column :open_studios_events, :special_event_start_date, :datetime
+    add_column :open_studios_events, :special_event_end_date, :datetime
+    add_column :open_studios_events, :special_event_start_time, :string, default: '12:00 PM'
+    add_column :open_studios_events, :special_event_end_time, :string, default: '4:00 PM'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_28_191150) do
+ActiveRecord::Schema.define(version: 2021_03_02_033543) do
 
   create_table "application_events", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -168,6 +168,10 @@ ActiveRecord::Schema.define(version: 2021_02_28_191150) do
     t.string "start_time", default: "noon"
     t.string "end_time", default: "6p"
     t.boolean "promote", default: true, null: false
+    t.datetime "special_event_start_date"
+    t.datetime "special_event_end_date"
+    t.string "special_event_start_time", default: "12:00 PM"
+    t.string "special_event_end_time", default: "4:00 PM"
     t.index ["key"], name: "index_open_studios_events_on_key", unique: true
   end
 

--- a/features/admin/open_studios_events/manage_open_studios.feature
+++ b/features/admin/open_studios_events/manage_open_studios.feature
@@ -40,5 +40,3 @@ Scenario: Editing an existing open studios event
 
   When I visit the open studios page
   Then I do not see "Register to Participate"
-
-

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -67,7 +67,7 @@ Given /there are application events in the system/ do
 end
 
 Given /there is a scheduled Open Studios event/ do
-  FactoryBot.create(:open_studios_event)
+  FactoryBot.create(:open_studios_event, :with_special_event)
 rescue ActiveRecord::RecordInvalid
   # there's already one there
 end

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -16,6 +16,9 @@ Then('I see the registration message') do
 end
 
 Then('I see the open studios info form') do
+  expect(page).to have_content(
+    OpenStudiosEventPresenter.new(OpenStudiosEventService.current).special_event_date_range,
+  )
   expect(page).to have_css('input[name=shopUrl]')
   expect(page).to have_css('input[name=showEmail]')
   expect(page).to have_button('Nope - not this time')
@@ -74,9 +77,6 @@ Then /I change the date to next month and the title to "(.*)"/ do |title|
   @start_date = Time.zone.now + 1.month
   @end_date = @start_date + 1.day
   set_start_end_date_on_open_studios_form(@start_date, @end_date)
-  # fill_in "Start date", with: @start_date.to_date
-  # fill_in "End date", with: @end_date.to_date
-  fill_in 'Key', with: @start_date.strftime('%Y%m')
   fill_in 'Title', with: title
   click_on 'Update'
 end

--- a/spec/factories/open_studios_events.rb
+++ b/spec/factories/open_studios_events.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
     trait :past do
       start_date { Time.zone.now - 6.months }
     end
+    trait :with_special_event do
+      end_date { start_date + 1.week }
+      special_event_start_date { start_date + 1.day }
+      special_event_end_date { special_event_start_date + 1.day }
+    end
   end
 end

--- a/spec/models/open_studios_event_spec.rb
+++ b/spec/models/open_studios_event_spec.rb
@@ -18,60 +18,124 @@ describe OpenStudiosEvent do
     ]
   end
 
-  before do
-    # allow_any_instance_of(OpenStudiosEvent).to receive(:save_attached_files).and_return(true)
-    freeze_time
-    [past_oses, current_os, future_oses].flatten
-  end
+  describe 'validations' do
+    it 'requires dates to be in order' do
+      os = build(:open_studios_event,
+                 start_date: Time.zone.today,
+                 end_date: Time.zone.yesterday)
+      expect(os).not_to be_valid
+      expect(os.errors[:end_date]).to include 'should be after start date'
+    end
+    it 'requires special event dates to be in order' do
+      os = build(:open_studios_event,
+                 start_date: Time.zone.today,
+                 end_date: Time.zone.today + 1.week,
+                 special_event_start_date: Time.zone.today + 2.days,
+                 special_event_end_date: Time.zone.today + 1.day)
 
-  describe '#for_display' do
-    it 'returns the pretty version for the current os' do
-      expect(current_os.for_display).to eql current_os.start_date.strftime('%Y %b')
+      expect(os).not_to be_valid
+      expect(os.errors[:special_event_end_date]).to include 'should be after start date'
+    end
+    it 'is invalid if special event start date is defined and end date is not' do
+      os = build(:open_studios_event,
+                 start_date: Time.zone.today,
+                 end_date: Time.zone.today + 1.week,
+                 special_event_end_date: nil,
+                 special_event_start_date: Time.zone.yesterday)
+
+      expect(os).not_to be_valid
+      expect(os.errors[:special_event_end_date]).to include 'must be present if special event start date is present'
+    end
+    it 'is invalid if special event end date is defined and start date is not' do
+      os = build(:open_studios_event,
+                 start_date: Time.zone.today,
+                 end_date: Time.zone.today + 1.week,
+                 special_event_start_date: nil,
+                 special_event_end_date: Time.zone.yesterday)
+
+      expect(os).not_to be_valid
+      expect(os.errors[:special_event_start_date]).to include 'must be present if special event end date is present'
     end
 
-    context 'with reverse true' do
-      context 'if the dates are within the same month' do
-        it 'returns the pretty version for the current os' do
-          expected = current_os.start_date.strftime('%b %-d-') + current_os.end_date.strftime('%-d %Y')
-          expect(current_os.for_display(reverse: true)).to eql expected
+    it 'requires special event dates to within event dates' do
+      os = build(:open_studios_event,
+                 start_date: Time.zone.today,
+                 end_date: Time.zone.today + 1.week,
+                 special_event_start_date: Time.zone.yesterday,
+                 special_event_end_date: Time.zone.today + 9.days)
+
+      expect(os).not_to be_valid
+      expect(os.errors[:special_event_start_date]).to include 'must be during the main event dates'
+      expect(os.errors[:special_event_start_date]).to include 'must be during the main event dates'
+    end
+
+    it 'special events can be the same as the main events' do
+      now = Time.zone.today
+      later = now + 1.day
+      os = build(:open_studios_event,
+                 start_date: now,
+                 end_date: later,
+                 special_event_start_date: now,
+                 special_event_end_date: later)
+      expect(os).to be_valid
+    end
+  end
+
+  describe 'scopes' do
+    before do
+      freeze_time
+      [past_oses, current_os, future_oses].flatten
+    end
+
+    describe '#future' do
+      it 'includes 2 open studios' do
+        expect(OpenStudiosEvent.future.size).to eq(3)
+      end
+    end
+
+    describe '#past' do
+      it 'includes 1 open studios' do
+        expect(OpenStudiosEvent.past.size).to eq(2)
+      end
+    end
+
+    describe '#current' do
+      it 'includes the nearest future event' do
+        expect(OpenStudiosEvent.current).to eql current_os
+      end
+
+      it 'shows the first future event if today is monday after the last event' do
+        travel_to(current_os.end_date + 1.day)
+
+        expect(OpenStudiosEvent.current).to eql future_oses.first
+      end
+    end
+
+    describe '#for_display' do
+      it 'returns the pretty version for the current os' do
+        expect(current_os.for_display).to eql current_os.start_date.strftime('%Y %b')
+      end
+
+      context 'with reverse true' do
+        context 'if the dates are within the same month' do
+          it 'returns the pretty version for the current os' do
+            expected = current_os.start_date.strftime('%b %-d-') + current_os.end_date.strftime('%-d %Y')
+            expect(current_os.for_display(reverse: true)).to eql expected
+          end
+        end
+        context 'if the dates are across months' do
+          let(:current_os) do
+            date = 1.month.since.beginning_of_month
+            date -= 1.day
+            FactoryBot.create(:open_studios_event, start_date: date)
+          end
+          it 'returns the pretty version for the current os' do
+            expected = current_os.start_date.strftime('%b %-d-') +
+                       current_os.end_date.strftime('%b %-d %Y')
+            expect(current_os.for_display(reverse: true)).to eql expected
+          end
         end
       end
-      context 'if the dates are across months' do
-        let(:current_os) do
-          date = 1.month.since.beginning_of_month
-          date -= 1.day
-          FactoryBot.create(:open_studios_event, start_date: date)
-        end
-        it 'returns the pretty version for the current os' do
-          expected = current_os.start_date.strftime('%b %-d-') +
-                     current_os.end_date.strftime('%b %-d %Y')
-          expect(current_os.for_display(reverse: true)).to eql expected
-        end
-      end
-    end
-  end
-
-  describe '#future' do
-    it 'includes 2 open studios' do
-      expect(OpenStudiosEvent.future.size).to eq(3)
-    end
-  end
-
-  describe '#past' do
-    it 'includes 1 open studios' do
-      expect(OpenStudiosEvent.past.size).to eq(2)
-    end
-  end
-
-  describe '#current' do
-    it 'includes the nearest future event' do
-      expect(OpenStudiosEvent.current).to eql current_os
-    end
-
-    it 'shows the first future event if today is monday after the last event' do
-      travel_to(current_os.end_date + 1.day)
-
-      expect(OpenStudiosEvent.current).to eql future_oses.first
     end
   end
 

--- a/spec/presenters/open_studios_event_presenter_spec.rb
+++ b/spec/presenters/open_studios_event_presenter_spec.rb
@@ -37,4 +37,62 @@ describe OpenStudiosEventPresenter do
       end
     end
   end
+
+  describe '.date_range_with_year' do
+    let(:os) do
+      build_stubbed(:open_studios_event,
+                    start_date: Time.zone.local(2015, 4, 30, 10, 0, 0),
+                    end_date: Time.zone.local(2015, 5, 1, 10, 0, 0))
+    end
+
+    it 'shows a pretty date with the year' do
+      expect(presenter.date_range_with_year).to eql 'Apr 30-May 1 2015'
+    end
+  end
+
+  describe '.special_event_date_range' do
+    context 'if the dates are in the same month' do
+      let(:os) do
+        build_stubbed(:open_studios_event,
+                      special_event_start_date: Time.zone.local(2015, 5, 1, 10, 0, 0),
+                      special_event_end_date: Time.zone.local(2015, 5, 2, 10, 0, 0))
+      end
+
+      it 'shows a pretty date' do
+        expect(presenter.special_event_date_range).to eql 'May 1-2'
+      end
+
+      it 'uses the separator if provided' do
+        expect(presenter.special_event_date_range(separator: ' & ')).to eql 'May 1 & 2'
+      end
+    end
+
+    context 'if the dates are go across months' do
+      let(:os) do
+        build_stubbed(:open_studios_event,
+                      special_event_start_date: Time.zone.local(2015, 4, 30, 10, 0, 0),
+                      special_event_end_date: Time.zone.local(2015, 5, 1, 10, 0, 0))
+      end
+
+      it 'shows a pretty date' do
+        expect(presenter.special_event_date_range).to eql 'Apr 30-May 1'
+      end
+
+      it 'uses the separator if provided' do
+        expect(presenter.special_event_date_range(separator: ' & ')).to eql 'Apr 30 & May 1'
+      end
+    end
+  end
+
+  describe '.special_event_date_range_with_year' do
+    let(:os) do
+      build_stubbed(:open_studios_event,
+                    special_event_start_date: Time.zone.local(2015, 4, 30, 10, 0, 0),
+                    special_event_end_date: Time.zone.local(2015, 5, 1, 10, 0, 0))
+    end
+
+    it 'shows a pretty date with the year' do
+      expect(presenter.special_event_date_range_with_year).to eql 'Apr 30-May 1 2015'
+    end
+  end
 end


### PR DESCRIPTION
problem
-------

ideally we should know if there is a special event timing inside the
*main* event timing.

solution
--------

Add that.

Now OpenStudiosEvent has a special_event set of date and time fields
which are must be *inside* the main date range.

These are used in the open studios registration text and later may be
used for switching on and off other features/data.

changes
-------
* add new fields for special event time and date range
* Shuffle date range helpers off together in preparation for special event time window helpers
* put that value conditionally in `openStudiosFormInfo` instructions
* add date validations and tests