### PR TITLE
Add language to html tags

### DIFF
--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html
+html lang='en'
   head
     = render '/extra_html_head'
     = render '/title'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html
+html lang='en'
   head
     = render '/extra_html_head'
     = render '/title'
@@ -25,7 +25,7 @@ html
     .body-highlight
     .container
 
-      .sidenav
+      aside.sidenav
         .sidenav__main
           a.brand href=root_path title="Mission Artists"
             .sidebar-logo title="Mission Artists" class="#{Date.today.month == 6 ? 'sidebar-logo--pride' : ''}"
@@ -38,7 +38,7 @@ html
           = render '/common/social_links'
           = render '/common/footer_links', revision: @revision
 
-      .main-container.js-main-container
+      main.main-container.js-main-container
         = render '/flash_notice_error'
         = yield
     javascript:

--- a/app/views/layouts/openstudios.html.slim
+++ b/app/views/layouts/openstudios.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html
+html lang='en'
   head
     = render '/extra_html_head'
     = render '/common/ganalytics'


### PR DESCRIPTION
Problem
--------

A11y reports remind us that we should specify the sites default
language.

Solution
----------

* Add `lang="en"` to html tags
* add `aside` for the sidebar and `main` for the main body of the site