### PR TITLE
Style the special event schedule checkboxes

### DIFF
--- a/app/webpack/js/app/helpers.js
+++ b/app/webpack/js/app/helpers.js
@@ -6,6 +6,10 @@ export function isFunction(func) {
   return Boolean(func && typeof func === "function");
 }
 
+export const isEmpty = (obj) =>
+  [Object, Array].includes((obj || {}).constructor) &&
+  !Object.entries(obj || {}).length;
+
 export function each(data, cb) {
   if (Array.isArray(data)) {
     data.forEach(cb);
@@ -55,15 +59,25 @@ export function some(arr, comparator = identity) {
   if (!arr) {
     return false;
   }
+  return arr.some(comparator);
+}
+
+export function all(arr, comparator = identity) {
+  if (!arr) {
+    return false;
+  }
+  if (isEmpty(arr)) {
+    return false;
+  }
   const len = arr.length;
   let ii = 0;
   for (; ii < len; ++ii) {
     const v = arr[ii];
-    if (comparator(v)) {
-      return true;
+    if (!comparator(v)) {
+      return false;
     }
   }
-  return false;
+  return true;
 }
 
 export function omit(obj, keysToOmit) {

--- a/app/webpack/js/app/helpers.test.js
+++ b/app/webpack/js/app/helpers.test.js
@@ -117,6 +117,7 @@ describe("helpers", () => {
   describe("some", () => {
     it("returns true if any of the entries test true with javascript truthy", () => {
       expect(helpers.some([null, undefined, 0, ""])).toBeFalsy();
+      expect(helpers.some([false, false])).toBeFalsy();
       expect(helpers.some([null, undefined, []])).toBeTruthy();
       expect(helpers.some([1])).toBeTruthy();
     });
@@ -135,6 +136,32 @@ describe("helpers", () => {
     it("returns false if the input is null/undefined", () => {
       expect(helpers.some(null)).toBeFalsy();
       expect(helpers.some(undefined)).toBeFalsy();
+    });
+  });
+
+  describe("all", () => {
+    it("returns true if all of the entries test true with javascript truthy", () => {
+      expect(helpers.all([null, undefined, 0, ""])).toBeFalsy();
+      expect(helpers.all([null, undefined, []])).toBeFalsy();
+      expect(helpers.all([true, false])).toBeFalsy();
+      expect(helpers.all([true, true])).toBeTruthy();
+      expect(helpers.all([1])).toBeTruthy();
+    });
+
+    it("returns false for an empty array", () => {
+      expect(helpers.all([])).toBeFalsy();
+    });
+
+    it("honors a comparator function", () => {
+      const comparator = (v) => v === "this";
+      expect(helpers.all([null, undefined, 0, ""], comparator)).toBeFalsy();
+      expect(helpers.all([null, "this", 0, ""], comparator)).toBeFalsy();
+      expect(helpers.all(["this", "this"], comparator)).toBeTruthy();
+    });
+
+    it("returns false if the input is null/undefined", () => {
+      expect(helpers.all(null)).toBeFalsy();
+      expect(helpers.all(undefined)).toBeFalsy();
     });
   });
 
@@ -178,5 +205,17 @@ describe("helpers", () => {
     it("works without a default", () => {
       expect(helpers.dig(testObject, "a.b")).toBeUndefined();
     });
+  });
+
+  describe("isEmpty", () => {
+    it.each([null, "", {}, []])("returns true for '%s'", (emptyThing) => {
+      expect(helpers.isEmpty(emptyThing)).toBeTruthy();
+    });
+    it.each(["a", { a: 1 }, [null, 0]])(
+      "returns false for '%s'",
+      (fullThing) => {
+        expect(helpers.isEmpty(fullThing)).toBeFalsy();
+      }
+    );
   });
 });

--- a/app/webpack/reactjs/components/mau_checkbox_field.tsx
+++ b/app/webpack/reactjs/components/mau_checkbox_field.tsx
@@ -9,6 +9,7 @@ interface MauCheckboxFieldProps {
   hint?: string | JSX.Element;
   id?: string;
   classes?: string;
+  disabled?: boolean;
 }
 
 export const MauCheckboxField: FC<MauCheckboxFieldProps> = ({
@@ -17,13 +18,19 @@ export const MauCheckboxField: FC<MauCheckboxFieldProps> = ({
   label,
   hint,
   classes,
+  disabled,
 }) => {
   return (
     <div
       className={cx("boolean input optional", { [classes]: Boolean(classes) })}
     >
       <label htmlFor={name}>
-        <Field type="checkbox" name={name} id={id ?? name} />
+        <Field
+          type="checkbox"
+          name={name}
+          id={id ?? name}
+          disabled={disabled}
+        />
         <span>{label}</span>
       </label>
       <MauHint>{hint}</MauHint>

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -117,9 +117,7 @@ describe("OpenStudiosInfoForm", () => {
       });
 
       it("shows schedule checkboxes for each time slot", () => {
-        const scheduleSection = screen.getByTestId(
-          "open-studios-info-form__special-event-schedule"
-        );
+        const scheduleSection = screen.getByTestId("special-event-schedule");
         const inputs = Array.from(
           scheduleSection.getElementsByTagName("INPUT")
         );
@@ -131,9 +129,7 @@ describe("OpenStudiosInfoForm", () => {
         // RTL to hear me. It also gets tricky with timezones because the browser on
         // CircleCI is in a different timezone and therefore generates a different label.
         // In any case...
-        const scheduleSection = screen.getByTestId(
-          "open-studios-info-form__special-event-schedule"
-        );
+        const scheduleSection = screen.getByTestId("special-event-schedule");
         const inputs = Array.from(
           scheduleSection.getElementsByTagName("INPUT")
         );

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -74,7 +74,7 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
     <section id="open-studios-info-form">
       <h3 className="open-studios-info-form__title">Your Open Studios Info</h3>
       <Formik initialValues={denullify(participant)} onSubmit={handleSubmit}>
-        {({ dirty, isSubmitting }) => {
+        {({ dirty, isSubmitting, values }) => {
           return (
             <Form
               className="open-studios-info-form"
@@ -110,6 +110,7 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
                     />
                     <SpecialEventScheduleFields
                       specialEvent={event.specialEvent}
+                      disabled={!values.videoConferenceUrl}
                     />
                   </div>
                   <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--youtube-url">

--- a/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/special_event_schedule_fields.test.tsx
@@ -1,12 +1,80 @@
-import { DateTime } from "luxon";
+import { all } from "@js/app/helpers";
+import { renderInForm } from "@reactjs/test/renderers";
+import { screen } from "@testing-library/react";
+import React from "react";
 
-import { parseTimeSlot } from "./special_event_schedule_fields";
+import { SpecialEventScheduleFields } from "./special_event_schedule_fields";
 
-describe("parseTimeSlot", () => {
-  it("returns timeslots parsed into date times", () => {
-    expect(parseTimeSlot("1605135600::1605139200")).toEqual({
-      start: DateTime.fromSeconds(1605135600),
-      end: DateTime.fromSeconds(1605139200),
+/* describe("parseTimeSlot", () => {
+ *   it("returns timeslots parsed into date times", () => {
+ *     expect(parseTimeSlot("1605135600::1605139200")).toEqual({
+ *       start: DateTime.fromSeconds(1605135600),
+ *       end: DateTime.fromSeconds(1605139200),
+ *     });
+ *   });
+ * });
+
+ *  */
+
+describe("SpecialEventScheduleFields", () => {
+  let rendered;
+  const event = {
+    dateRange: "Nov 12-13 2020",
+    timeSlots: [
+      "1605128400::1605132000",
+      "1605132000::1605135600",
+      "1605215000::1605218800",
+      "1605218800::1605222400",
+    ],
+  };
+
+  describe("when the component is enabled", () => {
+    beforeEach(() => {
+      rendered = renderInForm(
+        <SpecialEventScheduleFields specialEvent={event} />
+      );
+    });
+
+    it("shows the intro message", () => {
+      expect(
+        screen.queryByText("I will be open for virtual visitors", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("shows check boxes grouped by date", () => {
+      expect(
+        screen.queryByText("Wednesday, 11/11/20 PST", { exact: false })
+      ).toBeInTheDocument();
+      expect(screen.queryByText("1:00 PM - 2:00 PM")).toBeInTheDocument();
+      expect(screen.queryByText("2:00 PM - 3:00 PM")).toBeInTheDocument();
+
+      expect(
+        screen.queryByText("Thursday, 11/12/20 PST", { exact: false })
+      ).toBeInTheDocument();
+      expect(screen.queryByText("1:03 PM - 2:06 PM")).toBeInTheDocument();
+      expect(screen.queryByText("2:06 PM - 3:06 PM")).toBeInTheDocument();
+    });
+
+    it("renders checkboxes enabled", () => {
+      const cbs = Array.from(rendered.container.getElementsByTagName("INPUT"));
+
+      expect(cbs).toHaveLength(4);
+      expect(all(cbs, (cb) => !cb.disabled)).toBeTruthy();
+    });
+  });
+  describe("when the component is disabled", () => {
+    beforeEach(() => {
+      rendered = renderInForm(
+        <SpecialEventScheduleFields specialEvent={event} disabled={true} />
+      );
+    });
+    it("renders checkboxes disabled", () => {
+      const cbs = Array.from(rendered.container.getElementsByTagName("INPUT"));
+
+      expect(cbs).toHaveLength(4);
+      expect(all(cbs, (cb) => cb.disabled)).toBeTruthy();
     });
   });
 });

--- a/app/webpack/stylesheets/gto/components/index.scss
+++ b/app/webpack/stylesheets/gto/components/index.scss
@@ -1,4 +1,5 @@
+@import "./confirm_modal";
 @import "./credits_modal";
 @import "./mailer";
 @import "./open_studios_info_form";
-@import "./confirm_modal";
+@import "./special_event_schedule";

--- a/app/webpack/stylesheets/gto/components/open_studios_info_form.scss
+++ b/app/webpack/stylesheets/gto/components/open_studios_info_form.scss
@@ -11,7 +11,7 @@
   }
   h4 {
     border-bottom: 1px solid $lightbluegray;
-    margin-bottom: 10px;
+    margin-bottom: 12px;
     padding-bottom: 8px;
   }
 
@@ -24,7 +24,7 @@
   font-weight: $font-weight-light;
   font-size: 1.1rem;
   text-transform: uppercase;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .open-studios-info-form__subtitle {
@@ -33,7 +33,7 @@
 }
 
 .open-studios-info-form__input {
-  margin-bottom: 10px;
+  margin-bottom: 16px;
 }
 
 .open-studios-info-form__input--checkbox {
@@ -52,7 +52,7 @@
   @media screen and (max-width: $screen-xs-max) {
     flex-direction: column;
     & > * {
-      margin-bottom: 10px;
+      margin-bottom: 8px;
       &.confirm-modal__trigger > button {
         width: 100%;
       }
@@ -60,9 +60,16 @@
   }
 }
 
+.open-studios-info-form__special-event-schedule__day-title {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+}
+
 .open-studios-info-form__special-event-schedule__label {
   @include form-label;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .open-studios-info-form__special-event-schedule__timeslot {

--- a/app/webpack/stylesheets/gto/components/special_event_schedule.scss
+++ b/app/webpack/stylesheets/gto/components/special_event_schedule.scss
@@ -1,0 +1,24 @@
+.special-event-schedule__day-title {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+}
+
+.special-event-schedule__label {
+  @include form-label;
+  margin-bottom: 8px;
+}
+
+.special-event-schedule__timeslot {
+  margin-bottom: 8px;
+}
+
+.special-event-schedule {
+  opacity: 1;
+  @include transition(opacity 0.3s ease-in-out);
+}
+
+.special-event-schedule--disabled {
+  opacity: 0.4;
+}

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -163,7 +163,7 @@ When('I hover over a cms section') do
 end
 
 When('I select every other time slot for the video conference schedule') do
-  within '.open-studios-info-form__special-event-schedule' do
+  within '.special-event-schedule' do
     page.all("[type='checkbox']").each_slice(2) do |cb|
       cb[0].click
     end
@@ -171,7 +171,7 @@ When('I select every other time slot for the video conference schedule') do
 end
 
 When('I see every other time slot for the video conference schedule has been checked') do
-  within '.open-studios-info-form__special-event-schedule' do
+  within '.special-event-schedule' do
     page.all("[type='checkbox']").each_slice(2) do |cb|
       expect(cb[0].checked?).to eq true
       expect(cb[1].checked?).to eq false


### PR DESCRIPTION
Problem
--------

The checkboxes could use a little organization so it's clearer.

https://www.pivotaltracker.com/story/show/177260682

Solution
--------

Group them by date and show them in columns.  Also push all the times
into PST (no matter what your browser timezone is).  Finally, disable
checkboxes if the 'conference url' is not populated.

Screencap
-----------

Notice, we do *not* clear out the checkboxes if you add a conference url and then remove it.

So the pages that consume this data will need to do something like 
```
if videoConferenceUrl && schedule... then
   do whatever
```
![specialevent](https://user-images.githubusercontent.com/427380/111024996-d6fe6600-839e-11eb-8419-ce131917a6b7.gif)
