### PR TITLE
Responsive images in markdown content

### DIFF
--- a/app/webpack/stylesheets/gto/_cms_documents.scss
+++ b/app/webpack/stylesheets/gto/_cms_documents.scss
@@ -1,6 +1,11 @@
 @use "../colors" as c;
 @use "../mixins" as m;
 
+.section.markdown {
+  img {
+    max-width: 100%;
+  }
+}
 .section.markdown.editable {
   position: relative;
   .editable-content-trigger {


### PR DESCRIPTION
Problem
--------

For images in markdown, they don't scale well for mobile.

Solution
---------

Add a rule - max-width: 100% - so they better scale to fit.

Screenshots
-------------

**BEFORE**

![Screen Shot 2022-03-22 at 2 41 51 PM](https://user-images.githubusercontent.com/427380/159581018-34769cd0-228f-4249-8920-3a5287ffc36b.png)

**AFTER**

![Screen Shot 2022-03-22 at 2 41 41 PM](https://user-images.githubusercontent.com/427380/159581012-afd0606c-24eb-4915-a9f6-1781654337f8.png)
