### PR TITLE
Add max validator for price now that we're using a Decimal column

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -13,7 +13,7 @@ class ArtPiece < ApplicationRecord
                                     message: 'Only JPEG, PNG, and GIF images are allowed'
   validates_attachment_size :photo, less_than: 8.megabytes
   validates :artist_id, presence: true
-  validates :price, numericality: { greater_than_or_equal_to: 0.01 }, allow_nil: true
+  validates :price, numericality: { greater_than_or_equal_to: 0.01, less_than_or_equal_to: 99_999_999 }, allow_nil: true
 
   include Elasticsearch::Model
 

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -8,7 +8,7 @@ describe ArtPiece do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_least(2).is_at_most(80) }
-    it { is_expected.to validate_numericality_of(:price).allow_nil.is_greater_than_or_equal_to(0.01) }
+    it { is_expected.to validate_numericality_of(:price).allow_nil.is_greater_than_or_equal_to(0.01).is_less_than_or_equal_to(99_999_999) }
     it { is_expected.to validate_attachment_size(:photo).less_than(8.megabytes) }
   end
   describe 'new' do


### PR DESCRIPTION
Problem
--------

After a shift to a decimal column, the max value went way down and we
should now include a max validator before the db craps out with an out
of range error.

Solution
---------

Add a max value model validator to prevent the underlying db out of
range exception from hitting.