### PR TITLE
Disconnect favorites.service from angularjs

### DIFF
--- a/app/webpack/angularjs/components/social_buttons/favorite_this.test.js
+++ b/app/webpack/angularjs/components/social_buttons/favorite_this.test.js
@@ -24,7 +24,9 @@ describe("mau.directives.favoriteThis", function () {
     })
   );
   describe("with an art piece", function () {
-    beforeEach(() => {});
+    beforeEach(() => {
+      favService.add.mockClear();
+    });
 
     it("sets up the directive with the art piece attributes", function () {
       var args, e;

--- a/app/webpack/angularjs/services/favorites.service.js
+++ b/app/webpack/angularjs/services/favorites.service.js
@@ -1,35 +1,8 @@
-import { api } from "@services/api";
+import * as svc from "@services/favorites.service";
 import angular from "angular";
-const MUST_LOGIN_MESSAGE = "You need to login before you can favorite things";
 
-const favoritesService = function () {
-  return {
-    add: function (type, id) {
-      return api.users
-        .whoami()
-        .then(function ({ currentUser: { slug } }) {
-          return api.favorites
-            .add(slug, type, id)
-            .then(function ({ message }) {
-              return {
-                message:
-                  message ||
-                  "Great choice for a favorite!  We added it to your collection.",
-              };
-            })
-            .catch(function ({ message }) {
-              return {
-                message:
-                  message ||
-                  "That item doesn't seem to be available to favorite.  If you think it should be, please drop us a note and we'll look into it.",
-              };
-            });
-        })
-        .catch((_err) => ({
-          message: MUST_LOGIN_MESSAGE,
-        }));
-    },
-  };
+const favoritesService = () => {
+  return svc;
 };
 
 angular.module("mau.services").factory("favoritesService", favoritesService);

--- a/app/webpack/js/services/favorites.service.test.ts
+++ b/app/webpack/js/services/favorites.service.test.ts
@@ -1,0 +1,61 @@
+import { api } from "@services/api";
+import expect from "expect";
+
+import * as service from "./favorites.service";
+
+jest.mock("@services/api");
+
+describe("mau.services.favoriteService", function () {
+  beforeEach(function () {
+    jest.resetAllMocks();
+  });
+
+  describe(".add", function () {
+    it("calls the right endpoint to add this favorite if there is a logged in user", async function () {
+      const type = "Artist";
+      const id = "12";
+      const success = {
+        message: "eat at joes",
+      };
+      api.users.whoami = jest.fn().mockResolvedValue({
+        currentUser: {
+          id: 1,
+          login: "the_user",
+          slug: "the_user_slug",
+        },
+      });
+      api.favorites.add = jest.fn().mockResolvedValue(success);
+      const data = await service.add(type, id);
+
+      expect(data.message).toEqual("eat at joes");
+      expect(api.users.whoami).toHaveBeenCalled();
+      expect(api.favorites.add).toHaveBeenCalledWith("the_user_slug", type, id);
+    });
+    it("returns a message if there is not a logged in user", async function () {
+      api.users.whoami = jest.fn().mockResolvedValue({});
+      const data = await service.add("the_type", "the_id");
+      expect(data.message).toEqual(
+        "You need to login before you can favorite things"
+      );
+      expect(api.users.whoami).toHaveBeenCalled();
+      expect(api.favorites.add).not.toHaveBeenCalled();
+    });
+    it("returns a message if there is favoriting fails", async function () {
+      api.users.whoami = jest.fn().mockResolvedValue({
+        currentUser: {
+          id: 1,
+          login: "somebody",
+          slug: "somebody_slug",
+        },
+      });
+      api.favorites.add = jest.fn().mockRejectedValue({});
+      const data = await service.add(null, null);
+      expect(data).toEqual({
+        message:
+          "That item doesn't seem to be available to favorite.  If you think it should be, please drop us a note and we'll look into it.",
+      });
+      expect(api.users.whoami).toHaveBeenCalled();
+      expect(api.favorites.add).not.toHaveBeenCalledWith("xxx");
+    });
+  });
+});

--- a/app/webpack/js/services/favorites.service.ts
+++ b/app/webpack/js/services/favorites.service.ts
@@ -1,0 +1,28 @@
+import { api } from "@services/api";
+const MUST_LOGIN_MESSAGE = "You need to login before you can favorite things";
+
+export const add = function (type: string, id: string | number) {
+  return api.users
+    .whoami()
+    .then(function ({ currentUser: { slug } }) {
+      return api.favorites
+        .add(slug, type, id)
+        .then(function ({ message }) {
+          return {
+            message:
+              message ||
+              "Great choice for a favorite!  We added it to your collection.",
+          };
+        })
+        .catch(function ({ message }) {
+          return {
+            message:
+              message ||
+              "That item doesn't seem to be available to favorite.  If you think it should be, please drop us a note and we'll look into it.",
+          };
+        });
+    })
+    .catch((_err) => ({
+      message: MUST_LOGIN_MESSAGE,
+    }));
+};


### PR DESCRIPTION
As we move more stuff out of angular, this should help us because
it puts the actual functionality of the favorites service in it's own
vanilla service and outside of the angular connection.