### PR TITLE
Polish the attributions on the zoomed in art piece view

### DIFF
--- a/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
+++ b/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
@@ -34,6 +34,24 @@ exports[`ArtWindow matches the snapshot 1`] = `
           </span>
         </div>
         <div
+          class="art-window__annotation art-window__price"
+        >
+          <span
+            class="art-window__annotation-label"
+          >
+            Price:
+          </span>
+          <span
+            class="art-window__annotation-value"
+          >
+            $123
+          </span>
+        </div>
+      </div>
+      <div
+        class="art-window__info--right"
+      >
+        <div
           class="art-window__annotation art-window__dimensions"
         >
           <span
@@ -47,22 +65,18 @@ exports[`ArtWindow matches the snapshot 1`] = `
             10x 20
           </span>
         </div>
-      </div>
-      <div
-        class="art-window__info--right"
-      >
         <div
-          class="art-window__annotation art-window__price art-window__price--sold"
+          class="art-window__annotation art-window__date"
         >
           <span
             class="art-window__annotation-label"
           >
-            Price:
+            Year:
           </span>
           <span
             class="art-window__annotation-value"
           >
-            $123
+            2000
           </span>
         </div>
       </div>

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -48,28 +48,28 @@ export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
             classes="art-window__title"
           />
           <Annotation
+            label="Price:"
+            value={art.displayPrice}
+            classes={cx("art-window__price", {
+              "art-window__price--sold": art.hasSold(),
+            })}
+          />
+        </div>
+        <div className="art-window__info--right">
+          <Annotation
             label="Dimensions:"
             value={art.dimensions}
             classes="art-window__dimensions"
           />
-          <Annotation
-            label="Date:"
-            value={art.date}
-            classes="art-window__date"
-          />
-        </div>
-        <div className="art-window__info--right">
           <Annotation
             label="Medium:"
             value={art?.medium?.name}
             classes="art-window__medium"
           />
           <Annotation
-            label="Price:"
-            value={art.displayPrice}
-            classes={cx("art-window__price", {
-              "art-window__price--sold": art.hasSold,
-            })}
+            label="Year:"
+            value={art.year}
+            classes="art-window__date"
           />
         </div>
       </div>

--- a/app/webpack/stylesheets/gto/components/_art_window.scss
+++ b/app/webpack/stylesheets/gto/components/_art_window.scss
@@ -27,11 +27,12 @@
 .art-window__info-container {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   margin: auto;
   width: 80%;
   @media screen and (max-width: $screen-sm-max) {
     align-items: flex-start;
+    justify-content: flex-start;
     width: 90%;
     flex-direction: column;
   }


### PR DESCRIPTION
Problem
--------

We were a bit sloppy on the attributions when we open the zoom carousel
window.

https://www.pivotaltracker.com/story/show/177469176

Solution
--------

Go back and polish.  I fixed year renderer and moved dimensions and
price around so they are a bit more primary.

Screenshot
------------

<img width="1153" alt="Screen Shot 2021-03-28 at 1 22 38 PM" src="https://user-images.githubusercontent.com/427380/112766912-cff36c80-8fc8-11eb-926d-a59599fb3f8d.png">
