### PR TITLE
Change Registration button text before and after artist registers for open studios

### DIFF
--- a/app/controllers/open_studios_controller.rb
+++ b/app/controllers/open_studios_controller.rb
@@ -1,7 +1,7 @@
 class OpenStudiosController < ApplicationController
   def index
     @page_title = PageInfoService.title('Open Studios')
-    @presenter = OpenStudiosPresenter.new
+    @presenter = OpenStudiosPresenter.new(current_user)
   end
 
   def show

--- a/app/presenters/open_studios_presenter.rb
+++ b/app/presenters/open_studios_presenter.rb
@@ -3,6 +3,10 @@ class OpenStudiosPresenter
 
   delegate :promote?, to: :current_os
 
+  def initialize(current_user)
+    @user = current_user
+  end
+
   def packaged_summary
     section = 'summary'
     @packaged_summary ||= CmsDocument.packaged(PAGE, section)
@@ -23,6 +27,14 @@ class OpenStudiosPresenter
 
   def participating_artists
     @participating_artists ||= sort_artists_by_name(os_participants)
+  end
+
+  def register_for_open_studio_button_text
+    if @user&.artist? && @user&.doing_open_studios?
+      'Artist OS Info'
+    else
+      'Artist Registration'
+    end
   end
 
   private

--- a/app/views/open_studios/index.html.slim
+++ b/app/views/open_studios/index.html.slim
@@ -3,7 +3,7 @@
     h2.title #{open_studios_page_title}
     - if @presenter.promote?
       .action-button
-        = link_to "Register to Participate", register_open_studios_path, class: "pure-button-primary pure-button"
+        = link_to @presenter.register_for_open_studio_button_text, register_open_studios_path, class: "pure-button-primary pure-button"
 
 .pure-g.tab-content
   .pure-u-1-1#about

--- a/features/admin/open_studios_events/manage_open_studios.feature
+++ b/features/admin/open_studios_events/manage_open_studios.feature
@@ -39,4 +39,4 @@ Scenario: Editing an existing open studios event
   And I see a flash notice "Successfully updated"
 
   When I visit the open studios page
-  Then I do not see "Register to Participate"
+  Then I do not see "Artist Registration"

--- a/features/artists/open_studios_signup.feature
+++ b/features/artists/open_studios_signup.feature
@@ -15,7 +15,7 @@ Background:
 
 Scenario: "when I'm not logged in"
   When I visit the open studios page
-  And I click on "Register to Participate"
+  And I click on "Artist Registration"
   Then I see the login page
 
   When I fill in the login form with "artist/8characters"
@@ -30,7 +30,7 @@ Scenario: "when I'm not logged in"
 Scenario: "when I'm logged in"
   When I login as "artist"
   And I visit the open studios page
-  And I click on "Register to Participate"
+  And I click on "Artist Registration"
 
   Then I see my profile edit form
 
@@ -61,11 +61,18 @@ Scenario: "when I'm logged in"
   Then I see a flash notice "Maybe next time! :\)"
   Then I see "Yes - Register Me" on the page
 
+  When I click on "Yes - Register Me"
+  And I see the registration dialog
+  And I click on "Yes" in the ".ReactModal__Content"
+  Then I see the open studios info form
+
+  When I visit the open studios page
+  Then I see the new Artist OS Info button
 
 Scenario: "when I auto register but i'm not allowed (no address)"
   When I login as "no_address"
   And I visit the open studios page
-  And I click on "Register to Participate"
+  And I click on "Artist Registration"
 
   Then I see my profile edit form
   And I see the "events" profile panel is open

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -68,6 +68,12 @@ Then /^I see a new open studios form$/ do
   expect(page).to have_selector '#open_studios_event_end_date'
 end
 
+Then /^I see the new Artist OS Info button$/ do
+  within '.action-button' do
+    expect(page).to have_selector '.pure-button-primary', text: 'Artist OS Info'
+  end
+end
+
 def set_start_end_date_on_open_studios_form(start_date, end_date)
   fill_in 'Start date', with: start_date
   fill_in 'End date', with: end_date

--- a/spec/presenters/open_studios_presenter_spec.rb
+++ b/spec/presenters/open_studios_presenter_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe OpenStudiosPresenter do
-  subject(:presenter) { described_class.new }
+  let(:user) { build(:user) }
+  subject(:presenter) { described_class.new(user) }
   let(:open_studios_event) { create(:open_studios_event) }
   let!(:summary) do
     create(:cms_document,
@@ -75,6 +76,39 @@ describe OpenStudiosPresenter do
     end
     it 'are in order artist last name' do
       expect(subject.participating_artists.map { |a| a.lastname.downcase }).to be_monotonically_increasing
+    end
+  end
+
+  describe '#register_for_open_studio_button_text' do
+    context 'when the user is not logged in' do
+      let(:user) { nil }
+
+      it 'should show "Artist Registration"' do
+        expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
+      end
+    end
+
+    context 'when the user is a fan' do
+      let(:user) { build(:fan) }
+
+      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
+        expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
+      end
+    end
+
+    context 'when the user is an artist but not signed up yet for os' do
+      let(:user) { build(:artist, doing_open_studios: false) }
+      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
+        expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
+      end
+    end
+
+    context 'when the user is an artist that is signed up for th os' do
+      let(:user) { create(:artist, doing_open_studios: true) }
+
+      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
+        expect(subject.register_for_open_studio_button_text).to eq('Artist OS Info')
+      end
     end
   end
 end


### PR DESCRIPTION
1. customized button text based on user type and os info through presenter
2. Added some extra feature tests