### PR TITLE
Art piece navigation breaks when studio is indy [177294826]

### DIFF
--- a/app/webpack/js/services/json_api.js
+++ b/app/webpack/js/services/json_api.js
@@ -33,7 +33,7 @@ export const jsonApi = {
   },
   studios: {
     get: (id) => {
-      const resp = get(`/api/v2/studios/${id}.json`);
+      const resp = get(`/api/v2/studios/${id || 0}.json`);
       return resp.then((data) => {
         return new Studio(data.data, data.included);
       });

--- a/app/webpack/js/services/json_api.test.js
+++ b/app/webpack/js/services/json_api.test.js
@@ -120,6 +120,24 @@ describe("jsonApi", () => {
           })
         );
       });
+      it("calls for studio 0 if the value is null", async () => {
+        await jsonApi.studios.get(null);
+        expect(jQuery.ajax).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "/api/v2/studios/0.json",
+            method: "get",
+          })
+        );
+      });
+      it("calls for studio 0 if the value is undefined", async () => {
+        await jsonApi.studios.get();
+        expect(jQuery.ajax).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "/api/v2/studios/0.json",
+            method: "get",
+          })
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Problem
-------

The artpiece page breaks if the studio is independent.

With our new json_api serializers, we were not converting null to 0
and the backend was returning a 400 causing the rest of the rendering to
fail.

Solution
---------

Integerize the id from the front so we call for studio/0.json and the
backend knows to return the 'independent studio' record.