### PR TITLE
Open Studios Catalog shows artist stars after the first 40

### DIFF
--- a/app/controllers/open_studios_subdomain/main_controller.rb
+++ b/app/controllers/open_studios_subdomain/main_controller.rb
@@ -3,7 +3,7 @@ module OpenStudiosSubdomain
     def index
       cur_page = (params[:p] || 0).to_i
       @os_only = true
-      @gallery = ArtistsGallery.new(os_only: true, current_page: cur_page, per_page: 40)
+      @gallery = ArtistsGallery.new(os_only: true, current_page: cur_page, per_page: 100)
       if request.xhr?
         render partial: '/artists/artist_list', locals: { gallery: @gallery, in_catalog: true }
       else


### PR DESCRIPTION
Problem
--------

That page was set up to pull the first 40 artists, and after that
it falls back to infinite scroll which is pulling from the main site
using the main site design instead of the open studios rendering.

https://www.pivotaltracker.com/story/show/177801595

Solution
--------

Make that page pull the first 100 artists and hope that we don't have
more than 100 for this first run.

If we get up to 100 in the next 2 weeks, we can fix it properly which
would be to make the infinite scroll understand which domain it's asking
about.