### PR TITLE
Security bump Rack 2.2.3.1 - CVE-2022-30123

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       mojo_magick (~> 0.6.5)
       rqrcode_core (~> 0.1)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-handlers (0.7.3)


### PR DESCRIPTION
https://github.com/advisories/GHSA-wq4h-7r42-5hrr