### PR TITLE
Change 'nope' button copy

### DIFF
--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -68,7 +68,7 @@ describe("OpenStudiosInfoForm", () => {
         expect(findField("Show my e-mail")).toBeInTheDocument();
         expect(findField("Show my phone number")).toBeInTheDocument();
         expect(findButton("Update my details")).toBeInTheDocument();
-        expect(findButton("Nope - not this time")).toBeInTheDocument();
+        expect(findButton("Un-Register Me")).toBeInTheDocument();
       });
     });
 
@@ -194,7 +194,7 @@ describe("OpenStudiosInfoForm", () => {
     it("triggers a cancel when i click the cancel button", async () => {
       let cancelButton;
       act(() => {
-        cancelButton = findButton("Nope - not this time");
+        cancelButton = findButton("Un-Register Me");
         fireEvent.click(cancelButton);
       });
       await waitFor(() => {

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -151,7 +151,7 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
                   Update my details
                 </MauButton>
                 <MauButton type="cancel" onClick={cancelRegistration}>
-                  Nope - not this time
+                  Un-Register Me
                 </MauButton>
               </div>
             </Form>

--- a/features/artists/my_mau.feature
+++ b/features/artists/my_mau.feature
@@ -54,7 +54,7 @@ Scenario: I can update my os status
   And I click on "Personal Info"
 
   When I click on the current open studios edit section
-  And I click on "Nope - not this time"
+  And I click on "Un-Register Me"
   Then I see the registration message
 
   When I click on "Yes - Register Me"

--- a/features/artists/open_studios_signup.feature
+++ b/features/artists/open_studios_signup.feature
@@ -57,7 +57,7 @@ Scenario: "when I'm logged in"
     | shopUrl        | videoConferenceUrl |
     | https://www.rcode5.com  | https://www.youtube.com/watch?v=2SyPyBHJmiI |
 
-  When I click on "Nope - not this time"
+  When I click on "Un-Register Me"
   Then I see a flash notice "Maybe next time! :\)"
   Then I see "Yes - Register Me" on the page
 

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -21,7 +21,7 @@ Then('I see the open studios info form') do
   )
   expect(page).to have_css('input[name=shopUrl]')
   expect(page).to have_css('input[name=showEmail]')
-  expect(page).to have_button('Nope - not this time')
+  expect(page).to have_button('Un-Register Me')
 end
 
 Then(/^I see the open studios cms content/) do


### PR DESCRIPTION
Issue
-------
Virtual Open Studios Registration has a lot more decisions for an artist to make than the in-person open studios events. Decisions like: Am I participating in the whole event? The live event? Do I have a shopping cart? Registration is not an on-off switch any more. This means the Un-Register button which reads "Nope - not this time" is now not very clear.

Solution
--------
I changed the copy of the button to `Un-Register Me`.