### PR TITLE
Art file names with quotes/apostrophes are escaped

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -4,7 +4,26 @@ const buildOptimizations = require("./custom/buildOptimizations");
 
 const htmlLoader = {
   test: /\.html$/,
-  use: "html-loader",
+  use: [
+    {
+      loader: "html-loader",
+      options: {
+        minimize: {
+          caseSensitive: true,
+          collapseWhitespace: true,
+          conservativeCollapse: true,
+          keepClosingSlash: true,
+          minifyCSS: false,
+          minifyJS: true,
+          removeComments: true,
+          removeRedundantAttributes: true,
+          removeScriptTypeAttributes: true,
+          removeStyleLinkTypeAttributes: true,
+          removeAttributeQuotes: true,
+        },
+      },
+    },
+  ],
 };
 
 // Insert json loader at the end of list


### PR DESCRIPTION
Problem
--------

Sidnea D'amico (https://www.missionartists.org/art_pieces/10946#!#10946)
recently uploaded images with her name in the filename.  These images
are used in `background-image` tags in angular.  AngularJS is loading
these templates from webpack which consumes them with `html-loader`.
This loader has a bunch of aggressive minimization that happens which
includes ripping out the outer quotations from the `url(...)` section
but only in production which is why this was hard to find.

https://www.pivotaltracker.com/story/show/177709836

Solution
---------

Specify the minimization rules for the `html-loader`.  As it turns out
the problematic one was `minifyCSS`.  I found this by running production
builds of webpack locally and looking for that `background-image` tag to
make sure that it included the wrapper quotes.