### PR TITLE
Support keyboard navigation of the carousel

### DIFF
--- a/app/webpack/js/event_constants.ts
+++ b/app/webpack/js/event_constants.ts
@@ -1,0 +1,2 @@
+export const ARROW_LEFT_KEY = "ArrowLeft";
+export const ARROW_RIGHT_KEY = "ArrowRight";

--- a/app/webpack/reactjs/components/art_modal.tsx
+++ b/app/webpack/reactjs/components/art_modal.tsx
@@ -1,10 +1,15 @@
+import { ARROW_LEFT_KEY, ARROW_RIGHT_KEY } from "@js/event_constants";
 import { ArtPiece } from "@models/art_piece.model";
 import { ArtWindow } from "@reactjs/components/art_browser/art_window";
 import { CloseButton } from "@reactjs/components/close_button";
 import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
 import { ArtPiecesContext } from "@reactjs/contexts/art_pieces.context";
-import { useCarouselState, useModalState } from "@reactjs/hooks";
-import React, { FC, useContext } from "react";
+import {
+  useCarouselState,
+  useEventListener,
+  useModalState,
+} from "@reactjs/hooks";
+import React, { FC, useCallback, useContext } from "react";
 
 interface ArtModalWindowProps {
   artPiece: ArtPiece;
@@ -16,6 +21,17 @@ const ArtModalWindow: FC<ArtModalWindowProps> = ({ artPiece, handleClose }) => {
 
   const { artPieces } = useContext(ArtPiecesContext);
   const { current, next, previous } = useCarouselState(artPieces, artPiece);
+
+  const keyDownHandler = useCallback((e) => {
+    if (e.key === ARROW_LEFT_KEY) {
+      previous();
+    }
+    if (e.key === ARROW_RIGHT_KEY) {
+      next();
+    }
+  });
+
+  useEventListener("keydown", keyDownHandler);
 
   const handleNext = (e: MouseEvent) => {
     e.preventDefault();

--- a/app/webpack/reactjs/hooks/index.ts
+++ b/app/webpack/reactjs/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useCarouselState } from "./useCarouselState";
+export { useEventListener } from "./useEventListener";
 export { useModalState } from "./useModalState";

--- a/app/webpack/reactjs/hooks/useEventListener.js
+++ b/app/webpack/reactjs/hooks/useEventListener.js
@@ -1,0 +1,40 @@
+// Straight rip off from https://usehooks.com/useEventListener/
+// Left this as js cuz i didn't want to figure out the types.
+import { noop } from "@js/app/helpers";
+import { useEffect, useRef } from "react";
+
+export function useEventListener(eventName, handler, element = window) {
+  // Create a ref that stores handler
+  const savedHandler = useRef();
+
+  // Update ref.current value if handler changes.
+  // This allows our effect below to always get latest handler ...
+  // ... without us needing to pass it in effect deps array ...
+  // ... and potentially cause effect to re-run every render.
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  useEffect(
+    () => {
+      // Make sure element supports addEventListener
+      // On
+      const isSupported = element && element.addEventListener;
+      if (!isSupported) {
+        return noop;
+      }
+
+      // Create event listener that calls handler function stored in ref
+      const eventListener = (event) => savedHandler.current(event);
+
+      // Add event listener
+      element.addEventListener(eventName, eventListener);
+
+      // Remove event listener on cleanup
+      return () => {
+        element.removeEventListener(eventName, eventListener);
+      };
+    },
+    [eventName, element] // Re-run if eventName or element changes
+  );
+}

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -29,6 +29,10 @@ Scenario:
   When I click on "next" in ".art-modal__content"
   Then I see the next art piece in the modal
 
+  When I click on "previous" in ".art-modal__content"
+  And I press the "arrow_right" key
+  Then I see the next art piece in the modal
+
   When I click on "close" in ".art-modal__content"
   Then I don't see the art modal
 

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -366,3 +366,7 @@ end
 When('I see a {string} link') do |string|
   expect(page).to have_link(string)
 end
+
+When('I press the {string} key') do |string|
+  page.find('body').send_keys(string.to_sym)
+end


### PR DESCRIPTION
Problem
--------

With the previous carousel story #183, I did not add the keyboard event
handling because I was having trouble with it.

Solution
--------

Come back with a clear head and steal someone's nice `useEventListener`
hook and put it in place so when you hit left and right arrows, you
navigate through the carousel