### PR TITLE
Combine sequential schedule slots

### DIFF
--- a/app/helpers/open_studios_participants_helper.rb
+++ b/app/helpers/open_studios_participants_helper.rb
@@ -1,8 +1,25 @@
+require_relative '../../lib/util/range_helpers'
+
 module OpenStudiosParticipantsHelper
+  def merge_timeslots(timeslots)
+    RangeHelpers.merge_overlapping(timeslots.map do |ts|
+                                     Range.new(*OpenStudiosParticipant.parse_time_slot(ts))
+                                   end).map { |range| [range.begin, range.end] }
+  end
+
+  def display_time_slots(timeslots, compact: false)
+    Time.use_zone(Conf.event_time_zone) do
+      method = compact ? :_compact_display_time_slot : :_long_form_display_time_slot
+      merge_timeslots(timeslots).map do |ts|
+        send(method, *ts)
+      end
+    end
+  end
+
   def display_time_slot(timeslot, compact: false)
     Time.use_zone(Conf.event_time_zone) do
       method = compact ? :_compact_display_time_slot : :_long_form_display_time_slot
-      send(method, timeslot)
+      send(method, *OpenStudiosParticipant.parse_time_slot(timeslot))
     end
   end
 
@@ -10,8 +27,7 @@ module OpenStudiosParticipantsHelper
     %i[name domain].zip(email.split('@')).to_h
   end
 
-  def _compact_display_time_slot(timeslot)
-    start_time, end_time = OpenStudiosParticipant.parse_time_slot(timeslot)
+  def _compact_display_time_slot(start_time, end_time)
     [
       start_time.in_time_zone(Conf.event_time_zone).to_s(:os_day),
       ' ',
@@ -21,8 +37,7 @@ module OpenStudiosParticipantsHelper
     ].join
   end
 
-  def _long_form_display_time_slot(timeslot)
-    start_time, end_time = OpenStudiosParticipant.parse_time_slot(timeslot)
+  def _long_form_display_time_slot(start_time, end_time)
     [
       start_time.in_time_zone(Conf.event_time_zone).to_s(:date_month_first),
       start_time.in_time_zone(Conf.event_time_zone).to_s(:time_only),

--- a/app/presenters/open_studios_participant_presenter.rb
+++ b/app/presenters/open_studios_participant_presenter.rb
@@ -17,11 +17,11 @@ class OpenStudiosParticipantPresenter
   end
 
   def show_phone?
-    participant.show_phone_number? && artist.phone.present?
+    @show_phone ||= participant.show_phone_number? && artist.phone.present?
   end
 
   def conference_time_slots
-    time_slots.map { |s| display_time_slot(s, compact: true) }
+    @conference_time_slots ||= display_time_slots(time_slots, compact: true)
   end
 
   def has_shop? # rubocop:disable Naming/PredicateName

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -18,7 +18,7 @@
         .open-studios-artist__details__item.open-studios-artist__details__contact
           - if info.show_email?
             .open-studios-artist__details__email
-              = react_component id:"mailer", component:"Mailer", props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
+              = react_component id:"mailer", component:"Mailer", classes: 'open-studios-artist__details__email--link', props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
           - if info.show_phone?
             .open-studios-artist__details__phone
               = link_to artist.phone_for_display, "tel:#{artist.phone}", target: "_blank"
@@ -26,10 +26,9 @@
         .open-studios-artist__details__item.open-studios-artist__details__youtube
           = embed_you_tube(info.youtube_url)
       - if info.has_scheduled_conference? && !info.broadcasting?
-        .open-studios-artist__details__item.open-studios-artist__details__conference-url
+        .open-studios-artist__details__item.open-studios-artist__details__schedule
           .open-studios-artist__details__item--title
             | My Live Schedule
-          .open-studios-artist__details__conference-url--timeslots
+          .open-studios-artist__details__schedule--timeslots
             - info.conference_time_slots.each do |ts|
               .timeslot = ts
-          .open-studios-artist__details__conference-url--footnote

--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -26,16 +26,20 @@
   font-size: 1.4rem;
 }
 
