### PR TITLE
Sort artists in gallery by "who's open now"

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -81,7 +81,7 @@ class ArtistsController < ApplicationController
     # collect query args to build links
     @os_only = os_only?(params[:o])
 
-    @roster = ArtistsRoster.new(@os_only)
+    @roster = ArtistsRoster.new(os_only: @os_only)
 
     @page_title = PageInfoService.title('Artists')
 

--- a/app/controllers/open_studios_subdomain/main_controller.rb
+++ b/app/controllers/open_studios_subdomain/main_controller.rb
@@ -1,15 +1,8 @@
 module OpenStudiosSubdomain
   class MainController < BaseOpenStudiosController
     def index
-      cur_page = (params[:p] || 0).to_i
-      @os_only = true
-      @gallery = ArtistsGallery.new(os_only: true, current_page: cur_page, per_page: 100)
-      if request.xhr?
-        render partial: '/artists/artist_list', locals: { gallery: @gallery, in_catalog: true }
-      else
-        @presenter = OpenStudiosCatalogPresenter.new(current_user)
-        render
-      end
+      @gallery = OpenStudiosCatalogArtists.new
+      @presenter = OpenStudiosCatalogPresenter.new(current_user)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,8 +130,10 @@ class User < ApplicationRecord
   end
 
   def sortable_name
-    key = [lastname, firstname, login].join.downcase
-    key.gsub(/\W/, ' ').strip
+    @sortable_name ||= begin
+      key = [lastname, firstname, login].join.downcase
+      key.gsub(/\W/, ' ').strip
+    end
   end
 
   def validate_email

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -27,6 +27,7 @@ class ArtistPresenter < UserPresenter
            :pending?,
            :phone,
            :slug,
+           :sortable_name,
            :studio,
            :studio_id,
            :studionumber,
@@ -34,6 +35,7 @@ class ArtistPresenter < UserPresenter
            :updated_at,
            to: :artist, allow_nil: true
   delegate(*ALLOWED_LINKS, to: :artist, allow_nil: true)
+  delegate :broadcasting?, to: :open_studios_info, allow_nil: true
 
   def artist
     model

--- a/app/presenters/artists_gallery.rb
+++ b/app/presenters/artists_gallery.rb
@@ -8,7 +8,7 @@ class ArtistsGallery < ArtistsPresenter
   delegate :items, :more?, :current_page, :next_page, to: :pagination
 
   def initialize(os_only: false, letter: nil, ordering: nil, current_page: 0, per_page: Conf.pagination['artists']['per_page'])
-    super os_only
+    super os_only: os_only
     @letter = letter.try(:downcase)
     @ordering = %i[lastname firstname].include?(ordering.try(:to_sym)) ? ordering.to_sym : :lastname
     @per_page = per_page

--- a/app/presenters/artists_presenter.rb
+++ b/app/presenters/artists_presenter.rb
@@ -3,9 +3,10 @@
 class ArtistsPresenter < ViewPresenter
   attr_reader :os_only
 
-  def initialize(os_only = nil)
+  def initialize(os_only: false, sort_by_name: true)
     super()
     @os_only = !!os_only
+    @sort_by_name = sort_by_name
   end
 
   def artists
@@ -15,11 +16,12 @@ class ArtistsPresenter < ViewPresenter
     artists_list =
       begin
         if os_only
-          OpenStudiosEvent.current.artists.includes(:open_studios_participants)&.active
+          OpenStudiosEvent.current.artists.active.includes(:open_studios_participants, :art_pieces)
         else
           Artist.active.includes(:studio, :artist_info, :art_pieces, :open_studios_events)
         end
       end
-    @artists = (artists_list).sort_by(&:sortable_name).map { |artist| ArtistPresenter.new(artist) }
+    artists_list = artists_list.sort_by(&:sortable_name) if @sort_by_name
+    @artists = artists_list.map { |artist| ArtistPresenter.new(artist) }
   end
 end

--- a/app/presenters/open_studios_catalog_artists.rb
+++ b/app/presenters/open_studios_catalog_artists.rb
@@ -1,0 +1,9 @@
+class OpenStudiosCatalogArtists < ArtistsPresenter
+  def initialize
+    super(os_only: true, sort_by_name: false)
+  end
+
+  def artists
+    super.select(&:representative_piece).sort_by { |a| [a.broadcasting? ? 0 : 1, a.sortable_name] }
+  end
+end

--- a/app/presenters/social_catalog_presenter.rb
+++ b/app/presenters/social_catalog_presenter.rb
@@ -6,7 +6,7 @@ class SocialCatalogPresenter < ArtistsPresenter
   SOCIAL_KEYS = User.stored_attributes[:links].freeze
 
   def initialize
-    super(true)
+    super(os_only: true)
   end
 
   def artists

