### PR TITLE
Fix missing favorite thumbs

### DIFF
--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -16,7 +16,7 @@ module FavoritesHelper
   def draw_micro_favorite(fav, linkless: false)
     return '' unless fav
 
-    img, path, title = get_favorite_image_and_path fav, 'thumb'
+    img, path, title = get_favorite_image_and_path fav
     result = ''
     if img && path
       result << '<li>'

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -93,7 +93,7 @@ class Studio < ApplicationRecord
   end
 
   def get_profile_image(size)
-    photo? ? photo(size) : StudioImage.get_path(self, size)
+    photo(size)
   end
 
   def image_paths

--- a/app/models/studio_image.rb
+++ b/app/models/studio_image.rb
@@ -5,19 +5,4 @@ class StudioImage < ProfileImage
       [kk, path]
     end.to_h
   end
-
-  def self.get_path(studio, size = 'medium')
-    return studio.photo(size) if studio.photo?
-
-    # get path for image of size
-    # size should be either "thumb","small", or "medium"
-    dir = "/studiodata/#{studio.id}/profile/"
-    if studio.profile_image?
-      fname = File.basename(studio.profile_image)
-      ImageFile.get_path(dir, size, fname)
-    else
-      # return default image
-      ImageFile.get_path('/images/', size, 'default-studio.png')
-    end
-  end
 end

--- a/app/views/admin/studios/_studios_table.html.slim
+++ b/app/views/admin/studios/_studios_table.html.slim
@@ -13,7 +13,7 @@ table.js-data-tables.pure-table.pure-table-striped#studios_index
     - studios.each do |studio|
       tr
         td.profile-image
-          img src=studio.image(:thumb)
+          img src=studio.image(:small)
         td
           = link_to studio.name, studio_path(studio)
         td = studio.street

--- a/app/views/studios/_studio_thumb.html.slim
+++ b/app/views/studios/_studio_thumb.html.slim
@@ -4,7 +4,7 @@
   - if studio_thumb.open_studios_artists?
     .os-violator
   a href=studio_thumb.studio_path title=studio_thumb.name
-    .image style='background-image: url("#{studio_thumb.image(:medium)}")'
+    .image style=background_image_style(studio_thumb.image(:medium))
   .studio-card__desc
     .name
       a href=studio_thumb.studio_path title=studio_thumb.name

--- a/app/views/users/_favorite_thumb.slim
+++ b/app/views/users/_favorite_thumb.slim
@@ -1,5 +1,5 @@
 li
-  - img, path, title = get_favorite_image_and_path favorite_thumb, 'thumb'
+  - img, path, title = get_favorite_image_and_path favorite_thumb
   = link_to path, title: title do
-    .favorite-thumb style="background-image: url('#{img}');"
+    .favorite-thumb style=background_image_style(img)
     .favorite-thumb-icon.fa.fa-user


### PR DESCRIPTION
Problem
----------

Some time ago, we dumped the `thumb` size for paperclip but we never
stopped using it.

Solution
---------

Move all cases where we used `thumb` to using `small` (mostly around
favorites) and while in there, use the `background_image_style` helper
more so that we have a consistent rendering of the inline background
image style which we use a bunch.