### PR TITLE
Build ArtPage in reactjs

### DIFF
--- a/app/views/open_studios_subdomain/artists/show.html.slim
+++ b/app/views/open_studios_subdomain/artists/show.html.slim
@@ -5,10 +5,11 @@
   .pure-u-1-1.pure-u-sm-1-2.pure-u-md-1-3.pure-u-lg-1-5
     = render "/open_studios_subdomain/artists/info", artist: @artist
 
-  .pure-u-1-1.pure-u-sm-1-2.pure-u-md-2-3.pure-u-lg-4-5
-    .pure-g
-      - if @artist.art_pieces.present?
-        = render partial: "/open_studios_subdomain/artists/art_card", collection: @artist.art_pieces, as: :art_piece
-      - else
+  - if @artist.art_pieces.present?
+    = react_component id:"art-page-#{@artist.id}", component: "ArtPage", props: { artist_id: @artist.id}, classes: "pure-u-1-1 pure-u-sm-1-2 pure-u-md-2-3 pure-u-lg-4-5"
+  - else
+    / TODO - the page component above should probably handle this.
+    .pure-u-1-1.pure-u-sm-1-2.pure-u-md-2-3.pure-u-lg-4-5
+      .pure-g
         .pure-u-1-1.empty
-          h4 This artist has no art to show.
+           h4 This artist has no art to show.

--- a/app/webpack/js/app/helpers.js
+++ b/app/webpack/js/app/helpers.js
@@ -115,3 +115,7 @@ export const dig = (obj, path, defaultValue = undefined) => {
   const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
   return result === undefined || result === obj ? defaultValue : result;
 };
+
+export const eachByIndex = (arr, indexKey = "id") => {
+  return arr.reduce((acc, it) => ((acc[it[indexKey]] = it), acc), {});
+};

--- a/app/webpack/js/app/helpers.test.js
+++ b/app/webpack/js/app/helpers.test.js
@@ -218,4 +218,25 @@ describe("helpers", () => {
       }
     );
   });
+
+  describe("eachByIndex", () => {
+    it("returns an array keyed by 'id' by default", () => {
+      const arr = [{ id: 1 }, { id: 4 }, { id: 20 }];
+      const result = helpers.eachByIndex(arr);
+      expect(result).toEqual({
+        1: { id: 1 },
+        4: { id: 4 },
+        20: { id: 20 },
+      });
+    });
+    it("returns an array keyed by 'whatever' if you specify the key", () => {
+      const arr = [{ whatever: 1 }, { whatever: 4 }, { whatever: 20 }];
+      const result = helpers.eachByIndex(arr, "whatever");
+      expect(result).toEqual({
+        1: { whatever: 1 },
+        4: { whatever: 4 },
+        20: { whatever: 20 },
+      });
+    });
+  });
 });

--- a/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
         <div
           class="art-card__description-item"
         >
-          the title of the piece
+          the title goes here
         </div>
         <div
           class="art-card__description-item"
@@ -24,7 +24,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
           <span
             class="art-card__price"
           >
-            123
+            $123
           </span>
         </div>
         <div
@@ -35,7 +35,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
         <div
           class="art-card__description-item"
         >
-          1234
+          2000
         </div>
       </div>
     </div>
