### PR TITLE
Add artist paginator to open studios catalog

### DIFF
--- a/app/controllers/open_studios_subdomain/artists_controller.rb
+++ b/app/controllers/open_studios_subdomain/artists_controller.rb
@@ -4,7 +4,10 @@ module OpenStudiosSubdomain
       (redirect_to '/error' and return) unless FeatureFlags.virtual_open_studios?
 
       artist = Artist.active.joins(:open_studios_events).friendly.find(params[:id])
-      @artist = ArtistPresenter.new(artist) if artist&.doing_open_studios?
+      @artist = ArtistPresenter.new(artist)
+
+      gallery = OpenStudiosCatalogArtists.new
+      @paginator = OpenStudiosCatalogArtistsPaginator.new(gallery.artists, artist.id)
     rescue ActiveRecord::RecordNotFound
       flash[:error] = "It doesn't look like that artist is doing open studios" unless artist
       redirect_to open_studios_path

--- a/app/paginators/open_studios_catalog_artists_paginator.rb
+++ b/app/paginators/open_studios_catalog_artists_paginator.rb
@@ -1,0 +1,32 @@
+class OpenStudiosCatalogArtistsPaginator
+  def initialize(artists, current_artist_id)
+    @artists = artists
+    @current = current_artist_id
+  end
+
+  def previous
+    @artists[previous_index]
+  end
+
+  def next
+    @artists[next_index]
+  end
+
+  private
+
+  def current_index
+    @current_index = @artists.find_index { |a| a.id == @current }
+  end
+
+  def previous_index
+    return @artists.length - 1 unless current_index
+
+    current_index - 1
+  end
+
+  def next_index
+    return 0 unless current_index
+
+    (current_index + 1) % @artists.count
+  end
+end

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -33,6 +33,7 @@ class ArtistPresenter < UserPresenter
            :studionumber,
            :suspended?,
            :updated_at,
+           :to_model,
            to: :artist, allow_nil: true
   delegate(*ALLOWED_LINKS, to: :artist, allow_nil: true)
   delegate :broadcasting?, to: :open_studios_info, allow_nil: true

--- a/app/views/open_studios_subdomain/_container_header.slim
+++ b/app/views/open_studios_subdomain/_container_header.slim
@@ -1,7 +1,9 @@
 .container-header
   a.container-header__brand href=root_path title="Mission Artists"
-    .container-header__logo title="Mission Artists" class="#{Date.today.month == 6 ? 'container-header__logo--' : ''}"
+    .container-header__logo title="Mission Artists" class="#{Date.today.month == 6 ? 'container-header__logo--pride' : ''}"
     h2.container-header__mau-title.pure-u-sm-hidden Mission Artists
 
   h1.container-header__title
     = content_for(:open_studios_catalog_title) || "Catalog"
+  .container-header__paginator
+    = content_for(:open_studios_catalog_header_nav)

--- a/app/views/open_studios_subdomain/artists/_catalog_paginator.html.slim
+++ b/app/views/open_studios_subdomain/artists/_catalog_paginator.html.slim
@@ -1,0 +1,7 @@
+/ expects OpenStudiosArtistCatalogPaginator
+.catalog-paginator__container
+  = link_to @paginator.previous, title: @paginator.previous.name, class: "catalog-paginator__link catalog-paginator__link--prev" do
+    = fa_icon "chevron-left"
+  .catalog-paginator__main.pure-u-sm-hidden Catalog
+  = link_to @paginator.next, title: @paginator.next.name, class: "catalog-paginator__link catalog-paginator__link--next" do
+    = fa_icon "chevron-right"

--- a/app/views/open_studios_subdomain/artists/show.html.slim
+++ b/app/views/open_studios_subdomain/artists/show.html.slim
@@ -1,5 +1,7 @@
 - content_for :open_studios_catalog_title do
   = @artist.get_name
+- content_for :open_studios_catalog_header_nav do
+  = render partial: "/open_studios_subdomain/artists/catalog_paginator", locals: { paginator: @paginator }
 
 .pure-g.alpha.omega
   .pure-u-1-1.pure-u-sm-1-2.pure-u-md-1-3.pure-u-lg-1-5

--- a/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
@@ -12,6 +12,6 @@
 }
 
 .catalog-paginator__link {
-  padding: 0 6px;
+  padding: 0 12px;
   font-size: 18px;
 }

--- a/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
@@ -1,0 +1,17 @@
+.catalog-paginator__container {
+  display: flex;
+  align-items: center;
+  justify-items: center;
+}
+
+.catalog-paginator__main {
+  text-transform: uppercase;
+  font-size: 18px;
+  position: relative;
+  top: 1px;
+}
+
+.catalog-paginator__link {
+  padding: 0 6px;
+  font-size: 18px;
+}

--- a/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
@@ -11,6 +11,12 @@
   right: 0;
   z-index: 50;
 }