--- a/app/views/open_studios_subdomain/artists/_artist_list.slim
+++ b/app/views/open_studios_subdomain/artists/_artist_list.slim
@@ -1,9 +1,2 @@
-/ expects gallery as ArtistsGallery && filter as true/false
-.js-pagination-state( style="display:none;" data-current-page=gallery.current_page data-next-page=gallery.next_page data-has-more=(gallery.more? ? "t" : nil) data-current-letter=gallery.letter data-sort-order=gallery.ordering data-os-only="#{gallery.os_only}" )
-
-= render partial: "/open_studios_subdomain/artists/artist", collection: gallery.pagination.items
-- if gallery.more?
-  #js-scroll-load-more.scroll-load-more
-    .scroll-load-more__contents
-      = mau_spinner
-      .hint scroll down for more
+/ expects gallery as OpenStudiosCatalogArtists
+= render partial: "/open_studios_subdomain/artists/artist", collection: gallery.artists

--- a/spec/controllers/open_studios_subdomain/main_controller_spec.rb
+++ b/spec/controllers/open_studios_subdomain/main_controller_spec.rb
@@ -5,21 +5,10 @@ describe OpenStudiosSubdomain::MainController do
     create(:open_studios_event)
   end
   describe '#get' do
-    describe 'not xhr' do
-      it 'loads the gallery and presenter for the index page' do
-        get :index
-        expect(assigns(:gallery)).to be_a_kind_of(ArtistsGallery)
-        expect(assigns(:presenter)).to be_a_kind_of(OpenStudiosCatalogPresenter)
-      end
-    end
-    describe 'xhr' do
-      it 'loads the gallery with the next page' do
-        get :index, xhr: true, params: { p: 4 }
-        gallery = assigns(:gallery)
-        expect(gallery).to be_a_kind_of(ArtistsGallery)
-        expect(gallery.current_page).to eq 4
-        expect(assigns(:presenter)).to be_nil
-      end
+    it 'loads the gallery and presenter for the index page' do
+      get :index
+      expect(assigns(:gallery)).to be_a_kind_of(OpenStudiosCatalogArtists)
+      expect(assigns(:presenter)).to be_a_kind_of(OpenStudiosCatalogPresenter)
     end
   end
 end

--- a/spec/factories/open_studios_events.rb
+++ b/spec/factories/open_studios_events.rb
@@ -12,6 +12,13 @@ FactoryBot.define do
     trait :past do
       start_date { Time.zone.now - 6.months }
     end
+    trait :with_current_special_event do
+      end_date { start_date + 1.week }
+      special_event_start_date { start_date }
+      special_event_start_time { '12:01 am' }
+      special_event_end_date { special_event_start_date + 1.day }
+      special_event_end_time { '11:59 pm' }
+    end
     trait :with_special_event do
       end_date { start_date + 1.week }
       special_event_start_date { start_date + 1.day }

--- a/spec/presenters/artists_map_spec.rb
+++ b/spec/presenters/artists_map_spec.rb
@@ -7,7 +7,7 @@ describe ArtistsMap do
   let(:ne_bounds) { MissionBoundaries::BOUNDS['NE'] }
   let(:sw_bounds) { MissionBoudnaries::BOUNDS['SW'] }
 
