### PR TITLE
Fix issue computing timeslots when dates span months

### DIFF
--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -52,8 +52,9 @@ class OpenStudiosEvent < ApplicationRecord
   def generate_special_event_time_slots
     return if (changed & SPECIAL_EVENT_FIELDS).blank?
 
-    time_slots = (special_event_start_date.day..special_event_end_date.day).map.each_with_index do |_day, idx|
-      date = special_event_start_date + idx.days
+    number_of_days = (special_event_end_date.to_date - special_event_start_date.to_date).to_i
+    time_slots = Array.new(number_of_days + 1) do |day_offset|
+      date = special_event_start_date + day_offset.days
       TimeSlotComputer.new(date, special_event_start_time, special_event_end_time).run
     end.flatten
     self.special_event_time_slots = time_slots

--- a/spec/services/time_slot_computer_spec.rb
+++ b/spec/services/time_slot_computer_spec.rb
@@ -17,4 +17,16 @@ describe TimeSlotComputer do
       expect(slots).to eq expected
     end
   end
+
+  it 'returns nothing if the time spans midnight' do
+    freeze_time do
+      travel_to Time.zone.local(2020, 11, 24, 5, 4, 44)
+      date = Time.current
+      start_time = '11:30 PM'
+      end_time = ' 12:30 AM'
+      slots = TimeSlotComputer.new(date, start_time, end_time).run
+
+      expect(slots).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Problem
-------

There were issues in this PR https://github.com/bunnymatic/mau/pull/137
which would make this code not work *if* the event start/end dates
spanned across a month boundary.

This makes that work better.

Solution
--------

* leverage `(date - date).to_i` gives you days.
* update tests
* add another test to prove that we can't do start/end time across midnight boundary.  we don't care but the test will serve as a specification of expected behavior