### PR TITLE
Allow admins to update artists os status

### DIFF
--- a/app/services/admin_artist_update_service.rb
+++ b/app/services/admin_artist_update_service.rb
@@ -9,7 +9,7 @@ class AdminArtistUpdateService
     updated_count, skipped_count = run_update(os_status_by_artist_id, current_os)
 
     msg = "Updated setting for #{updated_count} artists"
-    msg += sprintf(' and skipped %d artists who are not in the mission or have an invalid address', skipped_count) if skipped_count.positive?
+    msg += sprintf(' and skipped %d artists whose settings did not change', skipped_count) if skipped_count.positive?
     [true, { notice: msg }]
   end
 
@@ -41,7 +41,6 @@ class AdminArtistUpdateService
 
     # return ternary - nil if the artist was skipped, else true if the artist setting was changed, false if not
     def update_artist_os_standing(artist, current_os, doing_it)
-      return nil if artist.address.blank?
       return false if artist.doing_open_studios? == doing_it
 
       if doing_it

--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -58,7 +58,7 @@
                   .tooltip-content
                     = a.reset_password_link
 
-            td data-order=(a.address.present? ? a.doing_open_studios?.to_s : -1)
+            td data-order=(a.active? && a.doing_open_studios?).to_s
               / this make sure that all os settings are sent to the controller
               - if a.active?
                 - checked = a.doing_open_studios?

--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -60,7 +60,7 @@
 
             td data-order=(a.address.present? ? a.doing_open_studios?.to_s : -1)
               / this make sure that all os settings are sent to the controller
-              - if a.address.present? && a.active?
+              - if a.active?
                 - checked = a.doing_open_studios?
                 - name = "os[#{a.id}]"
                 = hidden_field_tag name, "0"


### PR DESCRIPTION
Problem
--------

in https://github.com/bunnymatic/mau/pull/215 we removed the address
restriction from the register for open studios but that method was *not*
used for the frontend which gave that ability to admins.

Solution
---------

Remove address restrictions from the admin flow of updating folks'
open studios participation.