### PR TITLE
Better handling of the promo banner

### DIFF
--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -54,6 +54,10 @@ class OpenStudiosEventPresenter < ViewPresenter
     @model = os_event
   end
 
+  def empty?
+    !@model
+  end
+
   def num_participants
     model.open_studios_participants.count
   end

--- a/app/views/main/_virtual_os_banner.html.slim
+++ b/app/views/main/_virtual_os_banner.html.slim
@@ -1,3 +1,5 @@
+/ expects open_studios_event object
+
 .sampler__promo.js-sampler__promo.mod-virtual-os
-  = link_to open_studios_path
+  = link_to open_studios_path, title: "Mission Open Studios #{open_studios_event.date_range_with_year}"
     | &nbsp;

--- a/app/views/main/index.html.slim
+++ b/app/views/main/index.html.slim
@@ -1,7 +1,9 @@
 #main_thumbs
   #sampler.js-sampler data-seed=@seed
-    / = render "default_banner"
-    = render partial: 'virtual_os_banner', locals: {open_studios_event: current_open_studios}
+    - if current_open_studios.empty?
+      = render "default_banner"
+    - else
+      = render partial: 'virtual_os_banner', locals: {open_studios_event: current_open_studios}
     #js-scroll-load-more.scroll-load-more
       .scroll-load-more__contents
         = mau_spinner

--- a/app/views/main/index.html.slim
+++ b/app/views/main/index.html.slim
@@ -1,7 +1,7 @@
 #main_thumbs
   #sampler.js-sampler data-seed=@seed
     / = render "default_banner"
-    = render 'virtual_os_banner'
+    = render partial: 'virtual_os_banner', locals: {open_studios_event: current_open_studios}
     #js-scroll-load-more.scroll-load-more
       .scroll-load-more__contents
         = mau_spinner

--- a/app/webpack/stylesheets/gto/_sampler.scss
+++ b/app/webpack/stylesheets/gto/_sampler.scss
@@ -11,12 +11,12 @@
     width: 40%;
     float: left;
     &.mod-virtual-os {
-      background-image: url("../../images/virtual-open-studios-banner.svg");
-      @include background-cover;
       a {
-        height: 100%;
+        height: 250px;
         width: 100%;
         display: block;
+        background-image: url("../../images/virtual-open-studios-banner.svg");
+        @include background-cover;
       }
     }
   }


### PR DESCRIPTION
Problem
-------

The promo banner got rushed out and it didn't have a title or
any seo/accessibiity stuff.

Solution
---------

Take the time to get a title on the link for the promo banner.
Also give the promo thing a little gutter space so it looks like it
fits with all the other images.


<img width="825" alt="Screen Shot 2021-03-13 at 9 56 38 AM" src="https://user-images.githubusercontent.com/427380/111039372-9fb1a880-83e2-11eb-8164-5540632c75a3.png">
