### PR TITLE
Copy change on contact artist form

### DIFF
--- a/app/webpack/reactjs/components/contact_artist_form.tsx
+++ b/app/webpack/reactjs/components/contact_artist_form.tsx
@@ -72,7 +72,9 @@ export const ContactArtistForm: FC<ContactArtistFormProps> = ({
 
   return (
     <div className="contact-artist__container">
-      <h3 className="contact-artist__header">Send the artist a note!</h3>
+      <h3 className="contact-artist__header">
+        Send the artist a note about this piece!
+      </h3>
       <Formik
         initialValues={DEFAULT_FORM_VALUES}
         onSubmit={handleSubmit}


### PR DESCRIPTION
Problem
--------

Might be unclear that the note is about the piece you're on.

https://www.pivotaltracker.com/story/show/177807701

Solution
--------

To reduce any barriers and make it clear that the note is about *this*
piece, update the copy on the form to say "Send the artist a note about
*this* piece!".