### PR TITLE
Update 'participating artists' header style

### DIFF
--- a/app/views/open_studios/index.html.slim
+++ b/app/views/open_studios/index.html.slim
@@ -12,7 +12,7 @@
         = render_cms_content @presenter.packaged_summary
         = render_cms_content @presenter.packaged_preview_reception
         .section.open-studios-index__section
-          h4 Participating Artists
+          h4.section.open-studios-index__header Participating Artists
           ul.open-studios-index__partipipant-list
             - @presenter.participating_artists.each do |artist|
               li

--- a/app/webpack/stylesheets/gto/main/_open_studios.scss
+++ b/app/webpack/stylesheets/gto/main/_open_studios.scss
@@ -10,12 +10,12 @@
 }
 .open-studios-index__section {
   margin-bottom: 30px;
-  > h4 {
-    text-transform: uppercase;
-    margin-bottom: 10px;
-    font-size: 0.9rem;
-    font-weight: $font-weight-normal;
-  }
+}
+.open-studios-index__header {
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+  font-weight: $font-weight-bold;
 }
 .open-studios-index__participant-list {
   margin-top: 0;


### PR DESCRIPTION
Problem
-------
On the Open Studios page (the intro CMS-able page), I wish the "PARTICIPATING ARTISTS" text stood out a little more.

Solution
-------
I implemented the desired styling. I also made a small tweak to the css classes to make it a bit more bem-y.

Preview
------
<img width="817" alt="image" src="https://user-images.githubusercontent.com/19210117/110243349-d08b6c80-7f0e-11eb-98a4-481b0ceaf7ae.png">
