### PR TITLE
Header on open studios was getting scrolled over by content

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
@@ -9,6 +9,7 @@
   top: 0;
   left: 0;
   right: 0;
+  z-index: 50;
 }
 .container-header__brand {
   position: absolute;


### PR DESCRIPTION
Problem
-------

the Open Studios catalog header was not high enough (z-index) so as you
scrolled, content was going over the header.

Solution
--------

Move the header up (zindex).

Screenshot
-----------
![image](https://user-images.githubusercontent.com/427380/111890051-4974d480-89a3-11eb-9c90-974be85b0ae0.png)