@@ -59,7 +59,7 @@ exports[`ArtCard matches the snapshot with minimal props 1`] = `
         <div
           class="art-card__description-item"
         >
-          the title of the piece
+          the title goes here
         </div>
         <div
           class="art-card__description-item"

--- a/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
@@ -7,39 +7,35 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
   >
     <div>
       <div
-        class="art-piece"
+        class="image"
+        style="background-image: url(original.png);"
+      />
+      <div
+        class="art-card__description"
       >
         <div
-          class="image"
-          style="background-image: url(original.png);"
-        />
-        <div
-          class="art-card__description"
+          class="art-card__description-item"
         >
-          <div
-            class="art-card__description-item"
+          the title of the piece
+        </div>
+        <div
+          class="art-card__description-item"
+        >
+          <span
+            class="art-card__price"
           >
-            the title of the piece
-          </div>
-          <div
-            class="art-card__description-item"
-          >
-            <span
-              class="art-card__price"
-            >
-              123
-            </span>
-          </div>
-          <div
-            class="art-card__description-item"
-          >
-            10x 20
-          </div>
-          <div
-            class="art-card__description-item"
-          >
-            1234
-          </div>
+            123
+          </span>
+        </div>
+        <div
+          class="art-card__description-item"
+        >
+          10x 20
+        </div>
+        <div
+          class="art-card__description-item"
+        >
+          1234
         </div>
       </div>
     </div>
@@ -54,24 +50,20 @@ exports[`ArtCard matches the snapshot with minimal props 1`] = `
   >
     <div>
       <div
-        class="art-piece"
+        class="image"
+        style="background-image: url(original.png);"
+      />
+      <div
+        class="art-card__description"
       >
         <div
-          class="image"
-          style="background-image: url(original.png);"
-        />
-        <div
-          class="art-card__description"
+          class="art-card__description-item"
         >
-          <div
-            class="art-card__description-item"
-          >
-            the title of the piece
-          </div>
-          <div
-            class="art-card__description-item"
-          />
+          the title of the piece
         </div>
+        <div
+          class="art-card__description-item"
+        />
       </div>
     </div>
   </div>

--- a/app/webpack/reactjs/components/__snapshots__/art_modal.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_modal.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArtModal when there is no art renders nothing 1`] = `
+<div>
+  <div>
+    <button
+      data-testid="trigger"
+    >
+      trigger open
+    </button>
+  </div>
+</div>
+`;

--- a/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
+++ b/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ArtWindow matches the snapshot 1`] = `
           <span
             class="art-window__annotation-value"
           >
-            the title of the piece
+            the title goes here
           </span>
         </div>
         <div
@@ -62,7 +62,7 @@ exports[`ArtWindow matches the snapshot 1`] = `
           <span
             class="art-window__annotation-value"
           >
