### PR TITLE
ARG TIMEZONES! Ensure special event date/times are in event time zone

### DIFF
--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -56,7 +56,16 @@ module Admin
                                                  :special_event_start_date,
                                                  :special_event_start_time,
                                                  :special_event_end_date,
-                                                 :special_event_end_time)
+                                                 :special_event_end_time).tap do |prms|
+        # coerce/force dates to be in Conf.event_time_zone
+        Time.use_zone(Conf.event_time_zone) do
+          %i[start_date end_date special_event_start_date special_event_end_date].each do |fld|
+            next unless prms[fld]
+
+            prms[fld] = Time.zone.parse(prms[fld])
+          end
+        end
+      end
     end
   end
 end

--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -52,6 +52,11 @@ class OpenStudiosEvent < ApplicationRecord
   def generate_special_event_time_slots
     return if (changed & SPECIAL_EVENT_FIELDS).blank?
 
+    if [special_event_start_date, special_event_end_date, special_event_start_time, special_event_end_time].any?(&:blank?)
+      self.special_event_time_slots = []
+      return
+    end
+
     number_of_days = (special_event_end_date.to_date - special_event_start_date.to_date).to_i
     time_slots = Array.new(number_of_days + 1) do |day_offset|
       date = special_event_start_date + day_offset.days

--- a/spec/controllers/admin/open_studios_events_controller_spec.rb
+++ b/spec/controllers/admin/open_studios_events_controller_spec.rb
@@ -44,6 +44,25 @@ describe Admin::OpenStudiosEventsController do
         expect(event.reload.start_time).to eq 'whatever'
       end
     end
+
+    context 'with special event data' do
+      before do
+        post :update,
+             params: { id: event.id,
+                       open_studios_event: { special_event_start_date: '2020-10-10', special_event_end_date: '2020-10-11', start_date: '2020-10-1',
+                                             end_date: '2020-10-15' } }
+      end
+
+      it 'returns success' do
+        expect(response).to redirect_to admin_open_studios_events_path
+      end
+
+      it 'creates a new open studios event' do
+        event.reload
+        expect(event.special_event_start_date).to eq Time.zone.parse('2020-10-10 00:00:00.000000000 -0700')
+        expect(event.special_event_end_date).to eq Time.zone.parse('2020-10-11 00:00:00.000000000 -0700')
+      end
+    end
   end
 
   describe '#clear_cache' do

--- a/spec/models/open_studios_event_spec.rb
+++ b/spec/models/open_studios_event_spec.rb
@@ -119,12 +119,21 @@ describe OpenStudiosEvent do
         end
       end
 
-      it 'removes time slots if we delete special event data' do
+      it 'removes time slots if we delete start/end dates from special event data' do
         os = create(:open_studios_event, :with_special_event)
         expect(os.special_event_time_slots).to have_at_least(1).slot
-        os.special_event_start_time = nil
+        os.special_event_start_date = nil
+        os.special_event_end_date = nil
+        os.save!
+        os.reload
+        expect(os.special_event_time_slots).to eq []
+      end
+
+      it 'removes time slots if we delete end time from special event data' do
+        os = create(:open_studios_event, :with_special_event)
+        expect(os.special_event_time_slots).to have_at_least(1).slot
         os.special_event_end_time = nil
-        os.save
+        os.save!
         os.reload
         expect(os.special_event_time_slots).to eq []
       end


### PR DESCRIPTION
Problem
--------

Timezones!  We're sending date strings from the server and not doing any
time zone interpretation.

https://www.pivotaltracker.com/story/show/177331037
https://www.pivotaltracker.com/story/show/177331045

Solution
--------

For special event start and end dates we really care about the timezone
because we use that to compute the timeslots.  Let's make sure we put
them in the right timezone when we start.

Changes
-------

* Coerce incoming dates to pst before we put them in the database
* when editing times, if we can't generate new timeslots, blank them out