### PR TITLE
Only link to artists if the feature flag is on (in os)

### DIFF
--- a/app/views/open_studios_subdomain/artists/_artist.html.slim
+++ b/app/views/open_studios_subdomain/artists/_artist.html.slim
@@ -1,7 +1,11 @@
 / expects artist
 .artist-card(class=class_names(%w(pure-u-1-1 pure-u-sm-1-2 pure-u-md-1-3 pure-u-lg-1-4 pure-u-xl-1-5)))
-  = link_to artist_url(artist, subdomain: "openstudios"), title: artist.get_name(escape: true)
-    .image style=background_image_style(artist.representative_piece.path)
+  - if FeatureFlags.virtual_open_studios?
+    = link_to artist_url(artist, subdomain: "openstudios"), title: artist.get_name(escape: true)
+      .image style=background_image_style(artist.representative_piece.path)
+  - else
+    div
+      .image style=background_image_style(artist.representative_piece.path)
   .desc
     .name
       span.byline> by


### PR DESCRIPTION
problem
--------

to release this to the world we would like the catalog page to be live
but links to individual artists pages should be feature flagged.

solution
--------

Update the artist card to only link to artists if the feature flag is on,