### PR TITLE
Improve input focus styling so you can see what's going on

### DIFF
--- a/app/webpack/stylesheets/gto/_cms_documents.scss
+++ b/app/webpack/stylesheets/gto/_cms_documents.scss
@@ -1,4 +1,6 @@
 @import "colors";
+@import "gto/gto-mixins";
+
 .section.markdown.editable {
   position: relative;
   .edit_indicator {
@@ -19,7 +21,7 @@
       right: 20px;
       top: 20px;
       background-color: rgba(200, 220, 220, 0.6);
-      border: 1px solid $x-light-gray;
+      @include light-border;
       padding: 10px;
     }
   }

--- a/app/webpack/stylesheets/gto/_forms.scss
+++ b/app/webpack/stylesheets/gto/_forms.scss
@@ -84,10 +84,17 @@ tr.error-msg {
   input {
     padding: 10px;
     border-radius: 2px;
-    border: 1px solid $x-light-gray;
+    @include light-border;
     width: $input-width;
     @media screen and (max-width: $screen-xs-max) {
       width: $mobile-input-width;
+    }
+    &:focus + span,
+    &:checked + span {
+      color: $darkbluegray;
+    }
+    &:focus {
+      border-color: $gto_dark_teal;
     }
   }
   select {

--- a/app/webpack/stylesheets/gto/components/open_studios_info_form.scss
+++ b/app/webpack/stylesheets/gto/components/open_studios_info_form.scss
@@ -14,10 +14,6 @@
     margin-bottom: 12px;
     padding-bottom: 8px;
   }
-
-  label input:checked + span {
-    color: $darkbluegray;
-  }
 }
 
 .open-studios-info-form__title {

--- a/app/webpack/stylesheets/gto/gto-mixins.scss
+++ b/app/webpack/stylesheets/gto/gto-mixins.scss
@@ -8,6 +8,11 @@
     list-style: circle;
   }
 }
+
+@mixin light-border {
+  border: 1px solid $x-light-gray;
+}
+
 @mixin light-bottom-border {
   border-bottom: 1px solid $x-light-gray;
 }


### PR DESCRIPTION
Problem
--------

Our inputs leave much to be desired with regard to focus status.

https://www.pivotaltracker.com/story/show/177330939

Solution
---------

* Add a dark border when you are focused on an input.
* Change check box font color to dark when you're focused (or it's
  checked)

Screencap
-----------

![focus highlights](https://user-images.githubusercontent.com/427380/111082731-001a1600-84c7-11eb-940a-96cd64affcac.gif)
