### PR TITLE
Update open studios artist show page [176881854]

### DIFF
--- a/app/helpers/open_studios_participants_helper.rb
+++ b/app/helpers/open_studios_participants_helper.rb
@@ -8,4 +8,8 @@ module OpenStudiosParticipantsHelper
       end_time.in_time_zone(Conf.event_time_zone).to_s(:time_with_zone),
     ].join
   end
+
+  def split_email(email)
+    %i[name domain].zip(email.split('@')).to_h
+  end
 end

--- a/app/presenters/art_piece_presenter.rb
+++ b/app/presenters/art_piece_presenter.rb
@@ -1,4 +1,5 @@
 class ArtPiecePresenter < ViewPresenter
+  include ActionView::Helpers::NumberHelper
   attr_reader :model
 
   delegate :id, :year, :photo, :medium, :artist, :title, :updated_at, :to_param, to: :model
@@ -53,5 +54,17 @@ class ArtPiecePresenter < ViewPresenter
 
   def artist_path
     url_helpers.artist_path(artist)
+  end
+
+  def sold?
+    !!model.sold_at
+  end
+
+  def price?
+    model.price.present?
+  end
+
+  def price
+    number_to_currency(model.price)
   end
 end

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -3,6 +3,7 @@
 
 class ArtistPresenter < UserPresenter
   include ApplicationHelper
+  include ActionView::Helpers::NumberHelper
 
   ALLOWED_LINKS = User.stored_attributes[:links]
 
@@ -24,6 +25,7 @@ class ArtistPresenter < UserPresenter
            :max_pieces,
            :os_participation,
            :pending?,
+           :phone,
            :slug,
            :studio,
            :studio_id,
@@ -172,6 +174,17 @@ class ArtistPresenter < UserPresenter
 
   def self.keyed_links
     (User.stored_attributes[:links] || []).select { |attr| ALLOWED_LINKS.include? attr }
+  end
+
+  def open_studios_info
+    return unless artist.current_open_studios_participant
+
+    @open_studios_info ||=
+      OpenStudiosParticipantPresenter.new(artist.current_open_studios_participant)
+  end
+
+  def phone_for_display
+    number_to_phone(artist.phone)
   end
 
   private

--- a/app/presenters/open_studios_participant_presenter.rb
+++ b/app/presenters/open_studios_participant_presenter.rb
@@ -1,0 +1,35 @@
+class OpenStudiosParticipantPresenter
+  include OpenStudiosParticipantsHelper
+  attr_reader :participant
+
+  delegate :video_conference_time_slots, :youtube_url, :show_email?, :shop_url, to: :participant
+  def initialize(open_studios_participant)
+    @participant = open_studios_participant
+  end
+
+  def show_phone?
+    participant.show_phone_number? && artist.phone.present?
+  end
+
+  def conference_time_slots
+    video_conference_time_slots.map { |s| display_time_slot(s) }
+  end
+
+  def has_shop? # rubocop:disable Naming/PredicateName
+    participant.shop_url.present?
+  end
+
+  def has_scheduled_conference? # rubocop:disable Naming/PredicateName
+    participant.video_conference_time_slots.present? && participant.video_conference_url.present?
+  end
+
+  def has_youtube? # rubocop:disable Naming/PredicateName
+    participant.youtube_url.present?
+  end
+
+  private
+
+  def artist
+    @artist ||= participant.user
+  end
+end

--- a/app/views/open_studios_subdomain/_container_header.slim
+++ b/app/views/open_studios_subdomain/_container_header.slim
@@ -3,4 +3,5 @@
     .container-header__logo title="Mission Artists" class="#{Date.today.month == 6 ? 'container-header__logo--' : ''}"
     h2.container-header__mau-title.pure-u-sm-hidden Mission Artists
 
-  h1.container-header__title Open Studios Catalog
+  h1.container-header__title
+    = content_for(:open_studios_catalog_title) || "Open Studios Catalog"

