### PR TITLE
Allow admin to edit users phone

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -82,6 +82,7 @@ module Admin
         { video_conference_schedule: {} },
       ]
       params.require(:artist).permit(:firstname, :lastname,
+                                     :phone,
                                      :email, :nomdeplume,
                                      :studio_id,
                                      links: allowed_links,

--- a/app/views/admin/artists/_form.html.slim
+++ b/app/views/admin/artists/_form.html.slim
@@ -9,6 +9,7 @@
         = f.input :lastname
         = f.input :nomdeplume
         = f.input :studio
+        = f.input :phone
         = f.semantic_fields_for :artist_info do |artist_info|
           = artist_info.inputs do
             = artist_info.input :studionumber

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -26,6 +26,9 @@
         tr.admin-user__profile-table__row
           td Nom de Plume
           td = @user.nomdeplume
+        tr.admin-user__profile-table__row
+          td Phone
+          td = @user.phone_for_display
         tr.admin-user__profile-table__row.is-section-end
           td Link To Artist
           td = link_to artist_url(@user), artist_url(@user)

--- a/features/admin/artists/admin_edit.feature
+++ b/features/admin/artists/admin_edit.feature
@@ -13,12 +13,12 @@ Background:
 
 Scenario: Updating artists basic info
   When I fill in the form with:
-  | Email                | Firstname      | Lastname      |
-  | testdude@example.com | new first name | new last name |
+  | Email                | Firstname      | Lastname      | Phone |
+  | testdude@example.com | new first name | new last name | 4155551212 |
   And I click on "Update Artist"
   And I see the admin artist show page with updated values:
-  | Email                | First Name     | Last Name     |
-  | testdude@example.com | new first name | new last name |
+  | Email                | First Name     | Last Name     | Phone |
+  | testdude@example.com | new first name | new last name | 415-555-1212 |
 
 Scenario: Updating artist links
   When I fill in the form with:


### PR DESCRIPTION
Problem
--------

As an admin who might need to help folks fill out their info
I'd like to be able to update a user's phone number.

Solution
---------

Add phone to the admin user fields and let it be saved.