### PR TITLE
Prevent open studios routes from falling back [177334098]

### DIFF
--- a/app/controllers/open_studios_subdomain/error_controller.rb
+++ b/app/controllers/open_studios_subdomain/error_controller.rb
@@ -1,0 +1,7 @@
+module OpenStudiosSubdomain
+  class ErrorController < BaseOpenStudiosController
+    def index
+      render 'index', status: :bad_request
+    end
+  end
+end

--- a/app/views/open_studios_subdomain/error/index.slim
+++ b/app/views/open_studios_subdomain/error/index.slim
@@ -1,0 +1,14 @@
+.pure-g
+  .pure-u-1-1.f404
+    .oops oops... :(
+    .f404-container
+      p You have reached this page because you were trying to go somewhere on the site that doesn't exist or you don't have the proper permissions to do whatever you were trying to do.
+
+      - if flash[:error] && !flash[:error].empty?
+        p We think this is the reason you got here.
+        .error-msg
+          = flash[:error]
+      p
+        = "Try starting back at the "
+        '
+        = link_to("beginning", root_path)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   config.hosts << 'example.org'
   config.hosts << 'mau.local'
   config.hosts << 'openstudios.mau.local'
+  config.hosts << 'www.mau.local'
 end
 
 Rails.application.routes.default_url_options[:host] = ENVIRONMENT_HOST

--- a/config/openstudios_routes.rb
+++ b/config/openstudios_routes.rb
@@ -1,4 +1,5 @@
 scope module: 'open_studios_subdomain' do
   get '/', to: 'main#index'
   resources :artists, only: [:show], as: :artist_open_studios
+  get '*path' => 'error#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,170 +3,185 @@ Mau::Application.routes.draw do
     instance_eval(File.read(Rails.root.join('config/openstudios_routes.rb')))
   end
 
-  resources :media, only: %i[index show]
+  constraints subdomain: /^(www)?$/ do
+    resources :media, only: %i[index show]
 
-  resource :user_session, only: %i[new create destroy]
-  get '/logout' => 'user_sessions#destroy', as: :logout
-  get '/login' => 'user_sessions#new', as: :login
-  get '/sign_out' => 'user_sessions#destroy'
-  get '/sign_in' => 'user_sessions#new'
+    resource :user_session, only: %i[new create destroy]
+    get '/logout' => 'user_sessions#destroy', as: :logout
+    get '/login' => 'user_sessions#new', as: :login
+    get '/sign_out' => 'user_sessions#destroy'
+    get '/sign_in' => 'user_sessions#new'
 
-  resources :studios, only: %i[index show]
+    resources :studios, only: %i[index show]
 
-  resources :open_studios, only: [:index] do
-    collection do
-      get :register
+    resources :open_studios, only: [:index] do
+      collection do
+        get :register
+      end
     end
-  end
 
-  resource :catalog, only: [:show] do
-    member do
-      get :social
+    resource :catalog, only: [:show] do
+      member do
+        get :social
+      end
     end
-  end
 
-  resources :art_piece_tags, only: %i[index show] do
-    collection do
-      post :autosuggest
+    resources :art_piece_tags, only: %i[index show] do
+      collection do
+        post :autosuggest
+      end
     end
-  end
 
-  resources :feedbacks, only: %i[new create]
+    resources :feedbacks, only: %i[new create]
 
-  namespace :search do
-    match '/', action: 'index', via: %i[get post]
-  end
-
-  get '/register' => 'users#create', as: :register
-  get '/signup' => 'users#new', as: :signup
-  get '/activate/:activation_code' => 'users#activate', as: :activate
-  match 'reset/:reset_code' => 'users#reset', as: :reset, via: %i[get post]
-  post 'reset' => 'users#reset', as: :submit_reset
-
-  resources :users do
-    resources :favorites, only: %i[index create destroy]
-    resources :roles, only: [:destroy]
-    collection do
-      get :resend_activation
-      post :resend_activation
-      get :forgot
-      post :forgot
-      get :deactivate
-      get :whoami
+    namespace :search do
+      match '/', action: 'index', via: %i[get post]
     end
-    member do
-      put :change_password_update
-      patch :change_password_update
-    end
-  end
 
-  get '/mau_fans/:slug', to: redirect('/users/%{slug}'), as: :mau_fan
+    get '/register' => 'users#create', as: :register
+    get '/signup' => 'users#new', as: :signup
+    get '/activate/:activation_code' => 'users#activate', as: :activate
+    match 'reset/:reset_code' => 'users#reset', as: :reset, via: %i[get post]
+    post 'reset' => 'users#reset', as: :submit_reset
 
-  resources :art_pieces, only: %i[show edit update destroy]
-  resources :artists, except: %i[new create] do
-    resources :art_pieces, except: %i[index destroy edit update]
-    collection do
-      get :roster
-      post :destroyart
-      get :suggest
-      post :setarrangement
-      get :my_profile
-      get :register_for_current_open_studios
+    resources :users do
+      resources :favorites, only: %i[index create destroy]
+      resources :roles, only: [:destroy]
+      collection do
+        get :resend_activation
+        post :resend_activation
+        get :forgot
+        post :forgot
+        get :deactivate
+        get :whoami
+      end
+      member do
+        put :change_password_update
+        patch :change_password_update
+      end
     end
-    member do
+
+    get '/mau_fans/:slug', to: redirect('/users/%{slug}'), as: :mau_fan
+
+    resources :art_pieces, only: %i[show edit update destroy]
+    resources :artists, except: %i[new create] do
+      resources :art_pieces, except: %i[index destroy edit update]
+      collection do
+        get :roster
+        post :destroyart
+        get :suggest
+        post :setarrangement
+        get :my_profile
+        get :register_for_current_open_studios
+      end
+      member do
+        resources :favorites, only: [:index]
+        get :manage_art
+        post :notify_featured
+        post :update
+        # get :qrcode
+      end
+    end
+
+    resource :main, controller: :main, only: [] do
+      post :sampler
+    end
+
+    # uptime monitoring (newrelic)
+    get '/status' => 'main#status_page', as: :status
+    get '/venues' => 'main#venues', as: :venues
+    get '/privacy' => 'main#privacy', as: :privacy
+    get '/about' => 'main#about', as: :about
+    get '/contact' => 'main#contact', as: :contact
+    get '/version' => 'main#version', as: :version
+    get '/resources' => 'main#resources', as: :artist_resources
+    get '/error' => 'error#index', as: :error
+
+    namespace :admin do
+      resource :tests, only: [:show] do
+        get :custom_map
+        get :flash_test
+        get :qr
+        post :qr
+        get :social_icons
+        get :map
+        get :react_styleguide
+      end
+
+      get :os_status
+
+      resource :site_preferences, only: %i[edit update]
+      resources :mau_fans, only: [:index]
+      resource :palette, only: [:show]
+      resource :member_emails, only: [:show]
+
+      namespace :stats do
+        get :art_pieces_count_histogram
+        get :artists_per_day
+        get :art_pieces_per_day
+        get :favorites_per_day
+        get :user_visits_per_day
+        get :os_signups
+      end
+
+      match '/discount/markup' => 'discount#markup', as: :discount_processor, via: %i[get post]
+
+      resources :roles, except: [:show]
+      resources :cms_documents
+      resources :blacklist_domains, except: %i[show edit update]
+      resources :open_studios_events, only: %i[index edit new create update destroy] do
+        collection do
+          get :clear_cache
+        end
+      end
+      resources :email_lists, only: [:index] do
+        resources :emails, only: %i[index create new destroy]
+      end
+      resources :application_events, only: [:index]
       resources :favorites, only: [:index]
-      get :manage_art
-      post :notify_featured
-      post :update
-      # get :qrcode
+      resources :media, only: %i[index create new edit update destroy]
+      resources :artists, only: %i[index edit update] do
+        collection do
+          post :good_standing
+          post :bad_standing
+          post :pending
+          post :bulk_update, as: :bulk_update
+          get :purge
+        end
+        member do
+          post :suspend
+        end
+      end
+      resources :users, only: [:show]
+
+      resources :art_piece_tags, only: %i[index destroy] do
+        collection do
+          get :cleanup
+        end
+      end
+
+      resources :studios, only: %i[index new edit create update destroy] do
+        collection do
+          post :reorder
+        end
+        member do
+          post :unaffiliate_artist
+        end
+      end
     end
+
+    get '/admin' => 'admin#index', as: :admin
+
+    get '/sitemap.xml' => 'main#sitemap', as: :sitemap
+
+    # legacy urls
+    get '/main/openstudios', to: redirect('/open_studios')
+    get '/openstudios', to: redirect('/open_studios')
   end
 
-  resource :main, controller: :main, only: [] do
-    post :sampler
-  end
-
-  # uptime monitoring (newrelic)
-  get '/status' => 'main#status_page', as: :status
-  get '/venues' => 'main#venues', as: :venues
-  get '/privacy' => 'main#privacy', as: :privacy
-  get '/about' => 'main#about', as: :about
-  get '/contact' => 'main#contact', as: :contact
-  get '/version' => 'main#version', as: :version
-  get '/resources' => 'main#resources', as: :artist_resources
-  get '/error' => 'error#index', as: :error
-
+  # Routes available for all domains
   namespace :admin do
-    resource :tests, only: [:show] do
-      get :custom_map
-      get :flash_test
-      get :qr
-      post :qr
-      get :social_icons
-      get :map
-      get :react_styleguide
-    end
-
-    get :os_status
-
-    resource :site_preferences, only: %i[edit update]
-    resources :mau_fans, only: [:index]
-    resource :palette, only: [:show]
-    resource :member_emails, only: [:show]
-
-    namespace :stats do
-      get :art_pieces_count_histogram
-      get :artists_per_day
-      get :art_pieces_per_day
-      get :favorites_per_day
-      get :user_visits_per_day
-      get :os_signups
-    end
-
-    match '/discount/markup' => 'discount#markup', as: :discount_processor, via: %i[get post]
-
-    resources :roles, except: [:show]
     resources :cms_documents
-    resources :blacklist_domains, except: %i[show edit update]
-    resources :open_studios_events, only: %i[index edit new create update destroy] do
-      collection do
-        get :clear_cache
-      end
-    end
-    resources :email_lists, only: [:index] do
-      resources :emails, only: %i[index create new destroy]
-    end
-    resources :application_events, only: [:index]
-    resources :favorites, only: [:index]
-    resources :media, only: %i[index create new edit update destroy]
-    resources :artists, only: %i[index edit update] do
-      collection do
-        post :good_standing
-        post :bad_standing
-        post :pending
-        post :bulk_update, as: :bulk_update
-        get :purge
-      end
-      member do
-        post :suspend
-      end
-    end
-    resources :users, only: [:show]
-
-    resources :art_piece_tags, only: %i[index destroy] do
-      collection do
-        get :cleanup
-      end
-    end
-
-    resources :studios, only: %i[index new edit create update destroy] do
-      collection do
-        post :reorder
-      end
-      member do
-        post :unaffiliate_artist
-      end
-    end
   end
 
   namespace :api do
@@ -190,15 +205,6 @@ Mau::Application.routes.draw do
     end
   end
 
-  get '/admin' => 'admin#index', as: :admin
-
-  get '/sitemap.xml' => 'main#sitemap', as: :sitemap
-
-  # legacy urls
-  get '/main/openstudios', to: redirect('/open_studios')
-  get '/openstudios', to: redirect('/open_studios')
-
   get '*path' => 'error#index'
-
   root to: 'main#index'
 end


### PR DESCRIPTION
Problem
---------

Currently you can visit openstudios.mau/studios which is *not* supposed
to be a route in the catalog site.

https://www.pivotaltracker.com/story/show/177334098

Solution
---------

Add constraints for *all* routes so there is no fallback.

This is not *quite* true.  We've left `api/*` routes and
`admin/cms_documents/*`to be available on both sides of the house
because new react stuff uses the api endpoints and the we need
cms_documents editing in both places.

Also, add error controller so 404's in the subdomain use the subdomain
layout instead of the main.

Finally support `www` or '' for the main domain.

Screencap
-----------

Here is a walk through of `www.mau.local`, `mau.local` and `openstudios.mau.local` through pages that exist and that don't exist.

![subdomains](https://user-images.githubusercontent.com/427380/111949367-d2703680-8a9d-11eb-955b-8570d000e683.gif)