--- a/app/views/open_studios_subdomain/artists/_art.html.slim
+++ b/app/views/open_studios_subdomain/artists/_art.html.slim
@@ -6,7 +6,8 @@
     .desc
       .name
         = art_piece.title
-      .name
-        span.byline> by
-        '
-        = art_piece.artist_name
+      - if art_piece.price?
+        .name
+          span.art-card__price class=class_names({"art-card__price--sold": art_piece.sold?}) = art_piece.price
+          - if art_piece.sold?
+            span.art-card__sold Sold

--- a/app/views/open_studios_subdomain/artists/_art.html.slim
+++ b/app/views/open_studios_subdomain/artists/_art.html.slim
@@ -1,5 +1,5 @@
 / expects art_piece as art_piece_presenter
-- class_overrides ||= class_names(%w(pure-u-1-1 pure-u-sm-1-2 pure-u-md-1-3 pure-u-lg-1-4 pure-u-xl-1-5))
+- class_overrides ||= class_names(%w(pure-u-1-1 pure-u-sm-1-1 pure-u-md-1-2 pure-u-lg-1-3 pure-u-xl-1-4))
 .art-card class=class_overrides
   .art-piece
     .image style=background_image_style(art_piece.path)

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -9,7 +9,7 @@
       - if info.has_shop?
         .open-studios-artist__details__subsection.open-studios-artist__details__shop-url
           .open-studios-artist__details__shop-url--title
-            = link_to "Shop", info.shop_url
+            = link_to "My Shop", info.shop_url
       - if info.has_scheduled_conference?
         .open-studios-artist__details__subsection.open-studios-artist__details__conference-url
           .open-studios-artist__details__conference-url--title

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -4,14 +4,14 @@
   .pure-u-1-1.omega
     section.open-studios-artist__profile-image
       = render '/common/artist_profile_image', artist: artist
-      .open-studios-artist__profile-name = @artist.get_name
+      .open-studios-artist__profile-name.pure-u-sm-hidden = @artist.get_name
     section.open-studios-artist__details
       - if info.has_shop?
-        .open-studios-artist__details__entry.open-studios-artist__details__shop-url
+        .open-studios-artist__details__subsection.open-studios-artist__details__shop-url
           .open-studios-artist__details__shop-url--title
             = link_to "Shop", info.shop_url
       - if info.has_scheduled_conference?
-        .open-studios-artist__details__entry.open-studios-artist__details__conference-url
+        .open-studios-artist__details__subsection.open-studios-artist__details__conference-url
           .open-studios-artist__details__conference-url--title
             | Schedule
           .open-studios-artist__details__conference-url--timeslots
@@ -20,14 +20,16 @@
           .open-studios-artist__details__conference-url--footnote
             | The conference link will be available here.  Please come back and visit.
       - if info.has_youtube?
-        .open-studios-artist__details__entry.open-studios-artist__details__youtube-url
+        .open-studios-artist__details__subsection.open-studios-artist__details__youtube-url
           .open-studios-artist__details__youtube-url--title
             | Artist's Video
           .open-studios-artist__details__youtube-url--link
             = link_to info.youtube_url, info.youtube_url, target: "_blank"
