### PR TITLE
Add more info to the confirm open studios registration dialog.

### DIFF
--- a/app/views/admin/tests/react_styleguide.html.slim
+++ b/app/views/admin/tests/react_styleguide.html.slim
@@ -1,3 +1,10 @@
+ruby:
+  small_modal_content = <<~EOMESSAGE
+    Well, that's what you see at a toy store. And you must think you're in a toy store, because you're here shopping for an infant named Jeb.
+  EOMESSAGE
+  large_modal_content = <<~EOMESSAGE
+    Do you see any Teletubbies in here? Do you see a slender plastic tag clipped to my shirt with my name printed on it? Do you see a little Asian child with a blank expression on his face sitting outside on a mechanical helicopter that shakes when you put quarters in it? No? Well, that's what you see at a toy store. And you must think you're in a toy store, because you're here shopping for an infant named Jeb.
+  EOMESSAGE
 .pure-g.react-styleguide-page
   .pure-u-1-1.padded-content.header
     h2.title React Components/Styleguide
@@ -100,15 +107,26 @@
             h3.react-styleguide__component-title ConfirmModal
           .react-styleguide__example
             .react-styleguide__impl
-                = react_component id: "confirm-modal", component: "ConfirmModal", props: { children: "Are you sure?", buttonText: "Confirm This", buttonStyle: "secondary" }
+                = react_component id: "confirm-modal", component: "ConfirmModal", props: { children: small_modal_content, buttonText: "Confirm This", buttonStyle: "secondary" }
             .react-styleguide__code
                 pre
                   code
                     | = react_component
                       id: "confirm-modal", component: "ConfirmModal",
-                        props: { children: "Are you sure?",
+                        props: { children: small_modal_content,
                           buttonText: "Confirm This",
                             buttonStyle: "secondary" }
+          .react-styleguide__example
+            .react-styleguide__impl
+                = react_component id: "confirm-modal", component: "ConfirmModal", props: { children: large_modal_content, buttonText: "Confirm This", buttonStyle: "secondary", variant: "large" }
+            .react-styleguide__code
+                pre
+                  code
+                    | = react_component
+                      id: "confirm-modal", component: "ConfirmModal",
+                        props: { children: large_modal_content }
+                          buttonText: "Confirm This",
+                            buttonStyle: "secondary", variant: "large" }
 
         .react-styleguide__component
           .react-styleguide__header

--- a/app/webpack/reactjs/components/confirm_modal.tsx
+++ b/app/webpack/reactjs/components/confirm_modal.tsx
@@ -3,15 +3,23 @@ import { buttonStyleAttrs, MauButton } from "@reactjs/components/mau_button";
 import { MauModal, setAppElement } from "@reactjs/components/mau_modal";
 import { useModalState } from "@reactjs/hooks";
 import * as types from "@reactjs/types";
+import cx from "classnames";
 import React, { FC } from "react";
 
 type ConfirmModalHandler = (success: boolean) => void;