+
+.container-header__paginator {
+  right: 15px;
+}
+
+.container-header__paginator,
 .container-header__brand {
   display: flex;
   align-items: center;
@@ -35,9 +41,6 @@
   top: 2px;
   position: relative;
   @include ellipsis;
-  @media screen and (max-width: $screen-xs-max) {
-    padding-left: 40px;
-  }
 }
 
 .container-header__logo {

--- a/app/webpack/stylesheets/open_studios_subdomain/application.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/application.scss
@@ -1,7 +1,8 @@
 @import "_variables.scss";
 
 #open_studios_subdomain__layout {
-  @import "_layout.scss";
-  @import "_container_header.scss";
-  @import "_open_studios_artist.scss";
+  @import "layout.scss";
+  @import "container_header.scss";
+  @import "open_studios_artist.scss";
+  @import "catalog_paginator";
 }

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -32,6 +32,9 @@ Scenario:
   When I click on "close" in ".art-modal__content"
   Then I don't see the art modal
 
+  When I click the next button in the paginator
+  Then I see the next artist in the catalog
+
 Scenario: Visitors see the "visit me now" button when artists are broadcasting
   Given the first artist is broadcasting live now
 

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -281,3 +281,18 @@ end
 Then('I see a {string} link which goes to their conference call') do |string|
   expect(page).to have_link(string, href: @artist.current_open_studios_participant.video_conference_url)
 end
+
+When('I click the next button in the paginator') do
+  artists = OpenStudiosCatalogArtists.new.artists
+  next_index = artists.find_index(@artist) + 1
+  @next_artist = artists[next_index % artists.length]
+  within('.catalog-paginator__container') do
+    find('.catalog-paginator__link--next').click
+  end
+end
+
+Then('I see the next artist in the catalog') do
+  within('.container-header') do
+    expect(page).to have_content(@next_artist.get_name.upcase)
+  end
+end

--- a/spec/controllers/open_studios_subdomain/main_controller_spec.rb
+++ b/spec/controllers/open_studios_subdomain/main_controller_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 describe OpenStudiosSubdomain::MainController do
-  before do
-    create(:open_studios_event)
-  end
-  describe '#get' do
+  let!(:os) { create(:open_studios_event) }
+  describe 'get#index' do
     it 'loads the gallery and presenter for the index page' do
       get :index
       expect(assigns(:gallery)).to be_a_kind_of(OpenStudiosCatalogArtists)

--- a/spec/paginators/open_studios_catalog_artists_paginator_spec.rb
+++ b/spec/paginators/open_studios_catalog_artists_paginator_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe OpenStudiosCatalogArtistsPaginator do
+  let(:artists) do
+    [build_stubbed(:artist),
+     build_stubbed(:artist),
+     build_stubbed(:artist)]
+  end
+  let(:current_id) { nil }
+  let(:paginator) { described_class.new(artists, current_id) }
+
+  context 'when there is no current id' do
+    it 'previous returns the last item' do
+      expect(paginator.previous).to eq artists[2]
+    end
+    it 'next returns the first item' do
+      expect(paginator.next).to eq artists[0]
+    end
+  end
+
+  context 'when there is a current id' do
+    let(:current_id) { artists[1].id }
+    it 'previous returns the previous item' do
+      expect(paginator.previous).to eq artists[0]
+    end
+    it 'next returns the next item' do
+      expect(paginator.next).to eq artists[2]
+    end
+  end
+
+  context 'when current is the first item' do
+    let(:current_id) { artists[0].id }
+    it 'previous returns the last item' do
+      expect(paginator.previous).to eq artists[2]
+    end
+    it 'next returns the next item' do
+      expect(paginator.next).to eq artists[1]
+    end
+  end
+
+  context 'when current is the last item' do
+    let(:current_id) { artists[2].id }
+    it 'previous returns the previous item' do
+      expect(paginator.previous).to eq artists[1]
+    end
+    it 'next returns the first item' do
+      expect(paginator.next).to eq artists[0]
+    end
+  end
+
+  context "when the current id doesn't match anything" do
+    let(:current_id) { 120_000 }
+    it 'previous returns the last item' do
+      expect(paginator.previous).to eq artists[2]
+    end
+    it 'next returns the first item' do
+      expect(paginator.next).to eq artists[0]
+    end
+  end
+end


### PR DESCRIPTION
Problem
--------

As a visitor to the open studios event I have clicked on one artist from the Catalog page. If there was a Next Artist button, I could thumb through all the participating artists without having to go back to the Catalog page and pick another artist.

Wouldn't that be fun?

Solution
--------

Build a paginator to figure out whos previous and next and then
render links to these artists on the artist/show page in the catalog.

Screenshots
-------------

<img width="1019" alt="Screen Shot 2021-04-18 at 10 14 41 AM" src="https://user-images.githubusercontent.com/427380/115154308-0c960f00-a02f-11eb-8d69-b0488a758274.png">
<img width="563" alt="Screen Shot 2021-04-18 at 10 14 47 AM" src="https://user-images.githubusercontent.com/427380/115154315-10299600-a02f-11eb-8049-befbf7fdfdd3.png">
