### PR TITLE
Move from Artist OS Info button to Artist Registration

### DIFF
--- a/app/presenters/open_studios_presenter.rb
+++ b/app/presenters/open_studios_presenter.rb
@@ -30,11 +30,7 @@ class OpenStudiosPresenter
   end
 
   def register_for_open_studio_button_text
-    if @user&.artist? && @user&.doing_open_studios?
-      'Artist OS Info'
-    else
-      'Artist Registration'
-    end
+    'Artist Registration'
   end
 
   private

--- a/features/artists/open_studios_signup.feature
+++ b/features/artists/open_studios_signup.feature
@@ -70,7 +70,7 @@ Scenario: "when I'm logged in"
   Then I see the open studios info form
 
   When I visit the open studios page
-  Then I see the new Artist OS Info button
+  Then I see a "Artist Registration" link
 
 Scenario: "when I auto register but i'm not allowed (no address)"
   When I login as "no_address"

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -69,12 +69,6 @@ Then /^I see a new open studios form$/ do
   expect(page).to have_selector '#open_studios_event_end_date'
 end
 
-Then /^I see the new Artist OS Info button$/ do
-  within '.action-button' do
-    expect(page).to have_selector '.pure-button-primary', text: 'Artist OS Info'
-  end
-end
-
 def set_start_end_date_on_open_studios_form(start_date, end_date)
   fill_in 'Start date', with: start_date
   fill_in 'End date', with: end_date

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -358,3 +358,11 @@ end
 When(/^I go to the new tab$/) do
   page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 end
+
+When('I see a {string} button') do |string|
+  expect(page).to have_button(string)
+end
+
+When('I see a {string} link') do |string|
+  expect(page).to have_link(string)
+end

--- a/spec/presenters/open_studios_presenter_spec.rb
+++ b/spec/presenters/open_studios_presenter_spec.rb
@@ -91,14 +91,14 @@ describe OpenStudiosPresenter do
     context 'when the user is a fan' do
       let(:user) { build(:fan) }
 
-      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
+      it 'shows "Artist Registration" when current_user is a fan' do
         expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
       end
     end
 
     context 'when the user is an artist but not signed up yet for os' do
       let(:user) { build(:artist, doing_open_studios: false) }
-      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
+      it 'shows "Artist Registration" when current_user is an artist signed up for open studio event' do
         expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
       end
     end
@@ -106,8 +106,8 @@ describe OpenStudiosPresenter do
     context 'when the user is an artist that is signed up for th os' do
       let(:user) { create(:artist, doing_open_studios: true) }
 
-      it 'shows "Artist OS Info" when current_user is an artist signed up for open studio event' do
-        expect(subject.register_for_open_studio_button_text).to eq('Artist OS Info')
+      it 'shows "Artist Registration" when current_user is an artist signed up for open studio event' do
+        expect(subject.register_for_open_studio_button_text).to eq('Artist Registration')
       end
     end
   end


### PR DESCRIPTION
Problem
-------

> Now that the button is always on again, I can see the "Artist OS Info" on the promo page less clear.

https://www.pivotaltracker.com/story/show/177260902

Solution
--------

Make the button say "Artist Registration" always