### PR TITLE
Hide all special event form elements when there is no special event

### DIFF
--- a/app/views/artists/edit/_open_studios_status.html.slim
+++ b/app/views/artists/edit/_open_studios_status.html.slim
@@ -1,25 +1,30 @@
 / expects form, open_studios_event and current_user as presented current logged in user
+ruby:
+  open_studios_event_props = {
+    date_range: current_open_studios.date_range_with_year,
+    start_time: current_open_studios.start_time,
+    end_time: current_open_studios.end_time,
+  }
+  if (current_open_studios.special_event_date_range_with_year && current_open_studios.special_event_time_slots)
+    open_studios_event_props[:special_event] = {
+      date_range: current_open_studios.special_event_date_range_with_year,
+      time_slots: current_open_studios.special_event_time_slots,
+    }
+  end
+  registration_props = {
+    location: (current_user.studio.present? ? current_user.studio.name : current_user.address.to_s),
+    artist_id: current_user.id,
+    participant: current_user.current_open_studios_participant.as_json(root:false),
+    open_studios_event: open_studios_event_props
+  }
+
 .panel-heading
   h4.panel-title
     = link_to "Open Studios #{open_studios_event.link_text}", '#events', 'data-toggle' => 'collapse', 'data-parent' => '#user-accordion', class: 'collapsed'
     .fa.fa-icon.panel-opener
 .panel-collapse.collapse#events role="tabpanel"
   .panel-body
-    = react_component id: "os-registration", component: "OpenStudiosRegistrationSection", props: { \
-        location: (current_user.studio.present? ? current_user.studio.name : current_user.address.to_s), \
-        artist_id: current_user.id, \
-        participant: current_user.current_open_studios_participant.as_json(root:false), \
-        open_studios_event: { \
-          date_range: current_open_studios.date_range_with_year, \
-          start_time: current_open_studios.start_time, \
-          end_time: current_open_studios.end_time, \
-          special_event: { \
-            date_range: current_open_studios.special_event_date_range_with_year,\
-            time_slots: current_open_studios.special_event_time_slots,
-          } \
-        }\
-      }
-
+    = react_component id: "os-registration", component: "OpenStudiosRegistrationSection", props: registration_props
     .donate
       .note If you'd like to donate, here is our paypal link.  And Thanks!
       .form-group

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.test.tsx
@@ -61,12 +61,12 @@ describe("OpenStudiosInfoForm", () => {
           exact: false,
         });
 
-        expect(dateRanges).toHaveLength(3);
+        expect(dateRanges).toHaveLength(2);
       });
 
       it("shows a form", () => {
         expect(findField("Show my shopping cart link")).toBeInTheDocument();
-        expect(findField("Show my meeting")).toBeInTheDocument();
+        expect(findField("Show my meeting")).not.toBeInTheDocument();
         expect(findField("Show my YouTube video")).toBeInTheDocument();
         expect(findField("Show my e-mail")).toBeInTheDocument();
         expect(findField("Show my phone number")).toBeInTheDocument();
@@ -93,6 +93,16 @@ describe("OpenStudiosInfoForm", () => {
           },
           openStudiosEvent,
         });
+      });
+
+      it("shows a form", () => {
+        expect(findField("Show my shopping cart link")).toBeInTheDocument();
+        expect(findField("Show my meeting")).toBeInTheDocument();
+        expect(findField("Show my YouTube video")).toBeInTheDocument();
+        expect(findField("Show my e-mail")).toBeInTheDocument();
+        expect(findField("Show my phone number")).toBeInTheDocument();
+        expect(findButton("Save")).toBeInTheDocument();
+        expect(findButton("Un-Register Me")).toBeInTheDocument();
       });
 
       it("shows instructions with the special event date range", () => {

--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -113,17 +113,19 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
                       placeholder="e.g. https://www.youtube.com/watch?v=abc123"
                     />
                   </div>
-                  <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--video-conference-url">
-                    <MauTextField
-                      label={`Show my meeting link ${specialEventDateRange} so I can receive virtual visitors (Zoom or other)`}
-                      name="videoConferenceUrl"
-                      placeholder="e.g. https://my.zoom.room.com/me"
-                    />
-                    <SpecialEventScheduleFields
-                      specialEvent={event.specialEvent}
-                      disabled={!values.videoConferenceUrl}
-                    />
-                  </div>
+                  {event.specialEvent && (
+                    <div className="pure-u-1-1 open-studios-info-form__input open-studios-info-form__input--text open-studios-info-form__input--video-conference-url">
+                      <MauTextField
+                        label={`Show my meeting link ${specialEventDateRange} so I can receive virtual visitors (Zoom or other)`}
+                        name="videoConferenceUrl"
+                        placeholder="e.g. https://my.zoom.room.com/me"
+                      />
+                      <SpecialEventScheduleFields
+                        specialEvent={event.specialEvent}
+                        disabled={!values.videoConferenceUrl}
+                      />
+                    </div>
+                  )}
                 </div>
               </fieldset>
               <div className="open-studios-info-form__actions actions">


### PR DESCRIPTION
Problem
---------

If there is no special event, we were still surfacing the
zoom/conference url form field.

https://www.pivotaltracker.com/story/show/178924858

Solution
--------

Be more aggressive about hiding form fields for the case that we don't
have any special event schedule.

Screenshots
-------------

Without special event

![Screen Shot 2021-07-24 at 1 30 41 PM](https://user-images.githubusercontent.com/427380/126880440-89a43d48-168b-47a5-8676-d7d8293a0865.png)

With special event

![Screen Shot 2021-07-24 at 1 31 10 PM](https://user-images.githubusercontent.com/427380/126880442-dc1510c7-944d-4141-a91d-fea877e2622e.png)
