### PR TITLE
Remove address restriction for os registration

### DIFF
--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -5,16 +5,12 @@ module Api
     before_action :artist_required
 
     def register_for_open_studios
-      if current_artist.can_register_for_open_studios?
-        participant = UpdateArtistService.new(current_artist, os_participation: params[:participation]).update_os_status
+      participant = UpdateArtistService.new(current_artist, os_participation: params[:participation]).update_os_status
 
-        render json: {
-          success: true,
-          participant: participant.as_json(root: false),
-        }
-      else
-        render json: { success: false, participant: nil }, status: :bad_request
-      end
+      render json: {
+        success: true,
+        participant: participant.as_json(root: false),
+      }
     end
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -46,18 +46,6 @@ class ArtistsController < ApplicationController
     redirect_to(edit_artist_path(current_user, anchor: 'events'))
   end
 
-  def update_os_status_message(status, artist, os_event)
-    if status
-      "Thanks for participating in Open Studios #{os_event.for_display(reverse: true)}!\n"\
-      "Please confirm your studio address: #{artist.address}.\n"\
-      "Look for an email with more info.\n"\
-      "It's FREE to participate, we are completely donation and volunteer supported."
-    else
-      "You're account needs more info before you can "\
-      'register for Open Studios (probably an address or studio).'
-    end
-  end
-
   def my_profile
     redirect_to edit_artist_path(current_user, anchor: 'events')
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -109,10 +109,6 @@ class Artist < User
     images.to_h
   end
 
-  def can_register_for_open_studios?
-    studio.present? || address.present?
-  end
-
   def in_the_mission?
     return false unless address.present? && address.geocoded?
 

--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -16,7 +16,6 @@ class ArtistPresenter < UserPresenter
            :artist?,
            :artist_info,
            :at_art_piece_limit?,
-           :can_register_for_open_studios?,
            :current_open_studios_participant,
            :doing_open_studios?,
            :in_the_mission?,

--- a/app/services/update_artist_service.rb
+++ b/app/services/update_artist_service.rb
@@ -27,10 +27,6 @@ class UpdateArtistService
 
   def update_os_status
     participating = to_boolean(@params[:os_participation])
-    unless @artist.can_register_for_open_studios?
-      Rails.logger.info("#{@artist.login} isn't eligible to register to #{@current_os}")
-      return
-    end
     if participating != @artist.doing_open_studios?
       if participating
         OpenStudiosParticipationService.participate(@artist, @current_os)

--- a/app/views/artists/edit/_open_studios_status.html.slim
+++ b/app/views/artists/edit/_open_studios_status.html.slim
@@ -5,31 +5,22 @@
     .fa.fa-icon.panel-opener
 .panel-collapse.collapse#events role="tabpanel"
   .panel-body
-    - if !current_user.can_register_for_open_studios?
-      p You need to specify an address or studio affiliation to sign up for Open Studios!
-      p
-        | Check the
-        '
-        em Address/Studio Info
-        '
-        | section below.
-    - else
-      = react_component id: "os-registration", component: "OpenStudiosRegistrationSection", props: { \
-          location: (current_user.studio.present? ? current_user.studio.name : current_user.address.to_s), \
-          artist_id: current_user.id, \
-          participant: current_user.current_open_studios_participant.as_json(root:false), \
-          open_studios_event: { \
-            date_range: current_open_studios.date_range_with_year, \
-            start_time: current_open_studios.start_time, \
-            end_time: current_open_studios.end_time, \
-            special_event: { \
-              date_range: current_open_studios.special_event_date_range_with_year,\
-              time_slots: current_open_studios.special_event_time_slots,
-            } \
-          }\
-        }
+    = react_component id: "os-registration", component: "OpenStudiosRegistrationSection", props: { \
+        location: (current_user.studio.present? ? current_user.studio.name : current_user.address.to_s), \
+        artist_id: current_user.id, \
+        participant: current_user.current_open_studios_participant.as_json(root:false), \
+        open_studios_event: { \
+          date_range: current_open_studios.date_range_with_year, \
+          start_time: current_open_studios.start_time, \
+          end_time: current_open_studios.end_time, \
+          special_event: { \
+            date_range: current_open_studios.special_event_date_range_with_year,\
+            time_slots: current_open_studios.special_event_time_slots,
+          } \
+        }\
+      }
 
-      .donate
-        .note If you'd like to donate, here is our paypal link.  And Thanks!
-        .form-group
-          a.pure-button.button-secondary#donate_for_openstudios href="#" Donate
+    .donate
+      .note If you'd like to donate, here is our paypal link.  And Thanks!
+      .form-group
+        a.pure-button.button-secondary#donate_for_openstudios href="#" Donate

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@
   'Gouache',
   'Jewelry',
   'Mixed-Media',
+  'Painting',
   'Painting - Acrylic',
   'Painting - Encaustic',
   'Painting - Oil',

--- a/features/artists/open_studios_signup.feature
+++ b/features/artists/open_studios_signup.feature
@@ -82,12 +82,3 @@ Scenario: "when I'm logged in"
 
   When I visit the open studios page
   Then I see a "Artist Registration" link
-
-Scenario: "when I try to register without an address i'm not allowed"
-  When I login as "no_address"
-  And I visit the open studios page
-  And I click on "Artist Registration"
-
-  Then I see my profile edit form
-  And I see the "events" profile panel is open
-  And I see "Check the Address" on the page

--- a/spec/controllers/artists_controller_spec.rb
+++ b/spec/controllers/artists_controller_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 require 'htmlentities'
 
 describe ArtistsController, elasticsearch: :stub do
-  let(:studio) { create :studio }
-  let(:admin) { FactoryBot.create(:artist, :admin) }
-  let(:number_of_art_pieces) { 1 }
-  let(:artist_info) { artist.artist_info }
   let(:artist) do
     FactoryBot.create(:artist, :with_art,
                       studio: studio,
@@ -19,7 +15,6 @@ describe ArtistsController, elasticsearch: :stub do
   let(:number_of_art_pieces) { 1 }
   let(:artist_info) { artist.artist_info }
   let(:artist2) { FactoryBot.create(:artist, :active, studio: studio) }
-  let(:without_address) { FactoryBot.create(:artist, :active, :without_address) }
   let(:artists) do
     [artist] + FactoryBot.create_list(:artist, 2, :with_studio, :with_tagged_art, number_of_art_pieces: 1)
   end


### PR DESCRIPTION
Problem
---------

Virtual open studios doesn't require an address.

Solution
----------

Remove the address/studio affiliation constraint on os sign up.