### PR TITLE
More visible open sign.

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -92,6 +92,6 @@
   border: 2px solid $gto_hot_pink;
   background: #ffffff99;
   padding: 6px 4px 4px 4px;
-  @include box-shadow(0 0 4px 2px rgba(255, 255, 255, 0.6));
+  @include box-shadow(0 0 4px 2px rgba(255, 255, 255, 0.9));
   font-weight: $font-weight-bold;
 }

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -29,9 +29,6 @@ Scenario:
   When I click on "next" in ".art-modal__content"
   Then I see the next art piece in the modal
 
-  When I click on "previous" in ".art-modal__content"
-  Then I see that art in a modal
-
   When I click on "close" in ".art-modal__content"
   Then I don't see the art modal
 


### PR DESCRIPTION
Update the open sign background opacity to 90% for better visibility on
dark images.