+
+export enum ConfirmModalVariants {
+  normal = "normal",
+  large = "large",
+}
 
 interface ConfirmModalProps {
   id?: string;
   buttonText: string;
   buttonStyle?: types.MauButtonStyle;
   handleConfirm?: ConfirmModalHandler;
+  containerClass?: string;
+  variant?: "normal" | "large";
 }
 
 export const ConfirmModal: FC<ConfirmModalProps> = ({
@@ -19,6 +27,8 @@ export const ConfirmModal: FC<ConfirmModalProps> = ({
   buttonStyle,
   buttonText,
   handleConfirm,
+  containerClass,
+  variant = ConfirmModalVariants.normal,
   children,
 }) => {
   const { isOpen, open, close } = useModalState();
@@ -43,8 +53,19 @@ export const ConfirmModal: FC<ConfirmModalProps> = ({
         </MauButton>
       </div>
       <MauModal isOpen={isOpen}>
-        <div className="confirm-modal__content">
-          <div className="confirm-modal__content--main">{children}</div>
+        <div
+          className={cx("confirm-modal__content", {
+            [containerClass]: Boolean(containerClass),
+          })}
+        >
+          <div
+            className={cx("confirm-modal__content--main", {
+              "confirm-modal__content--main--large":
+                variant === ConfirmModalVariants.large,
+            })}
+          >
+            {children}
+          </div>
           <div className="confirm-modal__actions">
             <div className="confirm-modal__action-item">
               <MauButton primary onClick={submit(true)}>

--- a/app/webpack/reactjs/components/open_studios/open_studios_registration_section.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_registration_section.tsx
@@ -1,4 +1,7 @@
-import { ConfirmModal } from "@reactjs/components/confirm_modal";
+import {
+  ConfirmModal,
+  ConfirmModalVariants,
+} from "@reactjs/components/confirm_modal";
 import { OpenStudiosInfoForm } from "@reactjs/components/open_studios/open_studios_info_form";
 import { submitRegistration } from "@reactjs/components/open_studios/submit_registration";
 import * as types from "@reactjs/types";
@@ -28,7 +31,7 @@ export const OpenStudiosRegistrationSection: FC<OpenStudiosRegistrationSectionPr
   if (isParticipating) {
     message = `Yay! You are currently registered for Open Studios on ${event.dateRange}`;
   } else {
-    message = `Will you be participating in Open Studios on ${event.dateRange}`;
+    message = `Will you be participating in Open Studios on ${event.dateRange}?`;
   }
 
   const handleRegistration = (registering: boolean) => {
@@ -56,11 +59,24 @@ export const OpenStudiosRegistrationSection: FC<OpenStudiosRegistrationSectionPr
           buttonText="Yes - Register Me"
           buttonStyle="primary"
           handleConfirm={handleRegistration}
+          variant={ConfirmModalVariants.large}
+          containerClass="open-studios-registration-section__modal-content-container"
         >
           <p>
-            This will register you as a participating artist for Open Studios,{" "}
-            {event.dateRange}.
+            You are about to register as a participating artist for Open
+            Studios, {event.dateRange}.
           </p>
+          <p>Which means you will:</p>
+          <ul>
+            <li> Hang some art at your studio - {location}</li>
+            <li>
+              {" "}
+              Open your studio to the public {event.dateRange},{" "}
+              {event.startTime} - {event.endTime} (while complying with local,
+              state & federal guidelines around COVID 19).
+            </li>
+            <li> Promote your art and studio as part of the event.</li>
+          </ul>
           <p>Would you like to continue?</p>
         </ConfirmModal>
       )}

--- a/app/webpack/stylesheets/gto/components/_confirm_modal.scss
+++ b/app/webpack/stylesheets/gto/components/_confirm_modal.scss
@@ -5,6 +5,10 @@
   }
   margin-bottom: 10px;
 }
+.confirm-modal__content--main--large {
+  max-width: 500px;
+}
+
 .confirm-modal__actions {
   display: flex;
   width: 100%;

--- a/app/webpack/stylesheets/gto/components/_open_studios_registration_section.scss
+++ b/app/webpack/stylesheets/gto/components/_open_studios_registration_section.scss
@@ -1,0 +1,10 @@
+.open-studios-registration-section__modal-content-container {
+  ul,
+  ol {
+    margin-left: 10px;
+    & li {
+      list-style-type: circle;
+      margin-left: 10px;
+    }
+  }
+}

--- a/app/webpack/stylesheets/gto/components/index.scss
+++ b/app/webpack/stylesheets/gto/components/index.scss
@@ -15,3 +15,4 @@
 @import "./notify_mau_dialog";
 @import "./art_pieces_browser.scss";
 @import "./social_buttons.scss";
+@import "./open_studios_registration_section.scss";

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -13,7 +13,7 @@ end
 
 Then('I see the registration dialog') do
   within('.ReactModal__Content') do
-    expect(page).to have_content 'This will register you as a participating artist for Open Studios'
+    expect(page).to have_content 'You are about to register as a participating artist for Open Studios'
     expect(page).to have_content('Yes')
     expect(page).to have_content('No')
   end


### PR DESCRIPTION
Problem
--------

As we go back to in person OS, we want to make sure folks know what
they are signing up for so they don't accidentally say their doing
open studios without realizing that they should be present at their
studio.

https://www.pivotaltracker.com/story/show/178997715

Solution
---------

Re-instate (and update) the confirm message when you say i want to
register for open studios.

Screenshot
-------------
<img width="894" alt="Screen Shot 2021-08-08 at 5 58 28 PM" src="https://user-images.githubusercontent.com/427380/128651367-2eaac9d6-6f35-465b-9d88-e12363a98673.png">
