### PR TITLE
Update the art attribution tag to include only price/dimensions

### DIFF
--- a/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
         <div
           class="art-card__description-item"
         >
-          the title goes here
+          10x 20
         </div>
         <div
           class="art-card__description-item"
@@ -26,16 +26,6 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
           >
             $123
           </span>
-        </div>
-        <div
-          class="art-card__description-item"
-        >
-          10x 20
-        </div>
-        <div
-          class="art-card__description-item"
-        >
-          2000
         </div>
       </div>
     </div>
@@ -61,9 +51,6 @@ exports[`ArtCard matches the snapshot with minimal props 1`] = `
         >
           the title goes here
         </div>
-        <div
-          class="art-card__description-item"
-        />
       </div>
     </div>
   </div>

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -10,13 +10,7 @@ describe("ArtCard", () => {
   let artPiece;
 
   beforeEach(() => {
-    artPiece = new ArtPiece(
-      jsonApiArtPieceFactory.build({
-        title: "The title is here",
-        price: 123,
-        year: "2001",
-      })
-    );
+    artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
   });
 
   it("matches the snapshot with all the props", () => {
@@ -25,9 +19,9 @@ describe("ArtCard", () => {
   });
 
   it("matches the snapshot with minimal props", () => {
-    const { id, title, imageUrls } = artPiece;
-    const trimArtPiece = { id, title, imageUrls };
-    const { container } = render(<ArtCard artPiece={trimArtPiece} />);
+    artPiece.dimensions = undefined;
+    artPiece.price = undefined;
+    const { container } = render(<ArtCard artPiece={artPiece} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/app/webpack/reactjs/components/art_card.tsx
+++ b/app/webpack/reactjs/components/art_card.tsx
@@ -3,6 +3,34 @@ import { ArtModal } from "@reactjs/components/art_modal";
 import cx from "classnames";
 import React, { FC } from "react";
 
+interface AttributionProps {
+  artPiece: ArtPiece;
+}
+
+const AttributionItems: FC<AttributionProps> = ({ artPiece }) => {
+  if (!artPiece.dimensions && !artPiece.price) {
+    return <div className="art-card__description-item">{artPiece.title}</div>;
+  }
+  return (
+    <>
+      <div className="art-card__description-item">
+        {Boolean(artPiece.dimensions) && artPiece.dimensions}
+      </div>
+      <div className="art-card__description-item">
+        {Boolean(artPiece.price) && (
+          <span
+            className={cx("art-card__price", {
+              "art-card__price--sold": artPiece.hasSold(),
+            })}
+          >
+            {artPiece.displayPrice}
+          </span>
+        )}
+      </div>
+    </>
+  );
+};
+
 interface ArtCardProps {
   artPiece: ArtPiece;
   classes?: string;
@@ -16,30 +44,11 @@ export const ArtCard: FC<ArtCardProps> = ({ artPiece, classes }) => {
           className="image"
           style={{ backgroundImage: `url("${artPiece.imageUrls.original}")` }}
         ></div>
+        {Boolean(artPiece.hasSold()) && (
+          <span className="art-card__sold">Sold</span>
+        )}
         <div className="art-card__description">
-          <div className="art-card__description-item">{artPiece.title}</div>
-          <div className="art-card__description-item">
-            {Boolean(artPiece.price) && (
-              <span
-                className={cx("art-card__price", {
-                  "art-card__price--sold": artPiece.sold,
-                })}
-              >
-                {artPiece.displayPrice}
-              </span>
-            )}
-            {Boolean(artPiece.sold) && (
-              <span className="art-card__sold">Sold</span>
-            )}
-          </div>
-          {Boolean(artPiece.dimensions) && (
-            <div className="art-card__description-item">
-              {artPiece.dimensions}
-            </div>
-          )}
-          {Boolean(artPiece.year) && (
-            <div className="art-card__description-item">{artPiece.year}</div>
-          )}
+          <AttributionItems artPiece={artPiece} />
         </div>
       </ArtModal>
     </div>

--- a/app/webpack/reactjs/components/art_page.test.tsx
+++ b/app/webpack/reactjs/components/art_page.test.tsx
@@ -36,7 +36,7 @@ describe("ArtPage", () => {
         // building a factory with random values busts the snapshot
         // testing so here all pieces have the same title
         expect(
-          screen.queryAllByText(artPieces[0].title, { exact: false })
+          screen.queryAllByText(artPieces[0].dimensions, { exact: false })
         ).toHaveLength(2);
       });
     });

--- a/app/webpack/stylesheets/gto/components/_art_card.scss
+++ b/app/webpack/stylesheets/gto/components/_art_card.scss
@@ -9,8 +9,11 @@
   font-size: 0.8rem;
   color: $gto_yellow;
   position: absolute;
-  right: 6px;
-  top: 10px;
+  right: 15px;
+  bottom: 70px;
+  background-color: rgba(255, 255, 255, 0.8);
+  @include round-corners();
+  padding: 5px;
 }
 
 .art-card__description {
@@ -18,8 +21,20 @@
   @include light-border;
   position: relative;
   padding: 10px;
+  height: 49px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .art-card__description-item {
+  @include ellipsis;
   line-height: 1.7rem;
+  flex: 1;
+  &:first-child {
+    text-align: left;
+  }
+  &:last-child {
+    text-align: right;
+  }
 }

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -212,10 +212,8 @@ Then('I see details about the art on each art card') do
   pieces = @artist.art_pieces
   expect(pieces).to have_at_least(1).piece
   pieces.each do |piece|
-    expect(page).to have_content(piece.title)
     expect(page).to have_content(piece.price)
     expect(page).to have_content(piece.dimensions)
-    expect(page).to have_content(piece.year)
   end
 end
 
@@ -224,7 +222,7 @@ When('I click on the first art card in the catalog') do
   expect(pieces).to have_at_least(1).piece
   @art_piece = pieces.first
   card = page.all('.art-card').detect do |art_card|
-    art_card.text.include?(@art_piece.title)
+    art_card.text.include?(@art_piece.dimensions)
   end
   card.click
 end


### PR DESCRIPTION
problem
--------

at a glance, to get people interested in the art, we should focus
only on the size and price of an item.

solution
--------

Update attribution tag on the artists open studios catalog page to focus
on these two items.

and if there's neither item, use the title.


screenshot
-----------
<img width="720" alt="Screen Shot 2021-03-28 at 1 07 29 PM" src="https://user-images.githubusercontent.com/427380/112766791-3926b000-8fc8-11eb-9f28-833b6aec695d.png">