-.open-studios-artist__details__conference-url {
+.open-studios-artist__details__schedule {
   border-bottom: none;
+  display: flex;
+  flex-direction: column;
 }
 
-.open-studios-artist__details__conference-url--title {
+.open-studios-artist__details__schedule--title {
   margin-bottom: 8px;
 }
 
-.open-studios-artist__details__conference-url--timeslots {
+.open-studios-artist__details__schedule--timeslots {
   line-height: 1.2rem;
+  text-align: left;
+  margin: auto;
 }
 
 .open-studios-artist__details__item.open-studios-artist__details__youtube {
@@ -46,6 +50,10 @@
   line-height: 1.2rem;
   padding-top: 12px;
   @include light-top-border;
+}
+
+.open-studios-artist__details__email--link {
+  @include ellipsis;
 }
 
 .open-studios-artist__details__item--title {
@@ -64,10 +72,6 @@
     font-weight: $font-weight-bold;
     color: $gto_hot_pink;
   }
-}
-
-.open-studios-artist__details__conference-url--footnote {
-  font-size: 0.8rem;
 }
 
 .open-studios__artist-card__description {

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -203,8 +203,8 @@ end
 
 When('I see my video conference schedule') do
   expect(page).to have_content(/my live schedule/i)
-  expect(page.all('.open-studios-artist__details__conference-url--timeslots .timeslot'))
-    .to have(@artist.current_open_studios_participant.video_conference_time_slots.length).entries
+  expect(page.all('.open-studios-artist__details__schedule--timeslots .timeslot'))
+    .to have(merge_timeslots(@artist.current_open_studios_participant.video_conference_time_slots).length).entries
 end
 
 Then('I see details about the art on each art card') do

--- a/features/support/os_helpers.rb
+++ b/features/support/os_helpers.rb
@@ -1,0 +1,2 @@
+require_relative '../../app/helpers/open_studios_participants_helper'
+World OpenStudiosParticipantsHelper

--- a/lib/util/range_helpers.rb
+++ b/lib/util/range_helpers.rb
@@ -1,0 +1,19 @@
+module RangeHelpers
+  def self.overlap?(range_a, range_b)
+    range_a.cover?(range_b.begin) || range_b.cover?(range_a.begin)
+  end
+
+  def self.merge(range_a, range_b)
+    [range_a.min, range_b.min].min..[range_a.max, range_b.max].max
+  end
+
+  def self.merge_overlapping(overlapping_ranges)
+    overlapping_ranges.sort_by(&:begin).inject([]) do |ranges, range|
+      if !ranges.empty? && overlap?(ranges.last, range)
+        ranges[0...-1] + [merge(ranges.last, range)]
+      else
+        ranges + [range]
+      end
+    end
+  end
+end

--- a/spec/helpers/open_studios_participants_helper_spec.rb
+++ b/spec/helpers/open_studios_participants_helper_spec.rb
@@ -33,10 +33,59 @@ describe OpenStudiosParticipantsHelper do
     end
   end
 
+  describe '.display_time_slots' do
+    def make_timeslots(t) # rubocop:disable Naming/MethodParameterName
+      [
+        [t, t + 1.hour].map(&:to_i).join('::'),
+        [t + 1.hour, t + 3.hours].map(&:to_i).join('::'),
+        [t + 1.day, t + 1.day + 1.hour].map(&:to_i).join('::'),
+      ]
+    end
+
+    Time.use_zone(Conf.event_time_zone) do
+      test_scenarios = [
+        [Time.zone.local(2021, 1, 14, 16), ['01/14/2021 4:00pm - 7:00pm PST', '01/15/2021 4:00pm - 5:00pm PST']],
+        [Time.zone.local(2021, 5, 6, 1), ['05/06/2021 1:00am - 4:00am PDT', '05/07/2021 1:00am - 2:00am PDT']],
+        [Time.zone.local(2021, 10, 12, 14), ['10/12/2021 2:00pm - 5:00pm PDT', '10/13/2021 2:00pm - 3:00pm PDT']],
+      ]
+      test_scenarios.each do |scenario|
+        it 'returns long format merged time slots' do
+          time_slots = helper.display_time_slots(make_timeslots(scenario.first))
+          scenario.last.each do |entry|
+            expect(time_slots).to include entry
+          end
+        end
+      end
+    end
+
+    Time.use_zone(Conf.event_time_zone) do
+      test_scenarios = [
+        [Time.zone.local(2021, 1, 14, 16), ['Jan 14 4-7pm PST', 'Jan 15 4-5pm PST']],
+        [Time.zone.local(2021, 5, 6, 1), ['May 6 1-4am PDT', 'May 7 1-2am PDT']],
+        [Time.zone.local(2021, 10, 12, 14), ['Oct 12 2-5pm PDT', 'Oct 13 2-3pm PDT']],
+      ]
+      test_scenarios.each do |scenario|
+        it 'returns short format merged time slots with compact: true' do
+          time_slots = helper.display_time_slots(make_timeslots(scenario.first), compact: true)
+          scenario.last.each do |entry|
+            expect(time_slots).to include entry
+          end
+        end
+      end
+    end
+  end
+
   describe '.split_email' do
     it 'returns name and domain from email' do
       expect(helper.split_email('jon@whatever.com')).to eq({ name: 'jon', domain: 'whatever.com' })
       expect(helper.split_email('zzz+103@long.super.tld.example.com')).to eq({ name: 'zzz+103', domain: 'long.super.tld.example.com' })
+    end
+  end
+
+  describe '.generate_collapsed_timeslots' do
+    it 'returns collapsed time slots' do
+      timeslots = ['1617598800::1617602400', '1617595200::1617598800']
+      expect(helper.merge_timeslots(timeslots)).to eq([[Time.zone.parse('2021-04-05 04:00:00 UTC'), Time.zone.parse('2021-04-05 06:00:00 UTC')]])
     end
   end
 end

--- a/spec/presenters/open_studios_participant_presenter_spec.rb
+++ b/spec/presenters/open_studios_participant_presenter_spec.rb
@@ -32,7 +32,8 @@ describe OpenStudiosParticipantPresenter do
     its(:has_youtube?) { is_expected.to eq true }
     its(:has_scheduled_conference?) { is_expected.to eq true }
     it 'time slots are formatted' do
-      expect(subject.conference_time_slots).to include 'Apr 1 1-2pm PDT'
+      expect(subject.conference_time_slots).to include 'Apr 1 12-4pm PDT'
+      expect(subject.conference_time_slots).to include 'Apr 2 12-4pm PDT'
     end
   end
 

--- a/spec/util/range_helpers_spec.rb
+++ b/spec/util/range_helpers_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../spec_helper'
+require_relative '../../lib/util/range_helpers'
+
+describe 'RangeHelpers' do
+  include RangeHelpers
+  describe '.overlap?' do
+    [
+      [1..2, 1..4],
+      [3..4, 1..3.5],
+      [3..4, 1..3],
+    ].each do |range|
+      it "returns true if ranges overlap like #{range}" do
+        expect(RangeHelpers.overlap?(*range)).to eq true
+      end
+    end
+    [
+      [1..2, 3..4],
+      [3..4, 1..2],
+    ].each do |range|
+      it "returns false if ranges do not overlap like #{range}" do
+        expect(RangeHelpers.overlap?(*range)).to eq false
+      end
+    end
+  end
+
+  describe '.merge' do
+    [
+      [1..2, 1..4],
+      [3..4, 1..3.5],
+      [1..2, 3..4],
+    ].each do |range|
+      it "merges ranges like #{range}" do
+        expect(RangeHelpers.merge(*range)).to eq 1..4
+      end
+    end
+  end
+
+  describe '.merge_overlapping' do
+    it 'merges overlapping ranges' do
+      expect(RangeHelpers.merge_overlapping([1..2, 2..3, 3..4, 5..7, 6..8, 7..12])).to eq([1..4, 5..12])
+    end
+  end
+end


### PR DESCRIPTION
Problem
-------

Timeslots that are sequential were rendered individually making for an
ugly display of a long set of time slots.

Solution
--------

Display them combined if possible.

Changes
--------

* Add RangeHelpers which can merge coincidental ranges
* Use those helpers when building timeslots for display on the open
  studios page