### PR TITLE
Fix youtube embed video constructor code

### DIFF
--- a/app/helpers/you_tube_helper.rb
+++ b/app/helpers/you_tube_helper.rb
@@ -1,11 +1,26 @@
 module YouTubeHelper
-  YOUTUBE_URL_REGEX = %r{\?(v=|embed/|v/?)(\S+)?$}.freeze
+  YOUTUBE_URL_REGEX = %r{\?(v=|embed/|v/?)([^&\s]+)?}.freeze
+  YOUTUBE_SHORT_URL_REGEX = %r{//youtu\.be/(.*)$}.freeze
+
+  def _embed_url_from_url(url)
+    matches = YOUTUBE_URL_REGEX.match(url)
+    video_id = (if matches
+                  matches[2]
+                else
+                  matches = YOUTUBE_SHORT_URL_REGEX.match(url)
+                  matches && matches[1]
+                end)
+
+    return nil unless video_id
+
+    "https://www.youtube.com/embed/#{video_id}"
+  end
 
   def embed_you_tube(url, title: '', height: 200, width: '100%')
-    matches = YOUTUBE_URL_REGEX.match(url)
-    return '' unless matches
+    embed_url = _embed_url_from_url(url)
 
-    embed_url = "https://www.youtube.com/embed/#{matches[2]}"
+    return '' unless embed_url
+
     tag.iframe({ width: width,
                  height: height,
                  src: embed_url,

--- a/spec/helpers/you_tube_helper_spec.rb
+++ b/spec/helpers/you_tube_helper_spec.rb
@@ -25,4 +25,24 @@ describe YouTubeHelper do
     expect(rendered.attribute('height').value).to eq '40'
     expect(rendered.attribute('title').value).to eq 'whatever'
   end
+
+  describe '_embed_url_from_url' do
+    youtube_urls = [
+      'https://youtu.be/23ihawJKZcE',
+      'https://www.youtube.com/watch?v=23ihawJKZcE&feature=featured',
+      'https://www.youtube.com/watch?v=23ihawJKZcE',
+      'http://www.youtube.com/watch?v=23ihawJKZcE',
+      'https://youtube.com/watch?v=23ihawJKZcE',
+      'http://youtube.com/watch?v=23ihawJKZcE',
+      'https://m.youtube.com/watch?v=23ihawJKZcE',
+      'http://m.youtube.com/watch?v=23ihawJKZcE',
+      'https://www.youtube.com/watch?v=23ihawJKZcE',
+    ]
+
+    youtube_urls.each do |url|
+      it "returns the embed url for #{url}" do
+        expect(helper._embed_url_from_url(url)).to eq 'https://www.youtube.com/embed/23ihawJKZcE'
+      end
+    end
+  end
 end

--- a/spec/validators/youtube_url_validator_spec.rb
+++ b/spec/validators/youtube_url_validator_spec.rb
@@ -15,6 +15,7 @@ describe YoutubeUrlValidator do
 
   describe 'for a valid youtube url' do
     valid_youtube_urls = [
+      'https://youtu.be/VPfjWsbCZV0',
       'https://www.youtube.com/watch?v=23ihawJKZcE&feature=featured',
       'https://www.youtube.com/watch?v=23ihawJKZcE',
       'http://www.youtube.com/watch?v=23ihawJKZcE',


### PR DESCRIPTION
Problem
--------

The code we had to build a youtube embed url didn't work for the
commonly extracted short version `http://youtu.be/videoidgoeshere' video
format.

Solution
--------

Update the code around extracting the video id from youtube to better
align with and work with all our allowed video url formats.