### PR TITLE
More futzing with the header

### DIFF
--- a/app/views/open_studios_subdomain/artists/_catalog_paginator.html.slim
+++ b/app/views/open_studios_subdomain/artists/_catalog_paginator.html.slim
@@ -2,6 +2,5 @@
 .catalog-paginator__container
   = link_to @paginator.previous, title: @paginator.previous.name, class: "catalog-paginator__link catalog-paginator__link--prev" do
     = fa_icon "chevron-left"
-  .catalog-paginator__main.pure-u-sm-hidden Catalog
   = link_to @paginator.next, title: @paginator.next.name, class: "catalog-paginator__link catalog-paginator__link--next" do
     = fa_icon "chevron-right"

--- a/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_container_header.scss
@@ -41,6 +41,13 @@
   top: 2px;
   position: relative;
   @include ellipsis;
+  padding-left: 215px;
+  padding-right: 70px;
+  @media screen and (max-width: $screen-sm-max) {
+    font-size: 1.05rem;
+    letter-spacing: -0.04rem;
+    padding-left: 40px;
+  }
 }
 
 .container-header__logo {


### PR DESCRIPTION
After breaking things again, I sat down with Trish and we agreed that
the centering of the name was less important and preventing overlap was
more important so this PR does exactly that.

* Re-instate the padding and have it handle the full title.
* Use smaller font size on mobile
* Remove catalog from the navigation on the right

<img width="377" alt="Screen Shot 2021-04-20 at 7 41 16 AM" src="https://user-images.githubusercontent.com/427380/115415685-f6618d80-a1ab-11eb-8c5e-c21bb343cf7e.png">
<img width="578" alt="Screen Shot 2021-04-20 at 7 41 23 AM" src="https://user-images.githubusercontent.com/427380/115415690-f792ba80-a1ab-11eb-91e1-c243201d9691.png">
<img width="923" alt="Screen Shot 2021-04-20 at 7 41 31 AM" src="https://user-images.githubusercontent.com/427380/115415694-f95c7e00-a1ab-11eb-9e9a-615c9ca04446.png">