-      - if info.show_email?
-        .open-studios-artist__details__entry.open-studios-artist__details__email
-          = react_component id:"mailer", component:"Mailer", props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
-      - if info.show_phone?
-        .open-studios-artist__details__entry.open-studios-artist__details__phone
-          = link_to artist.phone_for_display, "tel:#{artist.phone}"
+      - if info.show_email? || info.show_phone?
+        .open-studios-artist__details__subsection
+          - if info.show_email?
+            .open-studios-artist__details__email
+              = react_component id:"mailer", component:"Mailer", props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
+          - if info.show_phone?
+            .open-studios-artist__details__phone
+              = link_to artist.phone_for_display, "tel:#{artist.phone}"

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -1,0 +1,33 @@
+/ expects artist as artist_presenter
+- info = artist.open_studios_info
+.pure-g.open-studios-artist__info
+  .pure-u-1-1.omega
+    section.open-studios-artist__profile-image
+      = render '/common/artist_profile_image', artist: artist
+      .open-studios-artist__profile-name = @artist.get_name
+    section.open-studios-artist__details
+      - if info.has_shop?
+        .open-studios-artist__details__entry.open-studios-artist__details__shop-url
+          .open-studios-artist__details__shop-url--title
+            = link_to "Shop", info.shop_url
+      - if info.has_scheduled_conference?
+        .open-studios-artist__details__entry.open-studios-artist__details__conference-url
+          .open-studios-artist__details__conference-url--title
+            | Schedule
+          .open-studios-artist__details__conference-url--timeslots
+            - info.conference_time_slots.each do |ts|
+              .timeslot = ts
+          .open-studios-artist__details__conference-url--footnote
+            | The conference link will be available here.  Please come back and visit.
+      - if info.has_youtube?
+        .open-studios-artist__details__entry.open-studios-artist__details__youtube-url
+          .open-studios-artist__details__youtube-url--title
+            | Artist's Video
+          .open-studios-artist__details__youtube-url--link
+            = link_to info.youtube_url, info.youtube_url, target: "_blank"
+      - if info.show_email?
+        .open-studios-artist__details__entry.open-studios-artist__details__email
+          = react_component id:"mailer", component:"Mailer", props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
+      - if info.show_phone?
+        .open-studios-artist__details__entry.open-studios-artist__details__phone
+          = link_to artist.phone_for_display, "tel:#{artist.phone}"

--- a/app/views/open_studios_subdomain/artists/show.html.slim
+++ b/app/views/open_studios_subdomain/artists/show.html.slim
@@ -1,17 +1,15 @@
-.pure-g.sticky-header
-  .pure-u-1-1.header.padded-content
-    h2.title
-      | Artist:
-      span.artist__name< #{@artist.get_name}
-      - if @artist.doing_open_studios?
-        = link_to open_studios_url(subdomain: ""), title: "I'm doing Open Studios" do
-          .os-violator
+- content_for :open_studios_catalog_title do
+  = @artist.get_name
+
 .pure-g.alpha.omega
-  .pure-u-1-1.pure-u-sm-2-3.pure-u-md-1-2.pure-u-lg-3-5#art
+  .pure-u-1-1.pure-u-sm-1-2.pure-u-md-1-3.pure-u-lg-1-5
+    = render "/open_studios_subdomain/artists/info", artist: @artist
+
+  .pure-u-1-1.pure-u-sm-1-2.pure-u-md-2-3.pure-u-lg-4-5
     .pure-g
       .pure-u-1-1
       - if @artist.art_pieces.present?
-        = render partial: "/open_studios_subdomain/artists/art", collection: @artist.art_pieces, as: :art_piece, locals: { class_overrides: "pure-u-1-1 pure-u-lg-1-2 pure-u-xl-1-3"}
+        = render partial: "/open_studios_subdomain/artists/art", collection: @artist.art_pieces, as: :art_piece
       - else
         .pure-u-1-1.empty
           h4 This artist has no art to show.

