### PR TITLE
Update nginx conf to support multiple SSL domains

### DIFF
--- a/devops/nginx-config/mau.rcode5.com
+++ b/devops/nginx-config/mau.rcode5.com
@@ -1,66 +1,81 @@
 upstream app {
-    # Path to Puma SOCK file, as defined previously
-    server unix:///home/deploy/deployed/mau/shared/tmp/sockets/puma.sock fail_timeout=0;
+  #server unix:/tmp/unicorn.mau.sock fail_timeout=0;
+
+  # Path to Puma SOCK file, as defined previously
+  server unix:/home/deploy/deployed/mau/shared/tmp/sockets/puma.sock fail_timeout=0;
+
 }
 
 server {
-    listen 80 default_server deferred;
-    server_name mau.rcode5.com;
-    root /home/deploy/deployed/mau/current/public;
+  server_name mau.rcode5.com openstudios.mau.rcode5.com;
+  root /home/deploy/deployed/mau/current/public;
 
-    #For Basic Auth
-    auth_basic "Restricted";
-    auth_basic_user_file /etc/nginx/.htpasswd;
+  #For Basic Auth
+  auth_basic "Restricted";
+  auth_basic_user_file /etc/nginx/.htpasswd;
 
-    location ~ (\.php|.aspx|.asp|myadmin) {
-        return 404;
+  location ~ (\.php|.aspx|.asp|myadmin) {
+    return 404;
+  }
+
+  location = /version {
+       auth_basic off;
+       allow all; # Allow all to see content 
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://app;
+  }
+
+  location = /status {
+       auth_basic off;
+       allow all; # Allow all to see content 
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://app;
+  }
+
+  # location / {
+  #   if (-f $document_root/maintenance.html) {
+  #     return 503;
+  #   }
+  # }
+
+  # error_page 503 @maintenance;
+  # location @maintenance {
+  #   if ($uri !~ ^/images/) {
+  #     rewrite ^(.*)$ /maintenance.html break;
+  #   }
+  # }
+
+  location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    if ($request_filename ~* \.(eot|woff|woff2|ttf|svg)$) {
+      add_header Access-Control-Allow-Origin *;
     }
-
-    location = /version {
-        auth_basic off;
-        allow all; # Allow all to see content
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_redirect off;
-        proxy_pass http://app;
+    if ($request_filename ~* \.woff2$) {
+      add_header Content-Type "application/woff2";
     }
+  }
 
-    location = /status {
-        auth_basic off;
-        allow all; # Allow all to see content
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_redirect off;
-        proxy_pass http://app;
-    }
+  try_files $uri/index.html $uri @app;
+  location @app {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://app;
 
-    location ^~ /assets/ {
-        gzip_static on;
-        expires max;
-        add_header Cache-Control public;
-        if ($request_filename ~* \.(eot|woff|woff2|ttf|svg)$) {
-            add_header Access-Control-Allow-Origin *;
-        }
-        if ($request_filename ~* \.woff2$) {
-            add_header Content-Type "application/woff2";
-        }
-    }
+  }
 
-    try_files $uri/index.html $uri @app;
-    location @app {
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_redirect off;
-        proxy_pass http://app;
-
-    }
-
-    error_page 500 502 503 504 /500.html;
-    client_max_body_size 20M;
-    keepalive_timeout 10;
+  error_page 500 502 503 504 /500.html;
+  client_max_body_size 20M;
+  keepalive_timeout 10;
 
     listen 443 ssl; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/mau.rcode5.com/fullchain.pem; # managed by Certbot
@@ -71,21 +86,33 @@ server {
     # Redirect non-https traffic to https
     if ($scheme != "https") {
         return 301 https://$host$request_uri;
-        } # managed by Certbot
+    } # managed by Certbot
 
-    # location / {
-    #   if (-f $document_root/maintenance.html) {
-    #     return 503;
-    #   }
-    # }
+}
 
-    # error_page 503 @maintenance;
-    # location @maintenance {
-    #   if ($uri !~ ^/images/) {
-    #     rewrite ^(.*)$ /maintenance.html break;
-    #   }
-    # }
+server {
+    if ($host = mau.rcode5.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
 
+
+  listen 80 default_server deferred;
+  server_name mau.rcode5.com;
+    return 404; # managed by Certbot
+
+
+}
+
+
+server {
+    if ($host = openstudios.mau.rcode5.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+  server_name openstudios.mau.rcode5.com;
+    listen 80;
+    return 404; # managed by Certbot
 
 
 }

--- a/devops/nginx-config/missionartists
+++ b/devops/nginx-config/missionartists
@@ -1,6 +1,6 @@
 upstream app {
     # Path to Puma SOCK file, as defined previously
-    server unix:///home/deploy/deployed/mau/shared/tmp/sockets/puma.sock fail_timeout=0;
+    server unix:/home/deploy/deployed/mau/shared/tmp/sockets/puma.sock fail_timeout=0;
 }
 
 server {
@@ -19,10 +19,11 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
+
 }
 
 server {
-    server_name www.missionartists.org;
+    server_name www.missionartists.org openstudios.missionartists.org;
     root /home/deploy/deployed/mau/current/public;
 
     location ~ (\.php|.aspx|.asp|myadmin) {
@@ -91,6 +92,7 @@ server {
         } # managed by Certbot
 
 
+
 }
 
 
@@ -116,6 +118,40 @@ server {
         listen 80 default_server deferred;
         server_name www.missionartists.org;
         return 404; # managed by Certbot
+
+
+}
+
+
+server {
+    if ($host = www.missionartists.org) {
+        return 301 https://$host$request_uri;
+        } # managed by Certbot
+    server_name openstudios.missionartists.org; # managed by Certbot
+        return 404; # managed by Certbot
+
+
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/www.missionartists.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/www.missionartists.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+server {
+    if ($host = openstudios.missionartists.org) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+
+
+        listen 80  ;
+    server_name openstudios.missionartists.org;
+    return 404; # managed by Certbot
 
 
 }


### PR DESCRIPTION
First, on each server server, I ran
```
# on mau.rcode5.com
certbot run --cert-name <site> -d openstudios.mau.rcode5.com -d mau.rcode5.com

# on www.missionartists.org
certbot run --cert-name <site> -d openstudios.missionartists.org -d www.missionartists.org -d missionartists.org
```

This updates the certs to support multiple domains (with a single cert).  These commands reported that they
were updating the existing cert to include the new `openstudios` subdomains

This updated the nginx configs slightly and those updates are included here in this PR into our deployment directory.


The configuration on `mau.rcode5.com` had a lot of hand tweaking before I figured out what needed to happen.  As you can see the mods on missionartists' conf was basically what Certbot added in the update cert step.

