### PR TITLE
Gzip app generated responses

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,8 @@ module Mau
 
     config.cache_store = :mem_cache_store, { namespace: "mau#{Rails.env}" }
 
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
+
     # app_paths = %w(services lib mailers presenters paginators models/concerns)
     # config.autoload_paths += app_paths.map{|path| File.join(Rails.root,'app', path)}
 


### PR DESCRIPTION
Following from https://github.com/carbonfive/raygun-rails/pull/691,
and https://www.schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/
we can add compression for responses generated by the app which
should include the html/views and JSON responses.

After turning this on, we see that both html and json responses have Gzip treatment.

<img width="684" alt="Screen Shot 2022-05-30 at 6 59 22 PM" src="https://user-images.githubusercontent.com/427380/171078178-4dcd9dcb-f908-4a2f-b24a-81e527a32342.png">
<img width="620" alt="Screen Shot 2022-05-30 at 7 00 16 PM" src="https://user-images.githubusercontent.com/427380/171078184-71bf766e-3ae1-4300-9b59-ac9c99f3ce50.png">

