### PR TITLE
Add address with link to the artist open studios page

### DIFF
--- a/app/presenters/open_studios_participant_presenter.rb
+++ b/app/presenters/open_studios_participant_presenter.rb
@@ -7,6 +7,18 @@ class OpenStudiosParticipantPresenter
     @participant = open_studios_participant
   end
 
+  def address
+    (@participant.user).becomes(Artist).address
+  end
+
+  def full_address
+    (@participant.user).becomes(Artist).full_address
+  end
+
+  def map_link
+    (@participant.user).becomes(Artist).map_link
+  end
+
   def broadcasting?
     Time.use_zone(Conf.event_time_zone) do
       now = Time.zone.now

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -32,6 +32,16 @@
               = fa_icon("instagram")
           .open-studios-artist__details__item--title
              = link_to "My Instagram", artist.keyed_links[:instagram], target: "_blank"
+      .open-studios-artist__details__item.open-studios-artist__details__address
+        = info.address.street
+        | ,
+        '
+        = info.address.city
+        '
+        = info.address.zipcode
+        span.open-studios-artist__details__address--icon
+          = link_to info.map_link, title: :map, target: "_blank" do
+            i.fa.fa-map-marker
       - if info.show_email? || info.show_phone?
         .open-studios-artist__details__item.open-studios-artist__details__contact
           - if info.show_email?

--- a/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_open_studios_artist.scss
@@ -78,10 +78,14 @@
   margin-top: 18px;
 }
 
+.open-studios-artist__details__address,
 .open-studios-artist__details__contact {
   line-height: 1.2rem;
   padding-top: 12px;
   @include light-top-border;
+}
+.open-studios-artist__details__address--icon {
+  margin-left: 10px;
 }
 
 .open-studios-artist__details__email--link {

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -185,7 +185,9 @@ Then('I see the summary information about that artists open studios events') do
   within('.open-studios-artist__info') do
     expect(page).to have_link 'My Shop', href: @artist.current_open_studios_participant.shop_url
     expect(page).to have_content @artist.email
+    expect(page).to have_content @artist.address.street
     expect(page).to have_link 'My Website', href: @artist.links[:website]
+    expect(page).to have_link 'map', href: @artist.map_link
   end
 end
 


### PR DESCRIPTION
Problem
--------

We want to show people's address on their open studios page as we move
towards a possibly in public Open Studios.

https://www.pivotaltracker.com/story/show/178997726

Solution
---------

Add the address to the open studios page with a link to google map.


![Screen Shot 2021-08-14 at 3 51 43 PM](https://user-images.githubusercontent.com/427380/129462086-14ac870b-ecd9-48e4-82fe-3fe5daa20216.png)