--- a/app/webpack/js/services/mailer.service.test.ts
+++ b/app/webpack/js/services/mailer.service.test.ts
@@ -5,16 +5,19 @@ import { mailToLink } from "./mailer.service";
 
 describe("mau.services.mailerService", () => {
   describe("#mailToLink", () => {
+
     it("returns the right email link with all things specified", () => {
       expect(mailToLink("the subject", "email_user", "email_domain")).toEqual(
-        "mailto:www@email_domain?subject=the%20subject"
+        "mailto:email_user@email_domain?subject=the%20subject"
       );
     });
+
     it("falls back to missionartists.org if no domain is specified", () => {
       expect(mailToLink("the subject", "email_user")).toEqual(
         "mailto:www@missionartists.org?subject=the%20subject"
       );
     });
+
     it("falls back to www if the user is not info, www, feedback, or mau", () => {
       expect(mailToLink("the subject", "email_user")).toEqual(
         "mailto:www@missionartists.org?subject=the%20subject"
@@ -32,5 +35,15 @@ describe("mau.services.mailerService", () => {
         "mailto:www@missionartists.org?subject=the%20subject"
       );
     });
+
+    it("does not fall back if domain is included", () => {
+      expect(mailToLink("the subject", "email_user", "example.com")).toEqual(
+        "mailto:email_user@example.com?subject=the%20subject"
+      );
+      expect(mailToLink("the subject", "info", "somewhere.com")).toEqual(
+        "mailto:info@somewhere.com?subject=the%20subject"
+      );
+    });
+
   });
 });

--- a/app/webpack/js/services/mailer.service.test.ts
+++ b/app/webpack/js/services/mailer.service.test.ts
@@ -5,7 +5,6 @@ import { mailToLink } from "./mailer.service";
 
 describe("mau.services.mailerService", () => {
   describe("#mailToLink", () => {
-
     it("returns the right email link with all things specified", () => {
       expect(mailToLink("the subject", "email_user", "email_domain")).toEqual(
         "mailto:email_user@email_domain?subject=the%20subject"
@@ -44,6 +43,5 @@ describe("mau.services.mailerService", () => {
         "mailto:info@somewhere.com?subject=the%20subject"
       );
     });
-
   });
 });

--- a/app/webpack/js/services/mailer.service.ts
+++ b/app/webpack/js/services/mailer.service.ts
@@ -1,9 +1,9 @@
 const ALLOWED_EMAILS = ["www", "info", "feedback", "mau"];
 
-export const mailToLink = function(
+export const mailToLink = function (
   subject: string,
   user?: string,
-  domain?: string,
+  domain?: string
 ) {
   if (!domain) {
     domain = domain || "missionartists.org";

--- a/app/webpack/js/services/mailer.service.ts
+++ b/app/webpack/js/services/mailer.service.ts
@@ -1,13 +1,16 @@
 const ALLOWED_EMAILS = ["www", "info", "feedback", "mau"];
-export const mailToLink = function (
+
+export const mailToLink = function(
   subject: string,
   user?: string,
-  domain?: string
+  domain?: string,
 ) {
-  if (!user || ALLOWED_EMAILS.indexOf(user) == -1) {
-    user = "www";
+  if (!domain) {
+    domain = domain || "missionartists.org";
+    if (!user || ALLOWED_EMAILS.indexOf(user) == -1) {
+      user = "www";
+    }
   }
-  domain = domain || "missionartists.org";
   const lnk = `mailto:${user}@${domain}`;
   if (!subject) {
     return lnk;

--- a/app/webpack/reactjs/components/mailer.tsx
+++ b/app/webpack/reactjs/components/mailer.tsx
@@ -5,13 +5,12 @@ type MailerProps = {
   domain?: string;
   name?: string;
   subject?: string;
-  external?: boolean;
   text: string;
 };
 
-export const Mailer: FC<MailerProps> = ({ subject, name, domain, text, external}) => {
+export const Mailer: FC<MailerProps> = ({ subject, name, domain, text }) => {
   const setLocation: void = (_ev) => {
-    window.location.assign(mailToLink(subject, name, domain, external));
+    window.location.assign(mailToLink(subject, name, domain));
   };
   return (
     <a className="mailer-link" onClick={setLocation}>

--- a/app/webpack/reactjs/components/mailer.tsx
+++ b/app/webpack/reactjs/components/mailer.tsx
@@ -5,12 +5,13 @@ type MailerProps = {
   domain?: string;
   name?: string;
   subject?: string;
+  external?: boolean;
   text: string;
 };
 
-export const Mailer: FC<MailerProps> = ({ subject, name, domain, text }) => {
+export const Mailer: FC<MailerProps> = ({ subject, name, domain, text, external}) => {
   const setLocation: void = (_ev) => {
-    window.location.assign(mailToLink(subject, name, domain));
+    window.location.assign(mailToLink(subject, name, domain, external));
   };
   return (
     <a className="mailer-link" onClick={setLocation}>

--- a/app/webpack/stylesheets/_mixins.scss
+++ b/app/webpack/stylesheets/_mixins.scss
@@ -337,7 +337,7 @@ $default_rounded_amount: 3px;
 @mixin all-caps-label {
   text-transform: uppercase;
   font-size: 0.8rem;
-  font-weight: bold;
+  font-weight: $font-weight-bold;
 }
 @mixin card-description {
   padding: 6px;

--- a/app/webpack/stylesheets/gto/media.scss
+++ b/app/webpack/stylesheets/gto/media.scss
@@ -14,7 +14,7 @@
     padding: 2px 10px;
   }
   .header h4.title {
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     text-transform: uppercase;
     font-size: 0.8rem;
     margin-bottom: 8px;

--- a/app/webpack/stylesheets/gto/studios/_studios.scss
+++ b/app/webpack/stylesheets/gto/studios/_studios.scss
@@ -84,7 +84,7 @@
         padding: 4px 2px;
         text-transform: uppercase;
         font-size: 0.8rem;
-        font-weight: bold;
+        font-weight: $font-weight-bold;
         margin-bottom: 8px;
       }
     }

--- a/app/webpack/stylesheets/open_studios_subdomain/_art_card.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_art_card.scss
@@ -1,0 +1,13 @@
+.art-card {
+}
+.art-card__price--sold {
+  text-decoration: line-through;
+}
+.art-card__sold {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: $gto_yellow;
+  position: absolute;
+  right: 6px;
+  bottom: 2px;
+}

--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -1,0 +1,48 @@
+.open-studios-artist__title {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0.83rem;
+}
+.open-studios-artist__info {
+  text-align: center;
+}
+.open-studios-artist__profile-image {
+  padding-top: 10px;
+}
+.open-studios-artist__profile-name {
+  margin: 15px;
+  font-size: 1.4rem;
+}
+
+.open-studios-artist__details__entry {
+  margin-bottom: 24px;
+  &:first-child {
+    margin-top: 24px;
+  }
+}
+
+.open-studios-artist__details__conference-url--title {
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.open-studios-artist__details__conference-url--timeslots {
+  margin-bottom: 8px;
+  > .timeslot {
+    margin-bottom: 4px;
+  }
+}
+.open-studios-artist__details__youtube-url--link {
+  @include ellipsis;
+}
+.open-studios-artist__details__youtube-url--title {
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.open-studios-artist__details__shop-url--title {
+  text-transform: uppercase;
+}
+.open-studios-artist__details__conference-url--footnote {
+  font-size: 0.8rem;
+}

--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -1,3 +1,4 @@
+@import "mixins";
 .open-studios-artist__title {
   text-align: center;
   margin-top: 0;
@@ -15,15 +16,15 @@
   font-size: 1.4rem;
 }
 
-.open-studios-artist__details__entry {
-  margin-bottom: 24px;
-  &:first-child {
-    margin-top: 24px;
+.open-studios-artist__details__subsection {
+  padding: 24px 0px;
+  @include light-bottom-border;
+  &:last-child {
+    border: none;
   }
 }
 
 .open-studios-artist__details__conference-url--title {
-  text-transform: uppercase;
   margin-bottom: 8px;
 }
 
@@ -37,11 +38,11 @@
   @include ellipsis;
 }
 .open-studios-artist__details__youtube-url--title {
-  text-transform: uppercase;
   margin-bottom: 8px;
 }
 .open-studios-artist__details__shop-url--title {
   text-transform: uppercase;
+  font-weight: $font-weight-bold;
 }
 .open-studios-artist__details__conference-url--footnote {
   font-size: 0.8rem;

--- a/app/webpack/stylesheets/open_studios_subdomain/application.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/application.scss
@@ -3,4 +3,5 @@
 #open_studios_subdomain__layout {
   @import "_layout.scss";
   @import "_container_header.scss";
+  @import "_open_studios_artist.scss";
 }

--- a/app/webpack/stylesheets/open_studios_subdomain/application.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/application.scss
@@ -4,4 +4,5 @@
   @import "_layout.scss";
   @import "_container_header.scss";
   @import "_open_studios_artist.scss";
+  @import "_art_card";
 }

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -6,6 +6,8 @@ Feature: Open Studios Catalog
 
 Background:
   Given there are open studios artists with art in the system
+  And the current open studios event has a special event
+  And participating artists have filled out their open studios info form
   And there is open studios catalog cms content
   And I'm logged out
 
@@ -16,3 +18,34 @@ Scenario:
 
   When I click on the first artist's card
   Then I see that artist's open studios pieces
+  And I see the artist's name in the header title
+  And I see the summary information about that artists open studios events
+
+
+Scenario: An artist sees their own pages
+  Given the following artists with art are in the system:
+    | login      | email              | number_of_art_pieces |
+    | artist     | artist@example.com |                    1 |
+  When I login as "artist"
+  And I visit the open studios page
+  And I click on "Artist Registration"
+
+  Then I see my profile edit form
+
+  When I click on "Yes - Register Me"
+  And I click on "Yes" in the ".ReactModal__Content"
+  Then I see the open studios info form
+  And I see the "events" profile panel is open
+
+  When I fill in the "#open_studios_info_form" form with:
+    | shopUrl        | videoConferenceUrl |
+    | https://www.rcode5.com  | https://www.youtube.com/watch?v=2SyPyBHJmiI |
+  And I select every other time slot for the video conference schedule
+  And I check "showEmail"
+  And I check "showPhoneNumber"
+  And I click on "Save"
+  Then I see a flash notice "Got it"
+
+  When I visit my open studios catalog page
+  And I see the summary information about that artists open studios events
+  And I see my video conference schedule

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -98,6 +98,24 @@ Given /there are open studios artists with art in the system/ do
   end
 end
 
+And /participating artists have filled out their open studios info form/ do
+  @artists.each do |a|
+    next unless a.current_open_studios_participant
+
+    participant = a.current_open_studios_participant
+    schedule = participant.open_studios_event.special_event_time_slots.index_with do |_timeslot|
+      true
+    end
+    participant.update({
+                         video_conference_schedule: schedule,
+                         show_email: true,
+                         show_phone_number: true,
+                         shop_url: 'http://myshop.com',
+                         youtube_url: 'http://m.youtube.com/watch?v=abcdefg',
+                       })
+  end
+end
+
 Given /there is open studios cms content( in the system)?$/ do |_|
   args = { page: :main_openstudios, section: :preview_reception }
   @os_reception_content ||= (CmsDocument.where(args).first || FactoryBot.create(:cms_document, args))

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -184,7 +184,7 @@ end
 Then('I see the summary information about that artists open studios events') do
   within('.open-studios-artist__info') do
     expect(page).to have_content @artist.get_name
-    expect(page).to have_link 'Shop', href: @artist.current_open_studios_participant.shop_url
+    expect(page).to have_link 'My Shop', href: @artist.current_open_studios_participant.shop_url
     expect(page).to have_content @artist.email
     expect(page).to have_content @artist.current_open_studios_participant.youtube_url
   end
@@ -197,7 +197,7 @@ Then('I see the artist\'s name in the header title') do
 end
 
 When('I see my video conference schedule') do
-  expect(page).to have_content('SCHEDULE')
+  expect(page).to have_content('Schedule')
   expect(page.all('.open-studios-artist__details__conference-url--timeslots .timeslot'))
     .to have(@artist.current_open_studios_participant.video_conference_time_slots.length).entries
 end

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -180,3 +180,24 @@ When('I see every other time slot for the video conference schedule has been che
     end
   end
 end
+
+Then('I see the summary information about that artists open studios events') do
+  within('.open-studios-artist__info') do
+    expect(page).to have_content @artist.get_name
+    expect(page).to have_link 'Shop', href: @artist.current_open_studios_participant.shop_url
+    expect(page).to have_content @artist.email
+    expect(page).to have_content @artist.current_open_studios_participant.youtube_url
+  end
+end
+
+Then('I see the artist\'s name in the header title') do
+  within('.container-header') do
+    expect(page).to have_content @artist.get_name
+  end
+end
+
+When('I see my video conference schedule') do
+  expect(page).to have_content('SCHEDULE')
+  expect(page.all('.open-studios-artist__details__conference-url--timeslots .timeslot'))
+    .to have(@artist.current_open_studios_participant.video_conference_time_slots.length).entries
+end

--- a/features/step_definitions/openstudios_subdomain.rb
+++ b/features/step_definitions/openstudios_subdomain.rb
@@ -20,3 +20,7 @@ Then('I see the open studios catalog cms message') do
     expect(page).to have_content('this is going to rock (catalog summary)')
   end
 end
+
+When /I visit my open studios catalog page/ do
+  step %(I visit "#{artist_path(@artist)} in the catalog)
+end

--- a/spec/factories/open_studios_participants.rb
+++ b/spec/factories/open_studios_participants.rb
@@ -8,5 +8,15 @@ FactoryBot.define do
     youtube_url { 'http://m.youtube.com/watch?v=abcdefg' }
     show_email { [true, false].sample }
     show_phone_number { [true, false].sample }
+
+    trait :with_conference_schedule do
+      open_studios_event { build(:open_studios_event, :with_special_event) }
+      after(:create) do |participant, _context|
+        schedule = participant.open_studios_event.special_event_time_slots.index_with do |_timeslot|
+          true
+        end
+        participant.video_conference_schedule = schedule
+      end
+    end
   end
 end

--- a/spec/helpers/open_studios_participants_helper_spec.rb
+++ b/spec/helpers/open_studios_participants_helper_spec.rb
@@ -1,19 +1,28 @@
 require 'rails_helper'
 
 describe OpenStudiosParticipantsHelper do
-  def make_1hour_timeslot(t) # rubocop:disable Naming/MethodParameterName
-    [t, t + 1.hour].map(&:to_i).join('::')
+  describe '.display_time_slot' do
+    def make_1hour_timeslot(t) # rubocop:disable Naming/MethodParameterName
+      [t, t + 1.hour].map(&:to_i).join('::')
+    end
+
+    Time.use_zone(Conf.event_time_zone) do
+      test_scenarios = [
+        [Time.zone.local(2021, 5, 6, 1), '05/06/2021 1:00am - 2:00am PDT'],
+        [Time.zone.local(2021, 10, 12, 14), '10/12/2021 2:00pm - 3:00pm PDT'],
+      ]
+      test_scenarios.each do |scenario|
+        it "returns #{scenario.last} for the date #{scenario.first}" do
+          expect(helper.display_time_slot(make_1hour_timeslot(scenario.first))).to eq scenario.last
+        end
+      end
+    end
   end
 
-  Time.use_zone(Conf.event_time_zone) do
-    test_scenarios = [
-      [Time.zone.local(2021, 5, 6, 1), '05/06/2021 1:00am - 2:00am PDT'],
-      [Time.zone.local(2021, 10, 12, 14), '10/12/2021 2:00pm - 3:00pm PDT'],
-    ]
-    test_scenarios.each do |scenario|
-      it "returns #{scenario.last} for the date #{scenario.first}" do
-        expect(helper.display_time_slot(make_1hour_timeslot(scenario.first))).to eq scenario.last
-      end
+  describe '.split_email' do
+    it 'returns name and domain from email' do
+      expect(helper.split_email('jon@whatever.com')).to eq({ name: 'jon', domain: 'whatever.com' })
+      expect(helper.split_email('zzz+103@long.super.tld.example.com')).to eq({ name: 'zzz+103', domain: 'long.super.tld.example.com' })
     end
   end
 end

--- a/spec/presenters/artist_presenter_spec.rb
+++ b/spec/presenters/artist_presenter_spec.rb
@@ -24,6 +24,13 @@ describe ArtistPresenter do
       expect(presenter.current_open_studios_participant).to eq artist.current_open_studios_participant
     end
 
+    context '#phone' do
+      it 'returns a formatted phone number' do
+        artist.phone = '1234567777'
+        expect(presenter.phone).to eq '123-456-7777'
+      end
+    end
+
     it 'has a good map div for google maps' do
       map_info = subject.map_info
       html = Capybara::Node::Simple.new(map_info)

--- a/spec/presenters/artist_presenter_spec.rb
+++ b/spec/presenters/artist_presenter_spec.rb
@@ -24,10 +24,10 @@ describe ArtistPresenter do
       expect(presenter.current_open_studios_participant).to eq artist.current_open_studios_participant
     end
 
-    context '#phone' do
+    context '#phone_for_display' do
       it 'returns a formatted phone number' do
         artist.phone = '1234567777'
-        expect(presenter.phone).to eq '123-456-7777'
+        expect(presenter.phone_for_display).to eq '123-456-7777'
       end
     end
 

--- a/spec/presenters/open_studios_participant_presenter_spec.rb
+++ b/spec/presenters/open_studios_participant_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe OpenStudiosParticipantPresenter do
+  let(:participant) { create(:open_studios_participant) }
+  subject(:presenter) { described_class.new(participant) }
+
+  before do
+    freeze_time
+    travel_to Time.zone.local(2021, 4, 1)
+  end
+
+  it 'delegates a bunch of stuff' do
+    %i[youtube_url shop_url].each do |f|
+      expect(presenter.send(f)).to eq participant.send(f)
+    end
+  end
+
+  context 'when a participant is doing everything' do
+    let(:user) do
+      create(:user, phone: '14155559999')
+    end
+    let(:participant) do
+      create(:open_studios_participant,
+             :with_conference_schedule,
+             user: user,
+             show_email: true,
+             show_phone_number: true)
+    end
+
+    its(:show_phone?) { is_expected.to eq true }
+    its(:has_shop?) { is_expected.to eq true }
+    its(:has_youtube?) { is_expected.to eq true }
+    its(:has_scheduled_conference?) { is_expected.to eq true }
+    it 'time slots are formatted' do
+      expect(subject.conference_time_slots).to include '04/01/2021 1:00pm - 2:00pm PDT'
+    end
+  end
+
+  context 'when a participant is doing nothing' do
+    let(:participant) do
+      create(:open_studios_participant,
+             shop_url: nil,
+             youtube_url: nil,
+             video_conference_url: nil,
+             show_email: false,
+             show_phone_number: false)
+    end
+
+    its(:show_phone?) { is_expected.to eq false }
+    its(:has_shop?) { is_expected.to eq false }
+    its(:has_youtube?) { is_expected.to eq false }
+    its(:has_scheduled_conference?) { is_expected.to eq false }
+  end
+end


### PR DESCRIPTION
First pass at an artist's show page for open studios catalog.

In this PR, we add art and open studios participant information to the
open studios artists page.

https://www.pivotaltracker.com/story/show/176881854

Screenshots
------------

![Screen Shot 2021-03-20 at 3 22 01 PM](https://user-images.githubusercontent.com/427380/111887154-5b994780-8990-11eb-9136-1cdddc8ae49b.png)

![Screen Shot 2021-03-20 at 3 22 20 PM](https://user-images.githubusercontent.com/427380/111887158-5dfba180-8990-11eb-890b-05bc9bfb1af8.png)
![Screen Shot 2021-03-20 at 3 23 25 PM](https://user-images.githubusercontent.com/427380/111887159-5f2cce80-8990-11eb-8d9f-c785f38320ad.png)
![Screen Shot 2021-03-20 at 3 23 34 PM](https://user-images.githubusercontent.com/427380/111887160-5f2cce80-8990-11eb-92ab-c2bedbd91474.png)
![Screen Shot 2021-03-20 at 3 23 43 PM](https://user-images.githubusercontent.com/427380/111887161-5fc56500-8990-11eb-91ac-d237a81be169.png)

Updated label to include price instead of name and treatment for 'sold'

![Screen Shot 2021-03-20 at 4 39 09 PM](https://user-images.githubusercontent.com/427380/111888559-d9625080-899a-11eb-84fb-10373ba6bced.png)

