### PR TITLE
Fix flaky test around subdomains

### DIFF
--- a/spec/routing/subdomain_routing_spec.rb
+++ b/spec/routing/subdomain_routing_spec.rb
@@ -47,16 +47,25 @@ shared_examples_for :open_studios_routes do
   end
 end
 
+old_host = Rails.application.routes.default_url_options[:host]
+
 describe 'Subdomain Routing Constraints' do
   let(:tld) { 'test.host' }
   let(:host) do
     [subdomain, tld].compact.join('.')
   end
+
+  before do
+    old_host = Rails.application.routes.default_url_options[:host]
+    Rails.application.routes.default_url_options[:host] = host
+  end
+
+  after do
+    Rails.application.routes.default_url_options[:host] = old_host
+  end
+
   describe 'for subdomain mau' do
     let(:subdomain) { 'mau' }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :app_routes
     it_should_behave_like :routes_to_app_error_page
@@ -64,9 +73,6 @@ describe 'Subdomain Routing Constraints' do
 
   describe 'for subdomain www.mau' do
     let(:subdomain) { 'www.mau' }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :app_routes
     it_should_behave_like :routes_to_app_error_page
@@ -74,18 +80,12 @@ describe 'Subdomain Routing Constraints' do
 
   describe 'for subdomain openstudios.mau' do
     let(:subdomain) { 'openstudios.mau' }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :open_studios_routes
     it_should_behave_like :routes_to_os_error_page
   end
 
   describe 'for subdomain openstudios' do
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     let(:subdomain) { 'openstudios' }
     it_should_behave_like :allowed_routes
     it_should_behave_like :open_studios_routes
@@ -94,9 +94,6 @@ describe 'Subdomain Routing Constraints' do
 
   describe 'for nil domain' do
     let(:subdomain) { nil }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :app_routes
     it_should_behave_like :routes_to_app_error_page
@@ -104,9 +101,6 @@ describe 'Subdomain Routing Constraints' do
 
   describe 'for empty string domain' do
     let(:subdomain) { '' }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :app_routes
     it_should_behave_like :routes_to_app_error_page
@@ -114,9 +108,6 @@ describe 'Subdomain Routing Constraints' do
 
   describe 'for unknown sub domain' do
     let(:subdomain) { 'other' }
-    before do
-      Rails.application.routes.default_url_options[:host] = host
-    end
     it_should_behave_like :allowed_routes
     it_should_behave_like :routes_to_app_error_page
   end


### PR DESCRIPTION
Problem
--------

There was a problem with our subdomain routing tests because we were
setting the Rails config in the test.  If those tests ran before the
server status tests, then the subdomain for the remaining test suite
would be making urls with the subdomain.

https://www.pivotaltracker.com/story/show/177802908

Solution
--------

This fix is to wrap before and after with the setting of the host
so that when the subdomain routing tests are finished, the environment
host remains in tact.