-            $123.00
+            $123
           </span>
         </div>
       </div>

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -10,7 +10,13 @@ describe("ArtCard", () => {
   let artPiece;
 
   beforeEach(() => {
-    artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
+    artPiece = new ArtPiece(
+      jsonApiArtPieceFactory.build({
+        title: "The title is here",
+        price: 123,
+        year: "2001",
+      })
+    );
   });
 
   it("matches the snapshot with all the props", () => {

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import { ArtPiece } from "@models/art_piece.model";
 import { jsonApiArtPieceFactory } from "@test/factories";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
 
 import { ArtCard } from "./art_card";
@@ -14,35 +14,14 @@ describe("ArtCard", () => {
   });
 
   it("matches the snapshot with all the props", () => {
-    const {
-      id,
-      title,
-      sold,
-      price,
-      dimensions,
-      year,
-      imageUrls: images,
-    } = artPiece;
-    const props = { id, title, sold, price, dimensions, year, images };
-    const { container } = render(<ArtCard {...props} />);
+    const { container } = render(<ArtCard artPiece={artPiece} />);
     expect(container).toMatchSnapshot();
   });
 
   it("matches the snapshot with minimal props", () => {
-    const { id, title, imageUrls: images } = artPiece;
-    const props = { id, title, images };
-    const { container } = render(<ArtCard {...props} />);
+    const { id, title, imageUrls } = artPiece;
+    const trimArtPiece = { id, title, imageUrls };
+    const { container } = render(<ArtCard artPiece={trimArtPiece} />);
     expect(container).toMatchSnapshot();
-  });
-
-  it("clicking the card opens the modal", () => {
-    const { id, title, imageUrls: images } = artPiece;
-    const props = { id, title, images };
-    render(<ArtCard {...props} />);
-    const trigger = screen.queryByText(title, { exact: false });
-    fireEvent.click(trigger);
-    expect(
-      screen.queryByRole("progressbar", { hidden: true })
-    ).toBeInTheDocument();
   });
 });

--- a/app/webpack/reactjs/components/art_card.tsx
+++ b/app/webpack/reactjs/components/art_card.tsx
@@ -1,59 +1,45 @@
+import { ArtPiece } from "@models/art_piece.model";
 import { ArtModal } from "@reactjs/components/art_modal";
-import * as types from "@reactjs/types";
 import cx from "classnames";
 import React, { FC } from "react";
 
 interface ArtCardProps {
-  id: number;
-  title: string;
-  sold?: boolean;
-  price?: string;
-  dimensions?: string;
-  year?: string;
-  classnames?: types.ClassNames;
-  images: any;
+  artPiece: ArtPiece;
+  classes?: string;
 }
 
-export const ArtCard: FC<ArtCardProps> = ({
-  classnames,
-  id,
-  title,
-  sold,
-  price,
-  dimensions,
-  year,
-  images,
-}) => {
-  const classes = cx("art-card", classnames);
+export const ArtCard: FC<ArtCardProps> = ({ artPiece, classes }) => {
   return (
-    <div className={classes}>
-      <ArtModal id={id}>
-        <div className="art-piece">
-          <div
-            className="image"
-            style={{ backgroundImage: `url("${images.original}")` }}
-          ></div>
-          <div className="art-card__description">
-            <div className="art-card__description-item">{title}</div>
-            <div className="art-card__description-item">
-              {Boolean(price) && (
-                <span
-                  className={cx("art-card__price", {
-                    "art-card__price--sold": sold,
-                  })}
-                >
-                  {price}
-                </span>
-              )}
-              {Boolean(sold) && <span className="art-card__sold">Sold</span>}
-            </div>
-            {Boolean(dimensions) && (
-              <div className="art-card__description-item">{dimensions}</div>
+    <div className={cx("art-card", classes)}>
+      <ArtModal artPiece={artPiece}>
+        <div
+          className="image"
+          style={{ backgroundImage: `url("${artPiece.imageUrls.original}")` }}
+        ></div>
+        <div className="art-card__description">
+          <div className="art-card__description-item">{artPiece.title}</div>
+          <div className="art-card__description-item">
+            {Boolean(artPiece.price) && (
+              <span
+                className={cx("art-card__price", {
+                  "art-card__price--sold": artPiece.sold,
+                })}
+              >
+                {artPiece.displayPrice}
+              </span>
             )}
-            {Boolean(year) && (
-              <div className="art-card__description-item">{year}</div>
+            {Boolean(artPiece.sold) && (
+              <span className="art-card__sold">Sold</span>
             )}
           </div>
+          {Boolean(artPiece.dimensions) && (
+            <div className="art-card__description-item">
+              {artPiece.dimensions}
+            </div>
+          )}
+          {Boolean(artPiece.year) && (
+            <div className="art-card__description-item">{artPiece.year}</div>
+          )}
         </div>
       </ArtModal>
     </div>

--- a/app/webpack/reactjs/components/art_modal.test.tsx
+++ b/app/webpack/reactjs/components/art_modal.test.tsx
@@ -1,7 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { noop } from "@js/app/helpers";
 import { ArtPiece } from "@models/art_piece.model";
-import { jsonApi } from "@services/json_api";
 import { jsonApiArtPieceFactory } from "@test/factories";
 import {
   act,
@@ -11,13 +9,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
-import { mocked } from "ts-jest/utils";
 
 import { ArtModal } from "./art_modal";
-
-jest.mock("@services/json_api");
-
-const mockApi = mocked(jsonApi, true);
 
 describe("ArtModal", () => {
   beforeEach(() => {
@@ -25,19 +18,15 @@ describe("ArtModal", () => {
   });
   const renderComponent = (props) => {
     return render(
-      <ArtModal id={5} {...props}>
+      <ArtModal {...props}>
         <button data-testid="trigger">trigger open</button>
       </ArtModal>
     );
   };
 
   it("renders the trigger", async () => {
-    act(() => {
-      renderComponent();
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId("trigger")).toBeInTheDocument();
-    });
+    renderComponent();
+    expect(screen.getByTestId("trigger")).toBeInTheDocument();
   });
 
   describe("when the art piece is available", () => {
@@ -45,63 +34,27 @@ describe("ArtModal", () => {
 
     beforeEach(() => {
       artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
-      mockApi.artPieces.get.mockResolvedValue(artPiece);
     });
 
-    describe("when you click the trigger", () => {
-      it("clicking the trigger fetches art piece data", async () => {
-        act(() => {
-          renderComponent();
-        });
-        await waitFor(noop);
+    it("clicking the trigger shows the modal window", async () => {
+      renderComponent({ artPiece });
+      const button = screen.getByTestId("trigger");
 
-        act(() => {
-          const button = screen.getByTestId("trigger");
-          fireEvent.click(button);
-        });
-        await waitFor(() => {
-          expect(mockApi.artPieces.get).toHaveBeenCalledWith(5);
-        });
+      act(() => {
+        fireEvent.click(button);
       });
-
-      it("clicking the trigger shows the modal window", async () => {
-        renderComponent();
-        const button = screen.getByTestId("trigger");
-
-        act(() => {
-          fireEvent.click(button);
-        });
-        await waitFor(() => {
-          expect(screen.queryByText(artPiece.title)).toBeInTheDocument();
-          expect(screen.queryByText(artPiece.dimensions)).toBeInTheDocument();
-          expect(screen.queryByText(artPiece.displayPrice)).toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(screen.queryByText(artPiece.title)).toBeInTheDocument();
+        expect(screen.queryByText(artPiece.dimensions)).toBeInTheDocument();
+        expect(screen.queryByText(artPiece.displayPrice)).toBeInTheDocument();
       });
     });
   });
 
-  describe("when the art piece fetch fails", () => {
-    beforeEach(() => {
-      mockApi.artPieces.get.mockRejectedValue({});
-    });
-
-    describe("when you click the trigger", () => {
-      it("renders a flash", async () => {
-        act(() => {
-          renderComponent();
-        });
-        act(() => {
-          const button = screen.getByTestId("trigger");
-          fireEvent.click(button);
-        });
-        await waitFor(() => {
-          expect(
-            screen.queryByText("We are having some issues getting that art", {
-              exact: false,
-            })
-          ).toBeInTheDocument();
-        });
-      });
+  describe("when there is no art", () => {
+    it("renders nothing", async () => {
+      const { container } = renderComponent();
+      expect(container).toMatchSnapshot();
     });
   });
 });

--- a/app/webpack/reactjs/components/art_modal.tsx
+++ b/app/webpack/reactjs/components/art_modal.tsx
@@ -1,31 +1,16 @@
-import Flash from "@js/app/jquery/flash";
-import { jsonApi as api } from "@js/services";
 import { ArtPiece } from "@models/art_piece.model";
 import { ArtWindow } from "@reactjs/components/art_browser/art_window";
 import { CloseButton } from "@reactjs/components/close_button";
 import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
-import { Spinner } from "@reactjs/components/spinner";
 import { useModalState } from "@reactjs/hooks/useModalState";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 
 interface ArtModalWindowProps {
-  id: number;
+  artPiece: ArtPiece;
   handleClose: (MouseEvent) => void;
 }
 
-const ArtModalWindow: FC<ArtModalWindowProps> = ({ id, handleClose }) => {
-  const [artPiece, setArtPiece] = useState<ArtPiece>();
-
-  useEffect(() => {
-    api.artPieces
-      .get(id)
-      .then(setArtPiece)
-      .catch((_error) => {
-        new Flash().show({
-          error: "We are having some issues getting that art.  Sorry!",
-        });
-      });
-  }, []);
+const ArtModalWindow: FC<ArtModalWindowProps> = ({ artPiece, handleClose }) => {
   setAppElement("body");
 
   return (
@@ -34,29 +19,27 @@ const ArtModalWindow: FC<ArtModalWindowProps> = ({ id, handleClose }) => {
       isOpen={true}
       onRequestClose={handleClose}
     >
-      {artPiece ? (
+      {artPiece && (
         <>
           <div className="art-modal__close">
             <CloseButton handleClick={handleClose} />
           </div>
           <ArtWindow art={artPiece} />
         </>
-      ) : (
-        <Spinner />
       )}
     </MauModal>
   );
 };
 
 interface ArtModalProps {
-  id: number;
+  artPiece: ArtPiece;
 }
 
-export const ArtModal: FC<ArtModalProps> = ({ id, children }) => {
+export const ArtModal: FC<ArtModalProps> = ({ artPiece, children }) => {
   const { isOpen, open, close } = useModalState(false);
   return (
     <>
-      {isOpen && <ArtModalWindow id={id} handleClose={close} />}
+      {isOpen && <ArtModalWindow artPiece={artPiece} handleClose={close} />}
       <div
         onClick={(ev) => {
           ev.preventDefault();

--- a/app/webpack/reactjs/components/art_page.test.tsx
+++ b/app/webpack/reactjs/components/art_page.test.tsx
@@ -33,12 +33,11 @@ describe("ArtPage", () => {
         render(<ArtPage artistId={artistId} />);
       });
       await waitFor(() => {
+        // building a factory with random values busts the snapshot
+        // testing so here all pieces have the same title
         expect(
-          screen.queryByText(artPieces[0].title, { exact: false })
-        ).toBeInTheDocument();
-        expect(
-          screen.queryByText(artPieces[1].title, { exact: false })
-        ).toBeInTheDocument();
+          screen.queryAllByText(artPieces[0].title, { exact: false })
+        ).toHaveLength(2);
       });
     });
   });

--- a/app/webpack/reactjs/components/art_page.test.tsx
+++ b/app/webpack/reactjs/components/art_page.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "@jest/globals";
+import { ArtPiece } from "@models/art_piece.model";
+import { jsonApi } from "@services/json_api";
+import { jsonApiArtPieceFactory } from "@test/factories";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { mocked } from "ts-jest/utils";
+
+import { ArtPage } from "./art_page";
+
+jest.mock("@services/json_api");
+
+const mockApi = mocked(jsonApi, true);
+
+describe("ArtPage", () => {
+  const artistId = 4;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("when the art pieces fetch succeeds", () => {
+    let artPieces: ArtPiece[];
+    beforeEach(() => {
+      artPieces = jsonApiArtPieceFactory
+        .buildList(2)
+        .map((artPiece) => new ArtPiece(artPiece));
+      mockApi.artPieces.index.mockResolvedValue(artPieces);
+    });
+
+    it("renders the 2 art cards", async () => {
+      act(() => {
+        render(<ArtPage artistId={artistId} />);
+      });
+      await waitFor(() => {
+        expect(
+          screen.queryByText(artPieces[0].title, { exact: false })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText(artPieces[1].title, { exact: false })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when the art pieces fetch fails", () => {
+    beforeEach(() => {
+      mockApi.artPieces.index.mockRejectedValue({});
+      render(<ArtPage artistId={artistId} />);
+    });
+
+    it("renders a flash", () => {
+      expect(screen.queryByText("Ack!", { exact: false })).toBeInTheDocument();
+    });
+  });
+});

--- a/app/webpack/reactjs/components/art_page.tsx
+++ b/app/webpack/reactjs/components/art_page.tsx
@@ -1,0 +1,42 @@
+import { eachByIndex } from "@js/app/helpers";
+import Flash from "@js/app/jquery/flash";
+import { ArtPiece } from "@models/art_piece.model";
+import { ArtCard } from "@reactjs/components/art_card";
+import { Spinner } from "@reactjs/components/spinner";
+import { jsonApi as api } from "@services/json_api";
+import React, { FC, useEffect, useState } from "react";
+
+interface ArtPageProps {
+  artistId: number;
+  initialArtPieceId?: number;
+}
+
+type ArtPiecesById = Record<number, ArtPiece>;
+
+export const ArtPage: FC<ArtPageProps> = ({ artistId, initialArtPieceId }) => {
+  const [artPieces, setArtPieces] = useState<ArtPiecesById>({});
+
+  useEffect(() => {
+    api.artPieces
+      .index(artistId)
+      .then((artPieces) => {
+        setArtPieces(eachByIndex(artPieces));
+      })
+      .catch((_err) => {
+        new Flash().show({
+          error:
+            "Ack!  We are having trouble finding that artist's art.  Try back later",
+        });
+      });
+  }, [artistId, initialArtPieceId]);
+
+  if (!artPieces) {
+    return <Spinner />;
+  }
+
+  const cardClasses =
+    "pure-u-1-1 pure-u-sm-1-1 pure-u-md-1-2 pure-u-lg-1-4 pure-u-xl-1-4";
+  return Object.entries(artPieces).map(([id, artPiece]) => (
+    <ArtCard key={id} artPiece={artPiece} classes={cardClasses} />
+  ));
+};

--- a/app/webpack/reactjs/components/index.ts
+++ b/app/webpack/reactjs/components/index.ts
@@ -3,6 +3,7 @@ import { FC } from "react";
 import { Welcome } from "./admin/tests/welcome";
 import { ArtCard } from "./art_card";
 import { ArtModal } from "./art_modal";
+import { ArtPage } from "./art_page";
 import { ConfirmModal } from "./confirm_modal";
 import { CreditsModal } from "./credits_modal";
 import { EditableContentTrigger } from "./editable_content_trigger";
@@ -24,6 +25,7 @@ that will be mounted at their root should be included here.
 export const reactComponents = {
   ArtCard,
   ArtModal,
+  ArtPage,
   ConfirmModal,
   CreditsModal,
   EditableContentTrigger,

--- a/app/webpack/reactjs/types/modelTypes.ts
+++ b/app/webpack/reactjs/types/modelTypes.ts
@@ -33,16 +33,6 @@ export interface JsonApiModel<T, R> {
   relationships: R;
 }
 
-interface JsonApiVersion {
-  version: string;
-}
-
-export interface JsonApiCollection<T, R> {
-  data: JsonApiModel<T, R>[];
-  included: unknown[];
-  jsonapi: JsonApiVersion;
-}
-
 type ImageSizes = "small" | "medium" | "large" | "original";
 
 // JsonAPI models look pretty different

--- a/app/webpack/reactjs/types/modelTypes.ts
+++ b/app/webpack/reactjs/types/modelTypes.ts
@@ -33,6 +33,16 @@ export interface JsonApiModel<T, R> {
   relationships: R;
 }
 
+interface JsonApiVersion {
+  version: string;
+}
+
+export interface JsonApiCollection<T, R> {
+  data: JsonApiModel<T, R>[];
+  included: unknown[];
+  jsonapi: JsonApiVersion;
+}
+
 type ImageSizes = "small" | "medium" | "large" | "original";
 
 // JsonAPI models look pretty different

--- a/app/webpack/stylesheets/gto/components/_art_window.scss
+++ b/app/webpack/stylesheets/gto/components/_art_window.scss
@@ -9,7 +9,6 @@
 }
 
 .art-window__image-container {
-  @include light-border;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -21,13 +20,8 @@
 }
 
 .art-window__image {
-  max-height: 100%;
-  max-width: 100%;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  height: 100%;
+  width: 100%;
 }
 
 .art-window__info-container {

--- a/app/webpack/test/factories/art_piece.factory.ts
+++ b/app/webpack/test/factories/art_piece.factory.ts
@@ -1,4 +1,7 @@
+import { identity } from "@js/app/helpers";
 import * as types from "@reactjs/types";
+import { randomInt } from "@test/support/faker_helpers";
+import { lorem } from "faker";
 import { Factory } from "rosie";
 
 const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes>(
@@ -6,11 +9,11 @@ const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes
 )
   .attr("artistName", "the artist name")
   .attr("favoritesCount", 0)
-  .attr("price", 123)
-  .attr("displayPrice", "$123.00")
-  .attr("year", "1234")
+  .attr("price", () => randomInt(100, 10000))
+  .attr("displayPrice", ["price"], (price: number) => `$${price}`)
+  .attr("year", () => randomInt(2020, 1940))
   .attr("dimensions", "10x 20")
-  .attr("title", "the title of the piece")
+  .attr("title", () => `the title of the piece ${lorem.words(4)}`)
   .attr("artistId", 45)
   .attr("imageUrls", {
     small: "small.png",
@@ -23,7 +26,7 @@ const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes
 export const jsonApiArtPieceFactory = Factory.define<types.JsonApiArtPiece>(
   "jsonApiArtPiece"
 )
-  .attr("id", 5)
+  .sequence("id", identity)
   .attr("type", "art_piece")
   .attr("attributes", () => jsonApiArtPieceAttributesFactory.build())
   .attr("relationships", {});

--- a/app/webpack/test/factories/art_piece.factory.ts
+++ b/app/webpack/test/factories/art_piece.factory.ts
@@ -1,7 +1,5 @@
 import { identity } from "@js/app/helpers";
 import * as types from "@reactjs/types";
-import { randomInt } from "@test/support/faker_helpers";
-import { lorem } from "faker";
 import { Factory } from "rosie";
 
 const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes>(
@@ -9,11 +7,11 @@ const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes
 )
   .attr("artistName", "the artist name")
   .attr("favoritesCount", 0)
-  .attr("price", () => randomInt(100, 10000))
+  .attr("price", "123")
   .attr("displayPrice", ["price"], (price: number) => `$${price}`)
-  .attr("year", () => randomInt(2020, 1940))
+  .attr("year", "2000")
   .attr("dimensions", "10x 20")
-  .attr("title", () => `the title of the piece ${lorem.words(4)}`)
+  .attr("title", "the title goes here")
   .attr("artistId", 45)
   .attr("imageUrls", {
     small: "small.png",

--- a/app/webpack/test/support/faker_helpers.ts
+++ b/app/webpack/test/support/faker_helpers.ts
@@ -1,1 +1,4 @@
 export const randomBoolean = (): Boolean => Math.random() > 0.5;
+export const randomInt = (max: number, min: number = 0): number => {
+  return Math.floor(Math.random() * Math.floor(max - min)) + min;
+};

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -157,7 +157,7 @@ end
 Then('I see that artist\'s open studios pieces') do
   expect(page).to have_content(@artist.name)
   expect(@artist.art_pieces).to have_at_least(1).art_piece
-  expect(page).to have_css('.art-piece', count: @artist.art_pieces.count)
+  expect(page).to have_css('.art-card', count: @artist.art_pieces.count)
 end
 
 When('I hover over a cms section') do

--- a/lib/generators/react_component/templates/component.test.tsx.erb
+++ b/lib/generators/react_component/templates/component.test.tsx.erb
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
 import { <%= class_name %> } from "./<%= file_name %>";
 import React from 'react'
 


### PR DESCRIPTION
Problem
--------

We want to make the art piece page include a browser/carousel.

This means we need to fetch all art pieces.  Since we *also* need that
for the art page, instead of having rails render a collection of art
cards, let's just fetch all the art and hand it to a react component.

Moving towards https://www.pivotaltracker.com/story/show/177431680

Solution
---------

React ArtPage component.  This replaces a large portion of the artist
show page.

Screenshot
------------

<img width="1440" alt="Screen Shot 2021-03-27 at 3 16 51 PM" src="https://user-images.githubusercontent.com/427380/112736404-8e52bb00-8f0f-11eb-8605-72c7f6da6757.png">
