### PR TITLE
Add timeslots to open studios event

### DIFF
--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -46,11 +46,17 @@ module Admin
     private
 
     def open_studios_event_params
-      params.require(:open_studios_event).permit(:title, :start_date, :end_date, :start_time, :end_time, :key, :promote,
+      params.require(:open_studios_event).permit(:title,
+                                                 :start_date,
+                                                 :end_date,
+                                                 :start_time,
+                                                 :end_time,
+                                                 :key,
+                                                 :promote,
                                                  :special_event_start_date,
                                                  :special_event_start_time,
                                                  :special_event_end_date,
-                                                 :special_event_end_date)
+                                                 :special_event_end_time)
     end
   end
 end

--- a/app/services/time_slot_computer.rb
+++ b/app/services/time_slot_computer.rb
@@ -1,0 +1,50 @@
+class TimeSlotComputer
+  CLOCK_TIME_REGEX = /^\s?(\d{1,2})\s?:\s?(\d{1,2})\s?([ap]m)\s?/i.freeze
+
+  attr_reader :date, :duration, :start_clock_time, :end_clock_time
+
+  def initialize(date, start_clock_time, end_clock_time, duration_minutes = 60)
+    # *_clock_time are strings like "11:00 PM" or "5:00 am"
+    @duration = duration_minutes
+    @date = date
+    @start_clock_time = start_clock_time
+    @end_clock_time = end_clock_time
+  end
+
+  def run
+    return [] unless date && start_clock_time && end_clock_time
+
+    start_time = build_date_time(date, start_clock_time)
+    end_time = build_date_time(date, end_clock_time)
+    current = start_time
+    slots = []
+    while current < end_time
+      current_end = current + duration.minutes
+      slots << format_slot(current, current_end)
+      current = current_end
+    end
+    slots
+  end
+
+  private
+
+  def format_slot(start, finish)
+    "#{start.iso8601}/#{finish.iso8601}"
+  end
+
+  def convert_to_24hr_time(clock_time)
+    matches = CLOCK_TIME_REGEX.match(clock_time).to_a
+    return unless matches
+
+    hour, minute, period = matches[1..3]
+    hour = hour.to_i % 12
+    minute = minute.to_i
+    hour += 12 if period.casecmp('pm').zero?
+    [hour, minute]
+  end
+
+  def build_date_time(date, clock_time)
+    hour, minute = convert_to_24hr_time(clock_time)
+    date.in_time_zone(Conf.event_time_zone).beginning_of_day + hour.hours + minute.minutes
+  end
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -43,6 +43,7 @@ production:
     new_art: 86400
 
 common:
+  event_time_zone: America/Los_Angeles
   open_studios_help_document_url: https://bit.ly/v-openstudios
   features:
     virtual_open_studios: false

--- a/db/migrate/20210307081730_add_special_event_time_slots_to_open_studios_event.rb
+++ b/db/migrate/20210307081730_add_special_event_time_slots_to_open_studios_event.rb
@@ -1,0 +1,5 @@
+class AddSpecialEventTimeSlotsToOpenStudiosEvent < ActiveRecord::Migration[6.1]
+  def change
+    add_column :open_studios_events, :special_event_time_slots, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_033543) do
+ActiveRecord::Schema.define(version: 2021_03_07_081730) do
 
   create_table "application_events", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2021_03_02_033543) do
     t.datetime "special_event_end_date"
     t.string "special_event_start_time", default: "12:00 PM"
     t.string "special_event_end_time", default: "4:00 PM"
+    t.text "special_event_time_slots"
     t.index ["key"], name: "index_open_studios_events_on_key", unique: true
   end
 

--- a/spec/models/open_studios_event_spec.rb
+++ b/spec/models/open_studios_event_spec.rb
@@ -81,6 +81,35 @@ describe OpenStudiosEvent do
     end
   end
 
+  describe 'lifecycle' do
+    describe 'before_save' do
+      it 'generates time slots if special event fields have changed' do
+        now = Time.zone.today
+        later = now + 1.day
+        os = build(:open_studios_event,
+                   start_date: now,
+                   end_date: later,
+                   special_event_start_date: now,
+                   special_event_end_date: later,
+                   special_event_start_time: '11:00 am',
+                   special_event_end_time: '2:00 pm')
+        os.save
+        os.reload
+        expect(os.special_event_time_slots).to have(6).slots
+      end
+
+      it 'works if we delete special event data' do
+        os = create(:open_studios_event, :with_special_event)
+        expect(os.special_event_time_slots).to have_at_least(1).slot
+        os.special_event_start_time = nil
+        os.special_event_end_time = nil
+        os.save
+        os.reload
+        expect(os.special_event_time_slots).to eq []
+      end
+    end
+  end
+
   describe 'scopes' do
     before do
       freeze_time

--- a/spec/services/time_slot_computer_spec.rb
+++ b/spec/services/time_slot_computer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe TimeSlotComputer do
+  it 'computes timeslots for a date and time range' do
+    freeze_time do
+      travel_to Time.zone.local(2020, 11, 24, 5, 4, 44)
+      date = Time.current
+      start_time = '11:00 AM'
+      end_time = ' 2:00pm '
+      slots = TimeSlotComputer.new(date, start_time, end_time).run
+
+      expected = [
+        '2020-11-23T11:00:00-08:00/2020-11-23T12:00:00-08:00',
+        '2020-11-23T12:00:00-08:00/2020-11-23T13:00:00-08:00',
+        '2020-11-23T13:00:00-08:00/2020-11-23T14:00:00-08:00',
+      ]
+      expect(slots).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
For the special events, we want to know a list of available
timeslots in some duration (now fixed to 1 hr).

After talking with @rdavid1099 we agreed on a new field that is
auto computed based on the special event start/end date and time.

As you update the event, we can re-record available time slots.

Then consumers (when we want artists to choose from available time
slots) can read that list of timeslots and use it for building forms
or whatever.

This PR is just the datamodel and save changes to support that.