### PR TITLE
Ask deploy branch for production capistrano

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -22,8 +22,8 @@ server 'www.missionartists.org',
          forward_agent: true,
        }
 
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
-set :branch, 'main'
+ask :branch, (proc { `git rev-parse --abbrev-ref HEAD`.chomp })
+# set :branch, 'main'
 set :deploy_to, '/home/deploy/deployed/mau'
 
 # you can set custom ssh options


### PR DESCRIPTION
Problem
--------

if we *don't* deploy main which is likely to be more the case now with
some focused development and pushes, we should ask for the branch when
we call `cap production deploy`.

Solution
--------

Tell capistrano to ask for the branch name (default is the one you're
on).