### PR TITLE
Add sold treatment to the modal art browser.

### DIFF
--- a/app/webpack/js/app/models/art_piece.model.js
+++ b/app/webpack/js/app/models/art_piece.model.js
@@ -6,7 +6,6 @@ import { Medium } from "@models/medium.model";
 export class ArtPiece extends JsonApiModel {
   constructor(data, included) {
     super(data, included);
-
     if (this.medium) {
       this.medium = new Medium(this.medium);
     }

--- a/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
@@ -10,6 +10,11 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
         class="image"
         style="background-image: url(original.png);"
       />
+      <span
+        class="art-card__sold"
+      >
+        Sold
+      </span>
       <div
         class="art-card__description"
       >
@@ -22,7 +27,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
           class="art-card__description-item"
         >
           <span
-            class="art-card__price"
+            class="art-card__price art-card__price--sold"
           >
             $123
           </span>
@@ -43,6 +48,11 @@ exports[`ArtCard matches the snapshot with minimal props 1`] = `
         class="image"
         style="background-image: url(original.png);"
       />
+      <span
+        class="art-card__sold"
+      >
+        Sold
+      </span>
       <div
         class="art-card__description"
       >

--- a/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
+++ b/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArtWindow matches the snapshot 1`] = `
+exports[`ArtWindow if the art has not sold matches the snapshot 1`] = `
 <div>
   <div
     class="art-window"
@@ -11,7 +11,13 @@ exports[`ArtWindow matches the snapshot 1`] = `
       <div
         class="art-window__image"
         style="background-image: url(original.png); background-size: contain; background-position: center center; background-repeat: no-repeat;"
-      />
+      >
+        <span
+          class="art-window__sold"
+        >
+          Sold
+        </span>
+      </div>
     </div>
     <div
       class="art-window__info-container"
@@ -34,7 +40,98 @@ exports[`ArtWindow matches the snapshot 1`] = `
           </span>
         </div>
         <div
-          class="art-window__annotation art-window__price"
+          class="art-window__annotation art-window__price art-window__price--sold"
+        >
+          <span
+            class="art-window__annotation-label"
+          >
+            Price:
+          </span>
+          <span
+            class="art-window__annotation-value"
+          >
+            $123
+          </span>
+        </div>
+      </div>
+      <div
+        class="art-window__info--right"
+      >
+        <div
+          class="art-window__annotation art-window__dimensions"
+        >
+          <span
+            class="art-window__annotation-label"
+          >
+            Dimensions:
+          </span>
+          <span
+            class="art-window__annotation-value"
+          >
+            10x 20
+          </span>
+        </div>
+        <div
+          class="art-window__annotation art-window__date"
+        >
+          <span
+            class="art-window__annotation-label"
+          >
+            Year:
+          </span>
+          <span
+            class="art-window__annotation-value"
+          >
+            2000
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ArtWindow if the art has sold matches the snapshot 1`] = `
+<div>
+  <div
+    class="art-window"
+  >
+    <div
+      class="art-window__image-container"
+    >
+      <div
+        class="art-window__image"
+        style="background-image: url(original.png); background-size: contain; background-position: center center; background-repeat: no-repeat;"
+      >
+        <span
+          class="art-window__sold"
+        >
+          Sold
+        </span>
+      </div>
+    </div>
+    <div
+      class="art-window__info-container"
+    >
+      <div
+        class="art-window__info--left"
+      >
+        <div
+          class="art-window__annotation art-window__title"
+        >
+          <span
+            class="art-window__annotation-label"
+          >
+            Title:
+          </span>
+          <span
+            class="art-window__annotation-value"
+          >
+            the title goes here
+          </span>
+        </div>
+        <div
+          class="art-window__annotation art-window__price art-window__price--sold"
         >
           <span
             class="art-window__annotation-label"

--- a/app/webpack/reactjs/components/art_browser/art_window.test.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.test.tsx
@@ -7,11 +7,23 @@ import { ArtWindow } from "./art_window";
 
 describe("ArtWindow", () => {
   let artPiece;
-  beforeEach(() => {
-    artPiece = new ArtPiece(artPieceFactory.build());
+  describe("if the art has sold", () => {
+    beforeEach(() => {
+      artPiece = new ArtPiece(artPieceFactory.build({ sold: undefined }));
+    });
+    it("matches the snapshot", () => {
+      const { container } = render(<ArtWindow art={artPiece} />);
+      expect(container).toMatchSnapshot();
+    });
   });
-  it("matches the snapshot", () => {
-    const { container } = render(<ArtWindow art={artPiece} />);
-    expect(container).toMatchSnapshot();
+
+  describe("if the art has not sold", () => {
+    beforeEach(() => {
+      artPiece = new ArtPiece(artPieceFactory.build({ sold: new Date() }));
+    });
+    it("matches the snapshot", () => {
+      const { container } = render(<ArtWindow art={artPiece} />);
+      expect(container).toMatchSnapshot();
+    });
   });
 });

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -38,7 +38,11 @@ export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
             backgroundSize: "contain",
             backgroundRepeat: "no-repeat",
           })}
-        ></div>
+        >
+          {Boolean(art.hasSold()) && (
+            <span className="art-window__sold">Sold</span>
+          )}
+        </div>
       </div>
       <div className="art-window__info-container">
         <div className="art-window__info--left">

--- a/app/webpack/stylesheets/_mixins.scss
+++ b/app/webpack/stylesheets/_mixins.scss
@@ -546,3 +546,10 @@ $sampler-thumbnail-size: 250px;
     list-style: circle;
   }
 }
