### PR TITLE
Add mixin for a common light bottom border

### DIFF
--- a/app/webpack/stylesheets/gto/_forms.scss
+++ b/app/webpack/stylesheets/gto/_forms.scss
@@ -80,9 +80,6 @@ tr.error-msg {
   label {
     @include form-label;
   }
-  select {
-    height: 35px;
-  }
   select,
   input {
     padding: 10px;
@@ -92,6 +89,10 @@ tr.error-msg {
     @media screen and (max-width: $screen-xs-max) {
       width: $mobile-input-width;
     }
+  }
+  select {
+    padding: 0 10px;
+    height: 37px;
   }
   .input {
     &.boolean input {

--- a/app/webpack/stylesheets/gto/_layout.scss
+++ b/app/webpack/stylesheets/gto/_layout.scss
@@ -1,6 +1,8 @@
 /** settings that affect layout/geometry */
 @import "variables";
 @import "mau-mixins";
+@import "gto/gto-mixins";
+
 html,
 body {
   height: 100%;
@@ -145,7 +147,7 @@ body {
 .pure-g {
   .header {
     &.bordered-header {
-      border-bottom: 1px solid $x-light-gray;
+      @include light-bottom-border;
       margin: 1em 0 0.83em;
       padding-bottom: 10px;
       display: flex;
@@ -174,7 +176,7 @@ body {
     }
     .title {
       font-weight: $font-weight-light;
-      border-bottom: 1px solid $x-light-gray;
+      @include light-bottom-border;
       padding-bottom: 8px;
       padding-left: 2px;
     }

--- a/app/webpack/stylesheets/gto/artists/_artists.scss
+++ b/app/webpack/stylesheets/gto/artists/_artists.scss
@@ -296,7 +296,7 @@
       }
     }
     .header {
-      border-bottom: 1px solid $x-light-gray;
+      @include light-bottom-border;
       padding: 4px 2px;
       margin-bottom: 8px;
       @include all-caps-label;

--- a/app/webpack/stylesheets/gto/gto-mixins.scss
+++ b/app/webpack/stylesheets/gto/gto-mixins.scss
@@ -8,6 +8,10 @@
     list-style: circle;
   }
 }
+@mixin light-bottom-border {
+  border-bottom: 1px solid $x-light-gray;
+}
+
 @mixin light-gray-button {
   @include transition(all 0.33s ease-in-out);
   @include round-corners(2px);
@@ -89,8 +93,7 @@
   }
   @media screen and (min-width: $screen-md-max) {
     .filter {
-      border-bottom: 1px solid $x-light-gray;
-      margin-top: 22px;
+      @include light-bottom-border margin-top: 22px;
       margin-left: -20px;
       padding-left: 20px;
       padding-bottom: 4px;
@@ -103,8 +106,7 @@
   text-transform: uppercase;
   font-size: 0.8rem;
   margin-bottom: 8px;
-  border-bottom: 1px solid $x-light-gray;
-  @include ellipsis;
+  @include light-bottom-border @include ellipsis;
 }
 
 @mixin popup-elements {
@@ -127,7 +129,7 @@
     padding: 10px 15px 4px;
     margin-bottom: 12px;
     position: relative;
-    border-bottom: 1px solid $x-light-gray;
+    @include light-bottom-border;
   }
   .popup-text {
     line-height: 1.1rem;

--- a/app/webpack/stylesheets/gto/studios/_studios.scss
+++ b/app/webpack/stylesheets/gto/studios/_studios.scss
@@ -81,7 +81,7 @@
       text-align: center;
       margin-bottom: 30px;
       .header {
-        border-bottom: 1px solid $x-light-gray;
+        @include light-bottom-border;
         padding: 4px 2px;
         text-transform: uppercase;
         font-size: 0.8rem;

--- a/app/webpack/stylesheets/gto_admin/roles.scss
+++ b/app/webpack/stylesheets/gto_admin/roles.scss
@@ -1,8 +1,10 @@
 @import "colors";
+@import "gto/gto-mixins";
+
 .admin.roles {
   .role-container {
     h4 {
-      border-bottom: 1px solid $x-light-gray;
+      @include light-bottom-border;
     }
 
     ul.role_members {

--- a/app/webpack/stylesheets/gto_admin/tests/react_styleguide.scss
+++ b/app/webpack/stylesheets/gto_admin/tests/react_styleguide.scss
@@ -1,14 +1,16 @@
+@import "gto/gto-mixins";
+
 .react-styleguide-page {
 }
 
 .react-styleguide__header {
   padding-bottom: 20px;
   margin-bottom: 20px;
-  border-bottom: 1px solid $x-light-gray;
+  @include light-bottom-border;
 }
 
 .react-styleguide__component {
-  border-bottom: 1px solid $x-light-gray;
+  @include light-bottom-border;
   margin-bottom: 30px;
 }
 


### PR DESCRIPTION
Problem
-------

we had `border-bottom 1px $x-light-gray` defined in a bunch of places.

This is a common border bottom.

Solution
--------

Make it a mixin for more reusability