### PR TITLE
Simplify phone validation - 10 digits

### DIFF
--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -3,8 +3,8 @@ class PhoneNumberValidator < ActiveModel::EachValidator
     return if value.blank?
 
     stripped = value.gsub(/\D/, '')
-    return if stripped.length == 11 || (stripped.length == 10 && !stripped.starts_with?('1'))
+    return if stripped.length == 10 && !stripped.starts_with?('1')
 
-    record.errors.add attribute, (options[:message] || 'must be 10 or 11 digits')
+    record.errors.add attribute, (options[:message] || 'must be 10 digits and cannot start with a 1')
   end
 end

--- a/app/views/users/edit/_basic_info.html.slim
+++ b/app/views/users/edit/_basic_info.html.slim
@@ -15,7 +15,7 @@
           = form.input :login, label: 'Username'
           = form.input :email, placeholder: 'e.g. leoDaVinci@example.com'
           - if model.class == Artist
-            = form.input :phone, hint: "We will never show this or use this without your permission", input_html: { value: pretty_phone_number(model.phone)}
+            = form.input :phone, placeholder: 'e.g. 415 555-1212',  hint: "We will never show this or use this without your permission", input_html: { value: pretty_phone_number(model.phone)}
     .pure-g
       .pure-u-1-1
         = form.actions do

--- a/features/artists/my_mau.feature
+++ b/features/artists/my_mau.feature
@@ -15,7 +15,7 @@ Scenario: I can edit my profile
   When I click on "Personal Info"
   And I update my personal information with:
   | artist_firstname | artist_lastname | artist_phone            |
-  | joe              | 蕭秋芬           | 1 (415) 555 1212 |
+  | joe              | 蕭秋芬           | (415) 555 1212   |
   And I click on "Save Changes"
 
   Then I see a flash notice including "has been updated"
@@ -59,12 +59,12 @@ Scenario: I can see when I make a mistake
 
   Then I see a flash error including "We had trouble updating your profile."
   Then I see an error in the form "can't be blank"
-  Then I see an error in the form "10 or 11 digits"
+  Then I see an error in the form "10 digits"
 
   When I close the flash
   And I update my personal information with:
   | artist_email               | artist_phone   |
-  | leodvinci@example.com     | 1 234 444 5555 |
+  | leodvinci@example.com     | 234 444 5555   |
   And I click on "Save Changes"
 
   When I click on "Personal Info"

--- a/spec/factories/studios.rb
+++ b/spec/factories/studios.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     lng { -122.41 }
     url { Faker::Internet.url }
     cross_street { Faker::Address.street_name }
-    phone { "1 (415) 555 #{Array.new(4) { rand(10) }.join}" }
+    phone { "(415) 555 #{Array.new(4) { rand(10) }.join}" }
     photo_file_name    { 'new-studio.jpg' }
     photo_content_type { 'image/jpeg' }
     photo_file_size    { 1234 }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     end
 
     trait :with_phone do
-      phone { "1 (415) 555 #{Array.new(4) { rand(10) }.join}" }
+      phone { "(415) 555 #{Array.new(4) { rand(10) }.join}" }
     end
 
     trait :with_photo do

--- a/spec/models/contact_artist_about_art_form_data_spec.rb
+++ b/spec/models/contact_artist_about_art_form_data_spec.rb
@@ -17,7 +17,7 @@ describe ContactArtistAboutArtFormData do
     it 'requires phone looks like an phone' do
       form_data = described_class.new({ phone: '12321' })
       expect(form_data).not_to be_valid
-      expect(form_data.errors['phone']).to include 'must be 10 or 11 digits'
+      expect(form_data.errors['phone']).to be_present
     end
     it 'is valid with only phone and not email' do
       form_data = described_class.new({ name: 'Joe', phone: '2325551212', art_piece_id: 1 })

--- a/spec/models/studio_spec.rb
+++ b/spec/models/studio_spec.rb
@@ -8,9 +8,9 @@ describe Studio do
   it { should validate_presence_of(:name) }
 
   it 'validates and cleans up the phone number on validate' do
-    studio.phone = '1 (415) 555 1212'
+    studio.phone = ' (415) 555 1212'
     expect(studio).to be_valid
-    expect(studio.phone).to eq '14155551212'
+    expect(studio.phone).to eq '4155551212'
   end
 
   it 'has a friendly id' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,9 +40,9 @@ describe User, elasticsearch: :stub do
 
   it 'validates and cleans phone number on validate' do
     user = FactoryBot.build(:user)
-    user.phone = '1 (415) 123 - 4567'
+    user.phone = '(415) 123 - 4567'
     expect(user).to be_valid
-    expect(user.phone).to eq '14151234567'
+    expect(user.phone).to eq '4151234567'
   end
 
   context '.login_or_email_finder' do

--- a/spec/presenters/open_studios_participant_presenter_spec.rb
+++ b/spec/presenters/open_studios_participant_presenter_spec.rb
@@ -17,7 +17,7 @@ describe OpenStudiosParticipantPresenter do
 
   context 'when a participant is doing everything' do
     let(:user) do
-      create(:user, phone: '14155559999')
+      create(:user, phone: '4155559999')
     end
     let(:participant) do
       create(:open_studios_participant,

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -16,10 +16,8 @@ describe 'PhoneNumberValidator' do
   it 'should allow valid phone numbers' do
     valid_numbers = [
       '4155551212',
-      '14155551212',
-      '1 (415) 555 1212',
-      '1 (415) 555-1212',
-      '+1 (415) 555-1212',
+      ' (415) 555 1212',
+      '(415) 555-1212',
       '415A5551212',
     ]
     valid_numbers.each do |test|
@@ -42,17 +40,18 @@ describe 'PhoneNumberValidator' do
     end
   end
   it 'should not allow invalid phone numbers' do
-    valid_numbers = [
+    invalid_numbers = [
       '1AAA5551212',
       '1 (415) 55512',
       '1 (415 555-121a',
       'abc123+1 (415) 555!1212',
       '1 415.111.2222 ext 1234',
     ]
-    valid_numbers.each do |test|
+    invalid_numbers.each do |test|
       subject.phone = test
       subject.validate
-      expect(subject.errors[:phone]).to include('must be 10 or 11 digits'), "#{test} is responding like a valid phone number which it shouldn't"
+      expect(subject.errors[:phone]).to include('must be 10 digits and cannot start with a 1'),
+                                        "#{test} is responding like a valid phone number which it shouldn't"
     end
   end
 end


### PR DESCRIPTION
Problem
--------

as an artist or admin
when I insert/update my phone number
it should be validated as 10 digits
because our phone number formatters (js) do not support 11 digits nicely.

Solution
--------

Harden phone validator to allow *only* 10 digits