### PR TITLE
Fix overlapping studio open studios stars

### DIFF
--- a/app/webpack/stylesheets/gto/studios/_studios.scss
+++ b/app/webpack/stylesheets/gto/studios/_studios.scss
@@ -63,7 +63,7 @@
     position: absolute;
     bottom: 24px;
     right: 24px;
-    z-index: 20;
+    z-index: 2;
   }
 }
 .studios.show {


### PR DESCRIPTION
Problem
--------

Studio open studios stars are too high in the z-index sense.

Solution
--------

Set them back a few layers.