### PR TITLE
Update icon chooser to better handle `blog`

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -197,18 +197,7 @@ class UserPresenter < ViewPresenter
     site = strip_http_from_link(site)
     key = 'star-alt' unless KNOWN_SOCIAL_ICONS.include?(key.to_sym)
     clz = [:fa, 'fa-ico-invert', "fa-#{key}"]
-    icon_chooser = (if /\.tumblr\./.match?(site)
-                      'fa-tumblr'
-                    elsif key.to_sym == :blog
-                      if /\.blogger\./.match?(site)
-                        'fa-blogger'
-                      elsif !site.empty?
-                        site_bits = site.split('.')
-                        "fa-#{site_bits.length > 2 ? site_bits[-3] : site_bits[0]}"
-                      end
-                    else
-                      ''
-                    end)
+    icon_chooser = choose_icon_from_site(site, key) || ''
 
     (clz + [icon_chooser]).join(' ')
   end
@@ -216,6 +205,21 @@ class UserPresenter < ViewPresenter
   private
 
   class << self
+    def choose_icon_from_site(site, key)
+      if /\.tumblr\./.match?(site)
+        'fa-tumblr'
+      elsif key.to_sym == :blog || key.to_sym == :blogger
+        if /\.blogger\./.match?(site)
+          'fa-blogger'
+        elsif site.present?
+          site_bits = site.split('.')
+          "fa-star-alt fa-#{site_bits.length > 2 ? site_bits[-3] : site_bits[0]}"
+        else
+          'fa-star-alt'
+        end
+      end
+    end
+
     def strip_http_from_link(link)
       link.gsub %r{^https?://}, ''
     end

--- a/app/webpack/stylesheets/socicon.scss
+++ b/app/webpack/stylesheets/socicon.scss
@@ -5,13 +5,12 @@
   @include small-rounded-corners;
   &:before {
     font-size: 1.1em;
-    margin-left: -0.05em;
   }
   display: inline-block;
   line-height: 1.4rem;
   font-size: 1.4rem;
   margin: 0;
-  padding: 0;
+  padding: 1px 0 0 0;
   background-color: lighten($gto_gray, 50%);
   color: $gto_dark_teal;
 }


### PR DESCRIPTION
Problem
--------

Recent icon changes busted the unknown blog link so we don't show icons
for blog entries in the artists links form and on their profile.

Solution
--------

Fix that chooser so it properly falls back to a star icon.