### PR TITLE
Style the Catalog page header on mobile and maybe on desktop as well

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
@@ -14,6 +14,19 @@
 .container-header__brand {
   display: flex;
   align-items: center;
+  position: absolute;
+  @media screen and (max-width: $screen-xs-max) {
+    position: relative;
+  }
+  .pure-u-sm-hidden {
+    @media screen and (max-width: $screen-md-max) {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: $screen-xs-max) {
+    position: relative;
+  }
 }
 .container-header__mau-title {
   padding-left: 5px;
@@ -23,13 +36,17 @@
 }
 .container-header__title {
   text-align: center;
-  margin: 0 0 8px 5px;
   flex: 1;
   font-size: 2em;
+  padding-bottom: 2px;
+  @include ellipsis;
+
   @media screen and (max-width: $screen-sm-max) {
+    font-size: 1.6em;
+  }
+  @media screen and (max-width: $screen-xs-max) {
     font-size: 1em;
   }
-  @include ellipsis;
 }
 .container-header__logo {
   background-image: url("../../images/yellow_sidebar_logo_gear_only.svg");

--- a/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
@@ -12,7 +12,6 @@
   z-index: 50;
 }
 .container-header__brand {
-  position: absolute;
   display: flex;
   align-items: center;
 }
@@ -24,8 +23,13 @@
 }
 .container-header__title {
   text-align: center;
-  margin: 0;
+  margin: 0 0 8px 5px;
   flex: 1;
+  font-size: 2em;
+  @media screen and (max-width: $screen-sm-max) {
+    font-size: 1em;
+  }
+  @include ellipsis;
 }
 .container-header__logo {
   background-image: url("../../images/yellow_sidebar_logo_gear_only.svg");


### PR DESCRIPTION
**Problem**

The Open Studio Header logo is overlapping with the title. 

**Solution**

1. Took out the `position: absolute" property from `.container-header__brand` 
1.  Decreased `.container-header__title ` font size for small screen sizes
1. Included `ellipsis` mixin for the title as well for long artist names