### PR TITLE
Fix open studios title for catalog pages

### DIFF
--- a/app/views/layouts/openstudios.html.slim
+++ b/app/views/layouts/openstudios.html.slim
@@ -3,7 +3,7 @@ html
   head
     = render '/extra_html_head'
 
-    title Mission Artists - Virtual Open Stuios
+    title Mission Artists - Virtual Open Studios
 
     = csrf_meta_tags
 


### PR DESCRIPTION
The open studios page title was misspelled Open Stuios.

https://www.pivotaltracker.com/story/show/177802897

This fixes it.