### PR TITLE
Add embedded youtube player for artists [177234531]

### DIFF
--- a/app/helpers/you_tube_helper.rb
+++ b/app/helpers/you_tube_helper.rb
@@ -1,0 +1,17 @@
+module YouTubeHelper
+  YOUTUBE_URL_REGEX = %r{\?(v=|embed/|v/?)(\S+)?$}.freeze
+
+  def embed_you_tube(url, title: '', height: 200, width: '100%')
+    matches = YOUTUBE_URL_REGEX.match(url)
+    return '' unless matches
+
+    embed_url = "https://www.youtube.com/embed/#{matches[2]}"
+    tag.iframe({ width: width,
+                 height: height,
+                 src: embed_url,
+                 title: title,
+                 frameborder: 0,
+                 allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+                 allowfullscreen: true }) {}
+  end
+end

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -21,10 +21,7 @@
             | The conference link will be available here.  Please come back and visit.
       - if info.has_youtube?
         .open-studios-artist__details__subsection.open-studios-artist__details__youtube-url
-          .open-studios-artist__details__youtube-url--title
-            | Artist's Video
-          .open-studios-artist__details__youtube-url--link
-            = link_to info.youtube_url, info.youtube_url, target: "_blank"
+          = embed_you_tube(info.youtube_url)
       - if info.show_email? || info.show_phone?
         .open-studios-artist__details__subsection
           - if info.show_email?

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -20,6 +20,7 @@ Scenario:
   Then I see that artist's open studios pieces
   And I see the artist's name in the header title
   And I see the summary information about that artists open studios events
+  And I see the artist's open studios you tube embed video
 
 
 Scenario: An artist sees their own pages

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -186,7 +186,13 @@ Then('I see the summary information about that artists open studios events') do
     expect(page).to have_content @artist.get_name
     expect(page).to have_link 'My Shop', href: @artist.current_open_studios_participant.shop_url
     expect(page).to have_content @artist.email
-    expect(page).to have_content @artist.current_open_studios_participant.youtube_url
+  end
+end
+
+And "I see the artist's open studios you tube embed video" do
+  within('.open-studios-artist__info') do
+    iframe = page.find('iframe')
+    expect(iframe[:src]).to include @artist.current_open_studios_participant.youtube_url.split('=').last
   end
 end
 

--- a/spec/helpers/you_tube_helper_spec.rb
+++ b/spec/helpers/you_tube_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe YouTubeHelper do
+  it 'renders a you tube embed iframe if the url is youtubey' do
+    iframe = helper.embed_you_tube('https://www.youtube.com/watch?v=biwW1Zx2KDU')
+    node = Nokogiri::HTML::DocumentFragment.parse(iframe)
+    rendered = node.css('iframe')
+    expect(rendered.attribute('src').value).to eq 'https://www.youtube.com/embed/biwW1Zx2KDU'
+    expect(rendered.attribute('width').value).to eq '100%'
+    expect(rendered.attribute('height').value).to eq '200'
+    expect(rendered.attribute('title').value).to be_empty
+  end
+
+  it 'renders nothing if the url is not youtubey' do
+    iframe = helper.embed_you_tube('https://www.youtube.com/not-a-video')
+    expect(iframe).to be_empty
+  end
+
+  it 'honors title, width and height args' do
+    iframe = helper.embed_you_tube('https://www.youtube.com/watch?v=biwW1Zx2KDU', height: 40, width: 20, title: 'whatever')
+    node = Nokogiri::HTML::DocumentFragment.parse(iframe)
+    rendered = node.css('iframe')
+    expect(rendered.attribute('src').value).to eq 'https://www.youtube.com/embed/biwW1Zx2KDU'
+    expect(rendered.attribute('width').value).to eq '20'
+    expect(rendered.attribute('height').value).to eq '40'
+    expect(rendered.attribute('title').value).to eq 'whatever'
+  end
+end


### PR DESCRIPTION
Problem
-------

We'd like a youtube embedded video in the sidebar

https://www.pivotaltracker.com/story/show/177234531

Solution
--------

make it so

Add YouTubeHelper with `embed_you_tube` method that returns the properly formatted iframe.

Screenshot
------------
![Screen Shot 2021-03-20 at 5 35 53 PM](https://user-images.githubusercontent.com/427380/111890001-c9e70580-89a2-11eb-8a4b-c4b79f958d4e.png)
