### PR TITLE
Update registration dialog copy

### DIFF
--- a/app/webpack/reactjs/components/open_studios/open_studios_registration.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration.test.tsx
@@ -46,7 +46,7 @@ describe("OpenStudiosRegistration", () => {
     renderComponent({ autoRegister: true });
     expect(
       screen.queryByText(
-        "You are registering to participate as an Open Studios artist",
+        "Would you like to register as a participating artist?",
         { exact: false }
       )
     ).toBeInTheDocument();

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration.tsx
@@ -1,6 +1,5 @@
 import Flash from "@js/app/jquery/flash";
 import { api } from "@js/services/api";
-import { mailToLink } from "@js/services/mailer.service";
 import { MauButton } from "@reactjs/components/mau_button";
 import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
 import { useModalState } from "@reactjs/hooks/useModalState";
@@ -46,12 +45,6 @@ const OpenStudiosRegistrationWindow: FC<OpenStudiosRegistrationWindowProps> = ({
   const accept = () => setRegistration(true);
   const decline = () => setRegistration(false);
 
-  const hasQuestions = () => {
-    onClose({ updated: false });
-    window.location = mailToLink(
-      "I have questions about registering for Open Studios"
-    );
-  };
   return (
     <div
       className="open-studios-modal__container"
@@ -74,20 +67,8 @@ const OpenStudiosRegistrationWindow: FC<OpenStudiosRegistrationWindowProps> = ({
         </div>
       </div>
       <div className="open-studios-modal__content popup-text">
-        <p>
-          You are registering to participate as an Open Studios artist{" "}
-          {dateRange}.
-        </p>
-        <p>This means you are committing to:</p>
-        <ol>
-          <li>Update the images on your profile with fresh, available art.</li>
-          <li>
-            Decide how you will participate and fill out the Open Studios
-            Information form.
-          </li>
-          <li>Promote the event to your mailing list and social fans.</li>
-        </ol>
-        <p>Continue with registration?</p>
+        <p>Open Studios is {dateRange}.</p>
+        <p>Would you like to register as a participating artist?</p>
         <div className="actions open-studios-registration-form__actions">
           <div className="open-studios-registration-form__action-item">
             <MauButton primary onClick={accept}>
@@ -97,11 +78,6 @@ const OpenStudiosRegistrationWindow: FC<OpenStudiosRegistrationWindowProps> = ({
           <div className="open-studios-registration-form__action-item">
             <MauButton secondary onClick={decline}>
               No
-            </MauButton>
-          </div>
-          <div className="open-studios-registration-form__action-item">
-            <MauButton secondary onClick={hasQuestions}>
-              I have questions
             </MauButton>
           </div>
         </div>

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration_section.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration_section.test.tsx
@@ -61,10 +61,7 @@ describe("OpenStudiosRegistrationSection", () => {
       });
       fireEvent.click(button);
       expect(
-        screen.queryByText(
-          "You are registering to participate as an Open Studios artist The dates of the event.",
-          { exact: false }
-        )
+        screen.queryByText("Would you like to register", { exact: false })
       ).toBeInTheDocument();
     });
   });
@@ -72,10 +69,7 @@ describe("OpenStudiosRegistrationSection", () => {
   it("if autoRegister is true, the modal starts open", () => {
     renderComponent({ autoRegister: true });
     expect(
-      screen.queryByText(
-        "You are registering to participate as an Open Studios artist The dates of the event.",
-        { exact: false }
-      )
+      screen.queryByText("Would you like to register", { exact: false })
     ).toBeInTheDocument();
   });
 });

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -5,8 +5,9 @@ end
 
 Then('I see the registration dialog') do
   expect(page).to have_css('.ReactModal__Content')
-  expect(page).to have_content('You are registering to participate as an Open Studios artist')
-  expect(page).to have_content('I have questions')
+  expect(page).to have_content('Would you like to register as a participating artist?')
+  expect(page).to have_content('Yes')
+  expect(page).to have_content('No')
 end
 
 Then('I see the registration message') do


### PR DESCRIPTION
Problem:
--------
The "registration yes/no" message text sucks. It's wordy and confusing.

https://www.pivotaltracker.com/story/show/177253880

Solution to Problem:
--------------------

Change the message text to this:

REGISTER FOR OPEN STUDIOS
"Open Studios is May 1-15, 2021
Would you like to register as a participating artist?"
Yes & No buttons only - please remove the "I have questions" button

Screenshot
------------

<img width="518" alt="Screen Shot 2021-03-08 at 6 54 49 PM" src="https://user-images.githubusercontent.com/427380/110413928-b0a99500-8043-11eb-9746-9f5105ca9a68.png">
