### PR TITLE
Add some TS lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,13 +14,22 @@
     "MAU": true,
     "module": true
   },
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 9,
     "sourceType": "module"
   },
-  "plugins": ["standard", "simple-import-sort", "prettier", "jest-dom"],
+  "plugins": [
+    "standard",
+    "simple-import-sort",
+    "prettier",
+    "jest-dom",
+    "unused-imports",
+    "@typescript-eslint"
+  ],
   "rules": {
     "no-duplicate-imports": ["error", { "includeExports": true }],
+    "unused-imports/no-unused-imports": "error",
     "no-unused-vars": [
       "error",
       {

--- a/app/webpack/js/services/api.ts
+++ b/app/webpack/js/services/api.ts
@@ -1,6 +1,6 @@
 import { destroy, get, post, put } from "@js/services/mau_ajax";
-import { camelizeKeys, decamelizeKeys } from "humps";
 import * as types from "@reactjs/types";
+import { camelizeKeys } from "humps";
 const camelize = (data) => camelizeKeys(data);
 
 export const api = {

--- a/app/webpack/reactjs/components/field_error.test.tsx
+++ b/app/webpack/reactjs/components/field_error.test.tsx
@@ -1,6 +1,7 @@
-import { FieldError } from "./field_error";
 import { render } from "@testing-library/react";
 import React from "react";
+
+import { FieldError } from "./field_error";
 
 describe("FieldError", () => {
   // This test is corrrect but fails with

--- a/app/webpack/reactjs/components/mau_button.test.tsx
+++ b/app/webpack/reactjs/components/mau_button.test.tsx
@@ -4,8 +4,6 @@ import React from "react";
 import { MauButton } from "./mau_button";
 
 describe("MauButton", () => {
-  let button;
-
   const renderComponent = ({ children, ...props }) => {
     render(<MauButton {...props}>{children}</MauButton>);
   };

--- a/app/webpack/reactjs/components/mau_checkbox_field.tsx
+++ b/app/webpack/reactjs/components/mau_checkbox_field.tsx
@@ -1,12 +1,11 @@
-import { Field } from "formik";
 import { MauHint } from "@reactjs/components/mau_hint";
 import cx from "classnames";
-import React, { FC } from "react";
+import { Field } from "formik";
+import React, { FC, JSX } from "react";
 
 interface MauCheckboxFieldProps {
   name: string;
   label: string;
-  checked?: boolean;
   hint?: string | JSX.Element;
   id?: string;
   classes?: string;
@@ -16,7 +15,6 @@ export const MauCheckboxField: FC<MauCheckboxFieldProps> = ({
   id,
   name,
   label,
-  checked,
   hint,
   classes,
 }) => {

--- a/app/webpack/reactjs/components/mau_hint.test.tsx
+++ b/app/webpack/reactjs/components/mau_hint.test.tsx
@@ -1,6 +1,7 @@
-import { MauHint } from "./mau_hint";
 import { render } from "@testing-library/react";
 import React from "react";
+
+import { MauHint } from "./mau_hint";
 
 describe("MauHint", () => {
   it("matches the snapshot", () => {

--- a/app/webpack/reactjs/components/mau_text_field.test.tsx
+++ b/app/webpack/reactjs/components/mau_text_field.test.tsx
@@ -1,6 +1,7 @@
-import { MauTextField } from "./mau_text_field";
 import { renderInForm } from "@reactjs/test/renderers";
 import React from "react";
+
+import { MauTextField } from "./mau_text_field";
 
 describe("MauTextField", () => {
   it("matches the snapshot", () => {

--- a/app/webpack/reactjs/components/mau_text_field.tsx
+++ b/app/webpack/reactjs/components/mau_text_field.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from "react";
-import { MauHint } from "@reactjs/components/mau_hint";
 import { FieldError } from "@reactjs/components/field_error";
-import { Field, ErrorMessage } from "formik";
+import { MauHint } from "@reactjs/components/mau_hint";
+import { ErrorMessage, Field } from "formik";
+import React, { FC, JSX } from "react";
 
 interface MauTextFieldProps {
   id?: string;
@@ -10,7 +10,6 @@ interface MauTextFieldProps {
   placeholder: string;
   className?: string;
   hint?: string | JSX.Element;
-  errors?: Record<string, unknown>;
 }
 
 export const MauTextField: FC<MauTextFieldProps> = ({
@@ -20,7 +19,6 @@ export const MauTextField: FC<MauTextFieldProps> = ({
   placeholder,
   className,
   hint,
-  errors,
 }) => {
   const classes = className ?? "";
   return (

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -1,13 +1,9 @@
-import { OpenStudiosInfoForm } from "./open_studios_info_form";
-import {
-  formatTimeSlot,
-  parseTimeSlot,
-} from "./special_event_schedule_fields.tsx";
+import { api } from "@js/services/api";
 import {
   openStudiosEventFactory,
   openStudiosParticipantFactory,
 } from "@test/factories";
-import { api } from "@js/services/api";
+import { fillIn, findButton, findField } from "@test/support/dom_finders";
 import {
   act,
   fireEvent,
@@ -15,9 +11,10 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { findButton, findField, fillIn } from "@test/support/dom_finders";
 import expect from "expect";
 import React from "react";
+
+import { OpenStudiosInfoForm } from "./open_studios_info_form";
 
 jest.mock("@js/services/api");
 

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -1,16 +1,15 @@
-import { Form, Formik } from "formik";
+import Flash from "@js/app/jquery/flash";
+import { api } from "@js/services/api";
 import { MauButton } from "@reactjs/components/mau_button";
 import { MauCheckboxField } from "@reactjs/components/mau_checkbox_field";
 import { MauTextField } from "@reactjs/components/mau_text_field";
 import { SpecialEventScheduleFields } from "@reactjs/components/open_studios/special_event_schedule_fields";
-import { api } from "@js/services/api";
 import * as types from "@reactjs/types";
-import Flash from "@js/app/jquery/flash";
+import { Form, Formik } from "formik";
 import { camelizeKeys } from "humps";
 import React, { FC } from "react";
 
 interface OpenStudiosInfoFormProps {
-  location: string;
   artistId: number;
   participant: types.OpenStudiosParticipant;
   openStudiosEvent: types.OpenStudiosEvent;
@@ -30,7 +29,6 @@ function denullify(participant) {
 }
 
 export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
-  location,
   artistId,
   participant,
   onUpdateParticipant,
@@ -87,7 +85,7 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
     <section id="open-studios-info-form">
       <h3 className="open-studios-info-form__title">Your Open Studios Info</h3>
       <Formik initialValues={denullify(participant)} onSubmit={handleSubmit}>
-        {({ values, errors, dirty, isSubmitting }) => {
+        {({ dirty, isSubmitting }) => {
           return (
             <Form
               className="open-studios-info-form"

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration.test.tsx
@@ -1,4 +1,5 @@
 import { api } from "@js/services/api";
+import { openStudiosParticipantFactory } from "@test/factories";
 import {
   act,
   fireEvent,
@@ -10,7 +11,6 @@ import expect from "expect";
 import React from "react";
 
 import { OpenStudiosRegistration } from "./open_studios_registration";
-import { openStudiosParticipantFactory } from "@test/factories";
 
 jest.mock("@js/services/api");
 

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration.tsx
@@ -1,14 +1,11 @@
-import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
-import { OpenStudiosInfoForm } from "@reactjs/components/open_studios/open_studios_info_form";
-import { MauButton } from "@reactjs/components/mau_button";
-import { mailToLink } from "@js/services/mailer.service";
-import { useModalState } from "@reactjs/hooks/useModalState";
-import { api } from "@js/services/api";
-import * as types from "@reactjs/types";
 import Flash from "@js/app/jquery/flash";
-import { isNil } from "@js/app/helpers";
-import cx from "classnames";
-import React, { FC, useState, useEffect } from "react";
+import { api } from "@js/services/api";
+import { mailToLink } from "@js/services/mailer.service";
+import { MauButton } from "@reactjs/components/mau_button";
+import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
+import { useModalState } from "@reactjs/hooks/useModalState";
+import * as types from "@reactjs/types";
+import React, { FC, useEffect } from "react";
 
 interface OpenStudiosRegWindowCloseFnArgs {
   updated: boolean;
@@ -25,7 +22,6 @@ interface OpenStudiosRegistrationWindowProps {
 }
 
 const OpenStudiosRegistrationWindow: FC<OpenStudiosRegistrationWindowProps> = ({
-  location,
   dateRange,
   onClose,
 }) => {
@@ -120,14 +116,13 @@ interface OpenStudiosRegistrationProps {
   autoRegister: Boolean;
   artistId: number;
   participant: types.OpenStudiosParticipant;
-  onUpdateParticipant: (participant: OpenStudiosParticipant) => void;
+  onUpdateParticipant: (participant: types.OpenStudiosParticipant) => void;
 }
 
 export const OpenStudiosRegistration: FC<OpenStudiosRegistrationProps> = ({
   location,
   openStudiosEvent,
   autoRegister,
-  artistId,
   onUpdateParticipant,
 }) => {
   const { isOpen, open, close } = useModalState();

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration_section.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration_section.test.tsx
@@ -1,16 +1,9 @@
-import { api } from "@js/services/api";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { openStudiosParticipantFactory } from "@test/factories";
+import { fireEvent, render, screen } from "@testing-library/react";
 import expect from "expect";
 import React from "react";
 
 import { OpenStudiosRegistrationSection } from "./open_studios_registration_section";
-import { openStudiosParticipantFactory } from "@test/factories";
 
 jest.mock("@js/services/api");
 
@@ -57,6 +50,7 @@ describe("OpenStudiosRegistrationSection", () => {
       const button = screen.queryByRole("button", {
         name: "Yes - Register Me",
       });
+      expect(button).toBeInTheDocument();
       expect(
         screen.queryByText("Will you be participating", { exact: false })
       ).toBeInTheDocument();

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration_section.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration_section.tsx
@@ -1,15 +1,8 @@
-import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
 import { OpenStudiosInfoForm } from "@reactjs/components/open_studios/open_studios_info_form";
 import { OpenStudiosRegistration } from "@reactjs/components/open_studios/open_studios_registration";
-import { MauButton } from "@reactjs/components/mau_button";
-import { mailToLink } from "@js/services/mailer.service";
-import { useModalState } from "@reactjs/hooks/useModalState";
-import { api } from "@js/services/api";
 import * as types from "@reactjs/types";
-import Flash from "@js/app/jquery/flash";
-import { isNil } from "@js/app/helpers";
 import cx from "classnames";
-import React, { FC, useState, useEffect } from "react";
+import React, { FC, useState } from "react";
 
 interface OpenStudiosRegistrationSectionProps {
   location: string;
@@ -26,9 +19,10 @@ export const OpenStudiosRegistrationSection: FC<OpenStudiosRegistrationSectionPr
   artistId,
   participant: initialParticipant,
 }) => {
-  const [participant, setParticipant] = useState<OpenStudiosParticipant | null>(
-    initialParticipant
-  );
+  const [
+    participant,
+    setParticipant,
+  ] = useState<types.OpenStudiosParticipant | null>(initialParticipant);
   const isParticipating = Boolean(participant);
 
   let message: string;

--- a/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.test.tsx
@@ -1,5 +1,6 @@
-import { parseTimeSlot } from "./special_event_schedule_fields";
 import { DateTime } from "luxon";
+
+import { parseTimeSlot } from "./special_event_schedule_fields";
 
 describe("parseTimeSlot", () => {
   it("returns timeslots parsed into date times", () => {

--- a/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.tsx
+++ b/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.tsx
@@ -1,6 +1,6 @@
-import { DateTime } from "luxon";
 import { MauCheckboxField } from "@reactjs/components/mau_checkbox_field";
 import * as types from "@reactjs/types";
+import { DateTime } from "luxon";
 import React, { FC } from "react";
 
 interface SpecialEventScheduleFieldsProps {

--- a/app/webpack/reactjs/helpers/automount.tsx
+++ b/app/webpack/reactjs/helpers/automount.tsx
@@ -7,17 +7,6 @@ import { lookup } from "../components";
 // This class name is used by `react_component` rails helper.  Make sure to keep them in sync
 const REACT_COMPONENT_CLASS = "react-component";
 
-function listAttributes(node) {
-  const result = {};
-  if (node.hasAttributes()) {
-    const attrs = node.attributes;
-    for (let i = attrs.length - 1; i >= 0; i--) {
-      result[attrs[i].name] = attrs[i].value;
-    }
-  }
-  return result;
-}
-
 export function automount() {
   document.addEventListener("DOMContentLoaded", function () {
     const els = Array.from(

--- a/app/webpack/reactjs/test/renderers.tsx
+++ b/app/webpack/reactjs/test/renderers.tsx
@@ -1,4 +1,4 @@
-import { RenderResult, render } from "@testing-library/react";
+import { render, RenderResult } from "@testing-library/react";
 import { Formik } from "formik";
 import React, { ReactElement } from "react";
 

--- a/app/webpack/reactjs/types/apiTypes.ts
+++ b/app/webpack/reactjs/types/apiTypes.ts
@@ -1,16 +1,1 @@
 /** api request/response shapes **/
-import * as modelTypes from "./modelTypes";
-
-interface ArtistsOpenStudiosRegisterForOsResponse {
-  success: boolean;
-  participating: boolean;
-  participant?: modelTypes.OpenStudiosParticipant;
-}
-
-interface OpenStudiosParticipantUpdateRequest {
-  id: number;
-  artistId: number;
-  openStudiosPartipicant: modelTypes.OpenStudiosParticipant;
-}
-
-type OpenStudiosParticipantUpdateResponse = modelTypes.OpenStudiosParticipant;

--- a/app/webpack/reactjs/types/index.ts
+++ b/app/webpack/reactjs/types/index.ts
@@ -2,6 +2,6 @@
 // Then we can bust it into smaller files and import them here
 // so consumers can stay the same.
 
-export * from "./utilTypes";
-export * from "./modelTypes";
 export * from "./apiTypes";
+export * from "./modelTypes";
+export * from "./utilTypes";

--- a/app/webpack/test/factories/index.ts
+++ b/app/webpack/test/factories/index.ts
@@ -1,2 +1,2 @@
-export * from "./open_studios_participant.factory";
 export * from "./open_studios_event.factory";
+export * from "./open_studios_participant.factory";

--- a/app/webpack/test/factories/open_studios_event.factory.ts
+++ b/app/webpack/test/factories/open_studios_event.factory.ts
@@ -1,6 +1,5 @@
 import * as types from "@reactjs/types";
 import { Factory } from "rosie";
-import faker from "faker";
 
 export const openStudiosEventFactory = Factory.define<types.OpenStudiosEvent>(
   "openStudiosEvent"

--- a/app/webpack/test/factories/open_studios_participant.factory.ts
+++ b/app/webpack/test/factories/open_studios_participant.factory.ts
@@ -1,7 +1,7 @@
 import * as types from "@reactjs/types";
 import { randomBoolean } from "@test/support/faker_helpers";
-import { Factory } from "rosie";
 import faker from "faker";
+import { Factory } from "rosie";
 
 export const openStudiosParticipantFactory = Factory.define<types.OpenStudiosParticipant>(
   "openStudiosParticipant"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.3",
+    "@typescript-eslint/eslint-plugin": "^4.16.1",
+    "@typescript-eslint/parser": "^4.16.1",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.0",
     "eslint": "^7.0",
@@ -13,6 +15,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-standard": "^5.0.0",
+    "eslint-plugin-unused-imports": "^1.1.0",
     "faker": "^5.4.0",
     "jest": "^26.0.0",
     "prettier": "^2.0.0",
@@ -20,8 +23,8 @@
     "webpack-dev-server": "^3.10.3"
   },
   "scripts": {
-    "eslint-fix": "eslint --fix app/**/*.js",
-    "eslint-lint": "eslint app/**/*.js",
+    "eslint-fix": "eslint --fix app/**/*.js app/**/*.ts app/**/*.tsx",
+    "eslint-lint": "eslint app/**/*.js app/**/*.ts app/**/*.tsx",
     "lint": "npm run eslint-lint && npm run prettier-lint",
     "lint-fix": "npm run eslint-fix && npm run prettier-fix",
     "prettier-fix": "prettier --write app/**/*.ts app/**/*.tsx app/**/*.js app/**/*.scss **/*.json",
@@ -42,7 +45,7 @@
     "@rails/ujs": "^6.0.2-1",
     "@rails/webpacker": "^5.0.0",
     "@types/faker": "^5.1.7",
-    "@types/react": "^16.9.48",
+    "@types/react": "^17.0.3",
     "@types/react-dom": "^16.9.8",
     "@types/react-modal": "^3.12.0",
     "angular": "^1.8.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["es6", "dom"],
     "module": "es6",
     "moduleResolution": "node",
+    "skipLibCheck": true,
     "sourceMap": true,
     "target": "es5",
     "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,13 +1451,27 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@^16", "@types/react@^16.9.48":
+"@types/react@^16":
   version "16.14.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.4.tgz#365f6a1e117d1eec960ba792c7e1e91ecad38e6f"
   integrity sha512-ETj7GbkPGjca/A4trkVeGvoIakmLV6ZtX3J8dcmOpzKzWVybbrOxanwaIPG71GZwImoMDY6Fq4wIe34lEqZ0FQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/react@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -1483,6 +1497,32 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz#2caf6a79dd19c3853b8d39769a27fccb24e4e651"
+  integrity sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.16.1"
+    "@typescript-eslint/scope-manager" "4.16.1"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz#da7a396dc7d0e01922acf102b76efff17320b328"
+  integrity sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.16.1"
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/typescript-estree" "4.16.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.2.tgz#5efd12355bd5b535e1831282e6cf465b9a71cf36"
@@ -1495,6 +1535,16 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/parser@^4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.16.1.tgz#3bbd3234dd3c5b882b2bcd9899bc30e1e1586d2a"
+  integrity sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.16.1"
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/typescript-estree" "4.16.1"
+    debug "^4.1.1"
+
 "@typescript-eslint/scope-manager@4.15.2":
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.2.tgz#5725bda656995960ae1d004bfd1cd70320f37f4f"
@@ -1503,10 +1553,23 @@
     "@typescript-eslint/types" "4.15.2"
     "@typescript-eslint/visitor-keys" "4.15.2"
 
+"@typescript-eslint/scope-manager@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz#244e2006bc60cfe46987e9987f4ff49c9e3f00d5"
+  integrity sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/visitor-keys" "4.16.1"
+
 "@typescript-eslint/types@4.15.2":
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.2.tgz#04acf3a2dc8001a88985291744241e732ef22c60"
   integrity sha512-r7lW7HFkAarfUylJ2tKndyO9njwSyoy6cpfDKWPX6/ctZA+QyaYscAHXVAfJqtnY6aaTwDYrOhp+ginlbc7HfQ==
+
+"@typescript-eslint/types@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.16.1.tgz#5ba2d3e38b1a67420d2487519e193163054d9c15"
+  integrity sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==
 
 "@typescript-eslint/typescript-estree@4.15.2":
   version "4.15.2"
@@ -1521,12 +1584,33 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz#c2fc46b05a48fbf8bbe8b66a63f0a9ba04b356f1"
+  integrity sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/visitor-keys" "4.16.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.15.2":
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.2.tgz#3d1c7979ce75bf6acf9691109bd0d6b5706192b9"
   integrity sha512-TME1VgSb7wTwgENN5KVj4Nqg25hP8DisXxNBojM4Nn31rYaNDIocNm5cmjOFfh42n7NVERxWrDFoETO/76ePyg==
   dependencies:
     "@typescript-eslint/types" "4.15.2"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz#d7571fb580749fae621520deeb134370bbfc7293"
+  integrity sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -4338,6 +4422,18 @@ eslint-plugin-standard@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz#c43f6925d669f177db46f095ea30be95476b1ee4"
   integrity sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==
+
+eslint-plugin-unused-imports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.0.tgz#4236063175c83f99cef42ea339a66679d75be19a"
+  integrity sha512-4SLYlkCwAbudvKDKZqn/3KjHlKAoorTxnP7AkAMMXkz59pQCBUjKPEaDv5pQ7fOyfDvLPCJKLowCcTl6HXcCuA==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -9089,7 +9185,7 @@ regexp.prototype.flags@^1.2.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==


### PR DESCRIPTION
Problem
--------

We added typscript but are *far* from obeying the rules.

Solution
---------

Take a half step there by adding a few linters and getting eslint to
checkout our Typescript code and complain as it seems appropriate.

`yarn tsc` still fails with lots of errors - mostly related to not
knowing the `@...` directory aliases.  For now, let that go.

Changes
--------

* add a couple ts related lint plugins
* run the linter and clean up so it passes