### PR TITLE
Wrap os participant list on index page

### DIFF
--- a/app/views/open_studios/index.html.slim
+++ b/app/views/open_studios/index.html.slim
@@ -8,13 +8,13 @@
 .pure-g.tab-content
   .pure-u-1-1#about
     .pure-g
-      .pure-u-1-1.pure-u-md-2-3.pure-u-lg-3-5.padded-content
+      .pure-u-1-1.pure-u-md-5-6.pure-u-lg-3-5.padded-content
         = render_cms_content @presenter.packaged_summary
         = render_cms_content @presenter.packaged_preview_reception
         .section.open-studios-index__section
           h4.section.open-studios-index__header Participating Artists
-          ul.open-studios-index__partipipant-list
+          ul.open-studios-index__participant-list
             - @presenter.participating_artists.each do |artist|
-              li
+              li.open-studios-index__participant
                 = link_to(artist.get_name, artist)
           = render :partial => '/main/info_footer'

--- a/app/webpack/stylesheets/gto/main/_open_studios.scss
+++ b/app/webpack/stylesheets/gto/main/_open_studios.scss
@@ -19,8 +19,21 @@
 }
 .open-studios-index__participant-list {
   margin-top: 0;
-  padding-left: 20px;
-  li {
-    list-style: circle;
+  display: flex;
+  flex-wrap: wrap;
+}
+.open-studios-index__participant {
+  width: 33%;
+  @media screen and (max-width: $screen-lg-max) {
+    width: 49%;
+  }
+  @media screen and (max-width: $screen-md-max) {
+    width: 49%;
+  }
+  @media screen and (max-width: $screen-sm-max) {
+    width: 100%;
+  }
+  @media screen and (max-width: $screen-xs-max) {
+    width: 100%;
   }
 }


### PR DESCRIPTION
on /open_studios/ where we list participants, when the list get's long,
you have to do a lot of scrolling to see everyone.

Solution
--------

Wrap the list to 3 columns or 2 columns (as room permits) so that on
larger screens, you could see a more compact list

Screenshots
-------------
<img width="807" alt="Screen Shot 2021-04-25 at 11 19 12 AM" src="https://user-images.githubusercontent.com/427380/116006258-4468fd80-a5bf-11eb-82b8-1aca14f1a258.png">
<img width="1218" alt="Screen Shot 2021-04-25 at 11 19 19 AM" src="https://user-images.githubusercontent.com/427380/116006260-4763ee00-a5bf-11eb-8051-b8efaaeab04b.png">
<img width="505" alt="Screen Shot 2021-04-25 at 11 20 38 AM" src="https://user-images.githubusercontent.com/427380/116006262-48951b00-a5bf-11eb-80db-d0d9c83b27d0.png">