+
+@mixin sold-sign {
+  text-transform: uppercase;
+  color: $gto_yellow;
+  background-color: rgba(255, 255, 255, 0.8);
+  @include round-corners();
+}

--- a/app/webpack/stylesheets/gto/components/_art_card.scss
+++ b/app/webpack/stylesheets/gto/components/_art_card.scss
@@ -5,14 +5,11 @@
   text-decoration: line-through;
 }
 .art-card__sold {
-  text-transform: uppercase;
+  @include sold-sign;
   font-size: 0.8rem;
-  color: $gto_yellow;
   position: absolute;
   right: 15px;
   bottom: 70px;
-  background-color: rgba(255, 255, 255, 0.8);
-  @include round-corners();
   padding: 5px;
 }
 

--- a/app/webpack/stylesheets/gto/components/_art_window.scss
+++ b/app/webpack/stylesheets/gto/components/_art_window.scss
@@ -22,6 +22,7 @@
 .art-window__image {
   height: 100%;
   width: 100%;
+  position: relative;
 }
 
 .art-window__info-container {
@@ -77,4 +78,14 @@
   .art-window__annotation-value {
     text-decoration: line-through;
   }
+}
+
+.art-window__sold {
+  @include sold-sign;
+  font-size: 1.4rem;
+  position: absolute;
+  left: 50%;
+  bottom: 10px;
+  padding: 8px;
+  transform: translateX(-50%);
 }

--- a/app/webpack/test/factories/art_piece.factory.ts
+++ b/app/webpack/test/factories/art_piece.factory.ts
@@ -19,7 +19,7 @@ const jsonApiArtPieceAttributesFactory = Factory.define<types.ArtPieceAttributes
     large: "large.png",
     original: "original.png",
   })
-  .attr("sold_at", "a time stamp");
+  .attr("soldAt", "a time stamp");
 
 export const jsonApiArtPieceFactory = Factory.define<types.JsonApiArtPiece>(
   "jsonApiArtPiece"


### PR DESCRIPTION
Problem
---------

we added a nice treatment for sold on the small art card but not in the
art window in the modal.

Solution
--------

Add a sold floating tag on the art window if the art has sold.

Notes
-----

because of the auto contain of the image on that modal, pinning this to
the bottom right corner is hard so i centered it instead.

Screenshot
------------
<img width="1406" alt="Screen Shot 2021-03-28 at 7 21 01 PM" src="https://user-images.githubusercontent.com/427380/112781344-7a868200-8fff-11eb-8880-e8fd4068912b.png">
