### PR TITLE
Trim schedule date format so it fits better - artists' catalog show

### DIFF
--- a/app/helpers/open_studios_participants_helper.rb
+++ b/app/helpers/open_studios_participants_helper.rb
@@ -1,5 +1,25 @@
 module OpenStudiosParticipantsHelper
-  def display_time_slot(timeslot)
+  def display_time_slot(timeslot, compact: false)
+    method = compact ? :_compact_display_time_slot : :_long_form_display_time_slot
+    send(method, timeslot)
+  end
+
+  def split_email(email)
+    %i[name domain].zip(email.split('@')).to_h
+  end
+
+  def _compact_display_time_slot(timeslot)
+    start_time, end_time = OpenStudiosParticipant.parse_time_slot(timeslot)
+    [
+      start_time.to_s(:os_day),
+      ' ',
+      start_time.in_time_zone(Conf.event_time_zone).strftime('%l').strip,
+      '-',
+      end_time.in_time_zone(Conf.event_time_zone).strftime('%l%P %Z').strip,
+    ].join
+  end
+
+  def _long_form_display_time_slot(timeslot)
     start_time, end_time = OpenStudiosParticipant.parse_time_slot(timeslot)
     [
       start_time.to_s(:date_month_first),
@@ -7,9 +27,5 @@ module OpenStudiosParticipantsHelper
       ' -',
       end_time.in_time_zone(Conf.event_time_zone).to_s(:time_with_zone),
     ].join
-  end
-
-  def split_email(email)
-    %i[name domain].zip(email.split('@')).to_h
   end
 end

--- a/app/presenters/open_studios_participant_presenter.rb
+++ b/app/presenters/open_studios_participant_presenter.rb
@@ -12,7 +12,7 @@ class OpenStudiosParticipantPresenter
   end
 
   def conference_time_slots
-    video_conference_time_slots.map { |s| display_time_slot(s) }
+    video_conference_time_slots.map { |s| display_time_slot(s, compact: true) }
   end
 
   def has_shop? # rubocop:disable Naming/PredicateName

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -4,7 +4,7 @@
   .pure-u-1-1.omega
     section.open-studios-artist__profile-image
       = render '/common/artist_profile_image', artist: artist
-      .open-studios-artist__profile-name.pure-u-sm-hidden = @artist.get_name
+      .open-studios-artist__profile-name.pure-u-sm-hidden = artist.get_name
     section.open-studios-artist__details
       - if info.has_shop?
         .open-studios-artist__details__subsection.open-studios-artist__details__shop-url

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,7 +1,7 @@
 Time::DATE_FORMATS[:pickadate] = '%d %B, %Y'
 Time::DATE_FORMATS[:admin] = '%Y-%m-%d %H:%M%p'
 Time::DATE_FORMATS[:admin_date_only] = '%Y-%m-%d'
-Time::DATE_FORMATS[:os_day] = '%b %d'
+Time::DATE_FORMATS[:os_day] = '%b %-d'
 Time::DATE_FORMATS[:time_with_zone] = '%l:%M%P %Z'
 Time::DATE_FORMATS[:time_only] = '%l:%M%P'
 Time::DATE_FORMATS[:date_month_first] = '%m/%d/%Y'

--- a/spec/helpers/open_studios_participants_helper_spec.rb
+++ b/spec/helpers/open_studios_participants_helper_spec.rb
@@ -8,12 +8,26 @@ describe OpenStudiosParticipantsHelper do
 
     Time.use_zone(Conf.event_time_zone) do
       test_scenarios = [
+        [Time.zone.local(2021, 1, 14, 16), '01/15/2021 4:00pm - 5:00pm PST'],
         [Time.zone.local(2021, 5, 6, 1), '05/06/2021 1:00am - 2:00am PDT'],
         [Time.zone.local(2021, 10, 12, 14), '10/12/2021 2:00pm - 3:00pm PDT'],
       ]
       test_scenarios.each do |scenario|
-        it "returns #{scenario.last} for the date #{scenario.first}" do
+        it "returns long format #{scenario.last} for the date #{scenario.first}" do
           expect(helper.display_time_slot(make_1hour_timeslot(scenario.first))).to eq scenario.last
+        end
+      end
+    end
+
+    Time.use_zone(Conf.event_time_zone) do
+      test_scenarios = [
+        [Time.zone.local(2021, 1, 14, 16), 'Jan 15 4-5pm PST'],
+        [Time.zone.local(2021, 5, 6, 1), 'May 6 1-2am PDT'],
+        [Time.zone.local(2021, 10, 12, 14), 'Oct 12 2-3pm PDT'],
+      ]
+      test_scenarios.each do |scenario|
+        it "returns short format #{scenario.last} for the date #{scenario.first} with compact: true" do
+          expect(helper.display_time_slot(make_1hour_timeslot(scenario.first), compact: true)).to eq scenario.last
         end
       end
     end

--- a/spec/presenters/open_studios_participant_presenter_spec.rb
+++ b/spec/presenters/open_studios_participant_presenter_spec.rb
@@ -32,7 +32,7 @@ describe OpenStudiosParticipantPresenter do
     its(:has_youtube?) { is_expected.to eq true }
     its(:has_scheduled_conference?) { is_expected.to eq true }
     it 'time slots are formatted' do
-      expect(subject.conference_time_slots).to include '04/01/2021 1:00pm - 2:00pm PDT'
+      expect(subject.conference_time_slots).to include 'Apr 1 1-2pm PDT'
     end
   end
 


### PR DESCRIPTION
Problem
---------

as a visitor
when i hit the artist show page in the catalog
the schedule dates should be formatted as follows

4/23 2-3pm PST
4/24 1-2pm PST

we can get away with this because we know that we are setting the special event timing to be on the hour. so for now... we can get away without the minutes and the year.

the current format is much longer

03/23/2021 2:00pm - 3:00pm PDT
03/24/2021 3:00pm - 4:00pm PDT

https://www.pivotaltracker.com/story/show/177431666

Solution
---------

Build a "compact" version of the time slot formatter and use it.

Screenshot
------------

<img width="678" alt="Screen Shot 2021-03-22 at 12 09 01 AM" src="https://user-images.githubusercontent.com/427380/111952843-f3875600-8aa2-11eb-8ae0-3ce42b06cb25.png">
