### PR TITLE
Add studio info to address in catalog

### DIFF
--- a/app/presenters/artist_presenter.rb
+++ b/app/presenters/artist_presenter.rb
@@ -113,10 +113,6 @@ class ArtistPresenter < UserPresenter
     number.present? ? "##{number}" : ''
   end
 
-  def studio_with_number
-    studio_name.present? ? "#{studio_name} #{studio_number}" : ''
-  end
-
   def map_url
     @map_url ||= model.map_link
   end

--- a/app/presenters/open_studios_participant_presenter.rb
+++ b/app/presenters/open_studios_participant_presenter.rb
@@ -3,6 +3,9 @@ class OpenStudiosParticipantPresenter
   attr_reader :participant
 
   delegate :video_conference_url, :video_conference_time_slots, :youtube_url, :show_email?, :shop_url, :updated_at, to: :participant
+
+  delegate :studio, to: :artist
+
   def initialize(open_studios_participant)
     @participant = open_studios_participant
   end
@@ -13,6 +16,10 @@ class OpenStudiosParticipantPresenter
 
   def full_address
     (@participant.user).becomes(Artist).full_address
+  end
+
+  def studio_number
+    artist&.artist_info&.studionumber
   end
 
   def map_link

--- a/app/views/open_studios_subdomain/artists/_address_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_address_info.html.slim
@@ -1,0 +1,22 @@
+/ expects an OpenStudiosParticipation entry as info
+- if info.studio
+  .open-studios-artist__details__studio-address
+    .open-studios-artist__details__studio-address__name
+      = info.studio.name
+    .open-studios-artist__details__studio-address__address-line-1
+      = info.address.street + ( info.studio_number ? " ##{info.studio_number}" : "")
+      span.open-studios-artist__details__address--icon
+        = link_to info.map_link, title: :map, target: "_blank", class: "gtm_catalog_map_marker" do
+          i.fa.fa-map-marker
+    .open-studios-artist__details__studio-address__address-line-2
+      = info.address.city
+
+- else
+  .open-studios-artist__details__studio-address
+    .open-studios-artist__details__studio-address__address-line-1
+      = info.address.street
+      span.open-studios-artist__details__address--icon
+        = link_to info.map_link, title: :map, target: "_blank", class: "gtm_catalog_map_marker" do
+          i.fa.fa-map-marker
+  .open-studios-artist__details__studio-address__address-line-2
+    = info.address.city

--- a/app/views/open_studios_subdomain/artists/_info.html.slim
+++ b/app/views/open_studios_subdomain/artists/_info.html.slim
@@ -33,15 +33,7 @@
           .open-studios-artist__details__item--title
              = link_to "My Instagram", artist.keyed_links[:instagram], target: "_blank", class: "gtm_catalog_instagram_url"
       .open-studios-artist__details__item.open-studios-artist__details__address
-        = info.address.street
-        | ,
-        '
-        = info.address.city
-        '
-        = info.address.zipcode
-        span.open-studios-artist__details__address--icon
-          = link_to info.map_link, title: :map, target: "_blank", class: "gtm_catalog_map_marker" do
-            i.fa.fa-map-marker
+        = render partial: "address_info", locals: { info: info }
       - if info.show_email? || info.show_phone?
         .open-studios-artist__details__item.open-studios-artist__details__contact
           - if info.show_email?


### PR DESCRIPTION
Problem
-------

As reported in the ticket

> When I look at an artist page on the open studios catalog, I can't tell if they are in a group studio. I also don't know what their studio number is (if they have one.) Let's show the studio name and the studio number in the way we do on the main site. However, do NOT link to the studio page. That'll take the visitor off the catalog subdomain and stick them on the main site and that will be confusing.
>
> Also maybe remove the zip code. That's info that's just taking up space.

https://www.pivotaltracker.com/story/show/179631968

Solution
--------

Update the address rendering to dump zipcode and be smarter about studio
relationships.

Screenshots
-------------

Without studio info and with studio info (studio name is Ortiz Group3)
<img width="659" alt="Screen Shot 2021-09-19 at 11 19 12 AM" src="https://user-images.githubusercontent.com/427380/133938405-6a2e9c7c-9d08-4d9e-93db-e24031ab7d2a.png">
<img width="635" alt="Screen Shot 2021-09-19 at 11 19 27 AM" src="https://user-images.githubusercontent.com/427380/133938407-7dbfd1b9-c4ec-44fd-bd64-44ccdcd9f64d.png">