-  subject(:map) { ArtistsMap.new(os_only) }
+  subject(:map) { ArtistsMap.new(os_only: os_only) }
   let(:artists) do
     [
       create(:artist, :active, :with_art, :in_the_mission),

--- a/spec/presenters/artists_presenter_spec.rb
+++ b/spec/presenters/artists_presenter_spec.rb
@@ -3,33 +3,62 @@ require 'rails_helper'
 describe ArtistsPresenter do
   include PresenterSpecHelpers
 
-  let(:os_only) { false }
-  let(:artists) { FactoryBot.create_list :artist, 4, :with_art, :in_the_mission }
-
-  subject(:presenter) { ArtistsPresenter.new(os_only) }
+  let!(:artists) { FactoryBot.create_list :artist, 4, :with_art, :in_the_mission }
 
   describe '#artists' do
-    context 'os_only is false' do
-      it 'shows active artists sorted by name' do
+    context 'with no params' do
+      subject(:presenter) { ArtistsPresenter.new }
+      it 'shows all active artists sorted by name' do
         expect(subject.artists.map(&:artist)).to eql Artist.active.sort_by(&:sortable_name).to_a
       end
     end
 
-    context 'os_only is true' do
-      let(:os_only) { true }
-      context 'when there is an open studios event' do
-        let(:os_participants) { OpenStudiosParticipant.all.map(&:user) }
-        before do
-          artists.first.open_studios_events << create(:open_studios_event)
-        end
-        it 'shows only os artists' do
-          expected = os_participants.select(&:in_the_mission?).sort_by(&:sortable_name).to_a
-          expect(subject.artists.map(&:artist).to_a).to eql(expected)
+    describe 'os_only flag' do
+      let(:os_only) { false }
+      subject(:presenter) { ArtistsPresenter.new(os_only: os_only) }
+
+      context 'os_only is false' do
+        it 'shows active artists sorted by name' do
+          expect(subject.artists).to have(4).artists
+          expect(subject.artists.map(&:artist)).to eql Artist.active.sort_by(&:sortable_name).to_a
         end
       end
-      context 'when there is no current open studios event' do
-        it 'shows returns none' do
-          expect(subject.artists.to_a).to eql([])
+
+      context 'os_only is true' do
+        let(:os_only) { true }
+        context 'when there is an open studios event' do
+          let(:os_participants) { OpenStudiosParticipant.all.map(&:user) }
+          before do
+            artists.first.open_studios_events << create(:open_studios_event)
+          end
+          it 'shows only os artists' do
+            expected = os_participants.select(&:in_the_mission?).sort_by(&:sortable_name).to_a
+            expect(subject.artists.map(&:artist).to_a).to eql(expected)
+          end
+        end
+        context 'when there is no current open studios event' do
+          it 'shows returns none' do
+            expect(subject.artists.to_a).to eql([])
+          end
+        end
+      end
+    end
+
+    describe 'sort_by_name flag' do
+      let(:sort_by_name) { false }
+      let!(:artists) do
+        [
+          FactoryBot.create(:artist, :with_art, :in_the_mission, firstname: 'Bb', lastname: 'bb', nomdeplume: nil),
+          FactoryBot.create(:artist, :with_art, :in_the_mission, firstname: 'AA', lastname: 'AA', nomdeplume: nil),
+          FactoryBot.create(:artist, :with_art, :in_the_mission, firstname: 'ZZ', lastname: 'zz', nomdeplume: nil),
+        ]
+      end
+      subject(:presenter) { ArtistsPresenter.new(sort_by_name: sort_by_name) }
+      context 'sort_by_name is false' do
+        it 'is returned unsorted' do
+          artists_names = subject.artists.map(&:sortable_name)
+          expect(artists_names).not_to be_monotonically_increasing
+          expect(artists_names).not_to be_monotonically_decreasing
         end
       end
     end

--- a/spec/presenters/open_studios_catalog_artists_spec.rb
+++ b/spec/presenters/open_studios_catalog_artists_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe OpenStudiosCatalogArtists do
+  let(:presenter) { described_class.new }
+  let(:os) { create(:open_studios_event, :with_current_special_event) }
+  let!(:artists) do
+    list = [
+      FactoryBot.create(:artist, :active, :with_art),
+      FactoryBot.create(:artist, :active, :with_art, lastname: 'AA'),
+      FactoryBot.create(:artist, :active, :with_art, lastname: 'TT'),
+      FactoryBot.create(:artist, :active, :with_art, lastname: 'GG'),
+      FactoryBot.create(:artist, :active),
+    ]
+    list.last(4).each { |a| a.open_studios_events << os }
+    list
+  end
+
+  it 'returns artists sorted by name' do
+    expect(presenter.artists.map(&:lastname)).to eq %w[AA GG TT]
+  end
+
+  it 'returns only os artists with art' do
+    expect(presenter.artists).to have(3).artists
+  end
+
+  describe 'when artists are broadcasting' do
+    before do
+      artists[2..3].each do |artist|
+        info = artist.current_open_studios_participant
+        info.video_conference_url = 'http://something.com'
+        info.video_conference_schedule = os.special_event_time_slots.index_with { |_ts| true }
+        info.save!
+      end
+    end
+    it 'they are sorted preferentially by broadcasting, then by name' do
+      expect(presenter.artists.map(&:lastname)).to eq %w[GG TT AA]
+    end
+  end
+end


### PR DESCRIPTION
Problem
--------

During the event, we'd like to promote those folks who are actively
broadcasting so if they are, they should be preferentially sorted to the
top of the catalog.

All others should be sorted by last name as they are now.

https://www.pivotaltracker.com/story/show/176835301

Solution
---------

Replace the `ArtistsGallery` presenter we were using with a new
`OpenStudiosCatalogArtists` that can take care of the sorting which is
specific to this page.

I also reworked the main controller to not worry about pagination
because we're not doing any (yet) and so it can use a simpler presenter
(not `ArtistsGallery` which has pagination built in).

Smaller changes were to make the boolean flags that the presenters get
be keyword args instead of just params so some tests needed to be
modified.

Screenshots
-------------

![Screen Shot 2021-04-17 at 4 53 25 PM](https://user-images.githubusercontent.com/427380/115129729-88e01200-9f9d-11eb-90d7-a9bee3e7b30d.png)
