### PR TITLE
Add tracking classes for gtm

### DIFF
--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -9,29 +9,29 @@
       - if info.broadcasting?
         .open-studios-artist__details__item.open-studios-artist__details__live-conference-url
           .open-studios-artist__details__item--title
-            = link_to "Visit me now", info.video_conference_url, target: "_blank"
+            = link_to "Visit me now", info.video_conference_url, target: "_blank", class: 'gtm_catalog_video_conference_url'
       - if info.has_shop?
         .open-studios-artist__details__item.open-studios-artist__details__item--link.open-studios-artist__details__shop-url
           .open-studios-artist__details__item--icon.open-studios-artist__details__item--icon--shop
-            = link_to info.shop_url, target: "_blank" do
+            = link_to info.shop_url, target: "_blank", class: "gtm_catalog_shop_url" do
               = fa_icon("cart-arrow-down")
           .open-studios-artist__details__item--title
-            = link_to "My Shop", info.shop_url, target: "_blank"
+            = link_to "My Shop", info.shop_url, target: "_blank",  class: "gtm_catalog_shop_url"
       - if artist.keyed_links[:website]
         .open-studios-artist__details__item.open-studios-artist__details__item--link.open-studios-artist__details__shop-url
           .open-studios-artist__details__item--icon
 
-            = link_to artist.keyed_links[:website], target: "_blank" do
+            = link_to artist.keyed_links[:website], target: "_blank",  class: "gtm_catalog_website_url" do
               = fa_icon("star-alt")
           .open-studios-artist__details__item--title
-            = link_to "My Website", artist.keyed_links[:website], target: "_blank"
+            = link_to "My Website", artist.keyed_links[:website], target: "_blank", class: "gtm_catalog_website_url"
       - if artist.keyed_links[:instagram]
         .open-studios-artist__details__item.open-studios-artist__details__item--link.open-studios-artist__details__shop-url
           .open-studios-artist__details__item--icon
-            = link_to artist.keyed_links[:instagram], target: "_blank" do
+            = link_to artist.keyed_links[:instagram], target: "_blank", class: "gtm_catalog_instagram_url" do
               = fa_icon("instagram")
           .open-studios-artist__details__item--title
-             = link_to "My Instagram", artist.keyed_links[:instagram], target: "_blank"
+             = link_to "My Instagram", artist.keyed_links[:instagram], target: "_blank", class: "gtm_catalog_instagram_url"
       .open-studios-artist__details__item.open-studios-artist__details__address
         = info.address.street
         | ,
@@ -40,7 +40,7 @@
         '
         = info.address.zipcode
         span.open-studios-artist__details__address--icon
-          = link_to info.map_link, title: :map, target: "_blank" do
+          = link_to info.map_link, title: :map, target: "_blank", class: "gtm_catalog_map_marker" do
             i.fa.fa-map-marker
       - if info.show_email? || info.show_phone?
         .open-studios-artist__details__item.open-studios-artist__details__contact
@@ -49,7 +49,7 @@
               = react_component id:"mailer", component:"Mailer", classes: 'open-studios-artist__details__email--link', props: { subject: "I saw your work on Mission Artists Virtual Open Studios!", text: artist.email, **split_email(artist.email) }
           - if info.show_phone?
             .open-studios-artist__details__phone
-              = link_to artist.phone_for_display, "tel:#{artist.phone}", target: "_blank"
+              = link_to artist.phone_for_display, "tel:#{artist.phone}", target: "_blank", class: "gtm_catalog_phone_link"
       - if info.has_youtube?
         .open-studios-artist__details__item.open-studios-artist__details__youtube
           = embed_you_tube(info.youtube_url)

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -2,7 +2,7 @@
 Feature: Open Studios Catalog
   As a visitor
   I can visit the main catalog page
-  and any cms content that an admin might have added
+  and see any cms content that an admin might have added exists
 
 Background:
   Given there are open studios artists with art in the system
@@ -22,6 +22,7 @@ Scenario:
   And I see the summary information about that artists open studios events
   And I see the artist's open studios you tube embed video
   And I see details about the art on each art card
+  And I see the gtm tracking classes on the links
 
   When I click on the first art card in the catalog
   Then I see that art in a modal
@@ -47,6 +48,8 @@ Scenario: Visitors see the "visit me now" button when artists are broadcasting
   When I click on the first artist's card
   Then I see the artist's name in the header title
   And I see a "Visit me now" link which goes to their conference call
+  And I see the gtm tracking class on the conference call link
+
 
 Scenario: An artist sees their own pages
   Given the following artists with art are in the system:

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -210,6 +210,16 @@ When('I see my video conference schedule') do
     .to have(merge_timeslots(@artist.current_open_studios_participant.video_conference_time_slots).length).entries
 end
 
+Then('I see the gtm tracking classes on the links') do
+  expect(page).to have_css('.gtm_catalog_shop_url')
+  expect(page).to have_css('.gtm_catalog_website_url')
+  expect(page).to have_css('.gtm_catalog_map_marker')
+end
+
+Then('I see the gtm tracking class on the conference call link') do
+  expect(page).to have_css('.gtm_catalog_video_conference_url')
+end
+
 Then('I see details about the art on each art card') do
   pieces = @artist.art_pieces
   expect(pieces).to have_at_least(1).piece


### PR DESCRIPTION
problem
-------

we want to track folks with gtm to figure out where our users are
clicking on catalog pages...
mostly so we can report back to users : "hey, 10 people clicked on your
video" or "10 people clicked on your instagram link".

https://www.pivotaltracker.com/story/show/178997720

solution
--------

Add `gtm_` prefixed classes for links on the artist's catalog page.

The following classes can be used for tracking

* gtm_catalog_video_conference_url
* gtm_catalog_shop_url
* gtm_catalog_website_url
* gtm_catalog_instagram_url
* gtm_catalog_phone_link