### PR TITLE
Really change opacity of the open sign

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -84,14 +84,14 @@
 }
 .open-studios__artist-card__open-now {
   position: absolute;
-  bottom: 65px;
+  bottom: 52px;
   right: 18px;
   color: $gto_hot_pink;
   text-transform: uppercase;
   @include round-corners();
   border: 2px solid $gto_hot_pink;
-  background: #ffffff99;
+  background: rgba(255, 255, 255, 0.9);
   padding: 6px 4px 4px 4px;
-  @include box-shadow(0 0 4px 2px rgba(255, 255, 255, 0.9));
+  @include box-shadow(0 0 4px 2px rgba(255, 255, 255, 0.6));
   font-weight: $font-weight-bold;
 }


### PR DESCRIPTION
Problem
--------

Previously this was done sloppily without IRL testing.

https://www.pivotaltracker.com/story/show/177779621

Solution
---------

*Actually* change the opacity of the background and it's positioning.


ScreenShots
-----------

<img width="598" alt="Screen Shot 2021-04-16 at 7 19 58 PM" src="https://user-images.githubusercontent.com/427380/115099154-f4b47300-9ee8-11eb-95a2-30f44d396d32.png">
