### PR TITLE
Update subdomain constraints

### DIFF
--- a/lib/routing_constraints/app_subdomain.rb
+++ b/lib/routing_constraints/app_subdomain.rb
@@ -1,0 +1,9 @@
+require_relative './open_studios_subdomain'
+
+module RoutingConstraints
+  class AppSubdomain
+    def self.matches?(request)
+      request.subdomain.blank? || !RoutingConstraints::OpenStudiosSubdomain.in_subdomain?(request)
+    end
+  end
+end

--- a/lib/routing_constraints/open_studios_subdomain.rb
+++ b/lib/routing_constraints/open_studios_subdomain.rb
@@ -1,0 +1,13 @@
+module RoutingConstraints
+  class OpenStudiosSubdomain
+    SUBDOMAIN = 'openstudios'.freeze
+
+    def self.in_subdomain?(request)
+      request.host.starts_with?(SUBDOMAIN)
+    end
+
+    def self.matches?(request)
+      request.subdomain.present? && in_subdomain?(request)
+    end
+  end
+end

--- a/spec/routing/subdomain_routing_spec.rb
+++ b/spec/routing/subdomain_routing_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+shared_examples_for :routes_to_app_error_page do
+  it 'routes errors to the main app' do
+    expect(get: "http://#{host}/path_that_wont_resolve").to route_to('error#index', path: 'path_that_wont_resolve')
+  end
+end
+
+shared_examples_for :routes_to_os_error_page do
+  it 'routes errors to the open studios app' do
+    expect(get: "http://#{host}/path_that_wont_resolve").to route_to('open_studios_subdomain/error#index', path: 'path_that_wont_resolve')
+  end
+end
+
+shared_examples_for :allowed_routes do
+  it 'can reach the cms documents' do
+    expect(get: admin_cms_documents_url).to route_to('admin/cms_documents#index')
+  end
+  it 'can reach the api' do
+    expect(get: api_v2_art_piece_url(5)).to route_to('api/v2/art_pieces#show', id: '5')
+  end
+end
+
+shared_examples_for :app_routes do
+  it 'can reach the sampler' do
+    expect(post: sampler_main_url).to route_to('main#sampler')
+  end
+  it 'can reach the media' do
+    expect(get: media_url).to route_to('media#index')
+  end
+  it 'routes to studios' do
+    expect(get: studios_url).to route_to('studios#index')
+  end
+end
+
+shared_examples_for :open_studios_routes do
+  it 'routes to root' do
+    expect(get: root_url).to route_to('open_studios_subdomain/main#index')
+  end
+
+  it 'routes to artists' do
+    expect(get: artist_url('whomever')).to route_to('open_studios_subdomain/artists#show', id: 'whomever')
+  end
+
+  it 'does not route to studios' do
+    expect(get: studios_url).to route_to('open_studios_subdomain/error#index', path: 'studios')
+  end
+end
+
+describe 'Subdomain Routing Constraints' do
+  let(:tld) { 'test.host' }
+  let(:host) do
+    [subdomain, tld].compact.join('.')
+  end
+  describe 'for subdomain mau' do
+    let(:subdomain) { 'mau' }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :app_routes
+    it_should_behave_like :routes_to_app_error_page
+  end
+
+  describe 'for subdomain www.mau' do
+    let(:subdomain) { 'www.mau' }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :app_routes
+    it_should_behave_like :routes_to_app_error_page
+  end
+
+  describe 'for subdomain openstudios.mau' do
+    let(:subdomain) { 'openstudios.mau' }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :open_studios_routes
+    it_should_behave_like :routes_to_os_error_page
+  end
+
+  describe 'for subdomain openstudios' do
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    let(:subdomain) { 'openstudios' }
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :open_studios_routes
+    it_should_behave_like :routes_to_os_error_page
+  end
+
+  describe 'for nil domain' do
+    let(:subdomain) { nil }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :app_routes
+    it_should_behave_like :routes_to_app_error_page
+  end
+
+  describe 'for empty string domain' do
+    let(:subdomain) { '' }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :app_routes
+    it_should_behave_like :routes_to_app_error_page
+  end
+
+  describe 'for unknown sub domain' do
+    let(:subdomain) { 'other' }
+    before do
+      Rails.application.routes.default_url_options[:host] = host
+    end
+    it_should_behave_like :allowed_routes
+    it_should_behave_like :routes_to_app_error_page
+  end
+end


### PR DESCRIPTION
Problem
-------

It appears that the subdomain constraint `/^(www)?$/` does not
successfully hit the bare domain.  On acceptance we're using
mau.rcode5.com (not www.mau.rcode5.com) and openstudios.mau.rcode5.com.
In practice, I noticed that the main pages and error pages were properly
working before this change but the `api` endpoints seemed to be blocked.

Solution
--------

Build custom slightly more flexible subdmain constraints with a couple
of little constraints library methods.

Changes 
---------

* rearrange the order of endpoints
* add lib/AppSubdomain and lib/OpenStudiosSubdomain constraint matcher classes/methods
* add routing tests


Note:
I setup mau.rcode5.com and open studios.mau.rcode5.com locally to point to my dev server to confirm the problem and then confirm this solution works.