### PR TITLE
Fix GTM template

### DIFF
--- a/app/views/common/_gtagmanager.html.erb
+++ b/app/views/common/_gtagmanager.html.erb
@@ -1,0 +1,11 @@
+<% if Rails.env == "production" %>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe
+      src='https://www.googletagmanager.com/ns.html?id=<%= Conf.gtm_key %>'
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<% else %>
+  <!-- GTM would be here with key '#{Conf.gtm_key}' -->
+<% end %>

--- a/app/views/common/_gtagmanager.html.slim
+++ b/app/views/common/_gtagmanager.html.slim
@@ -1,8 +1,0 @@
-- if Rails.env == "production"
-  javascript:
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src='https://www.googletagmanager.com/ns.html?id=#{Conf.gtm_key}'
-                      height= "0" width = "0" style = "display:none;visibility:hidden" > < /iframe></noscript >
-    <!-- End Google Tag Manager (noscript) -->
-- else
-  <!-- GTM would be here with key '#{Conf.gtm_key}' -->


### PR DESCRIPTION
problem
--------

The GTM partial was causing some issues because the HTML tags where
prefixed with the slim `javascript:` tag which i think caused issues
with formatting. the page had the following

```
<noscript><iframe src='https://www.googletagmanager.com/ns.html?id=GTM-M7V3ZMB'
                  height= "0" width = "0" style = "display:none;visibility:hidden" > < /iframe></noscript >
```

which made the browser complain with
```
Uncaught SyntaxError: Unexpected token '<'
```

solution
---------

make the template a little dumber using erb so that all the tags in the
partial look like regular tags.