### PR TITLE
Center thumb images on search

### DIFF
--- a/app/webpack/stylesheets/gto/components/search_results.scss
+++ b/app/webpack/stylesheets/gto/components/search_results.scss
@@ -54,6 +54,7 @@
     .img {
       width: 100%;
       height: 100%;
+      background-position: center center;
     }
     @media screen and (min-width: v.$screen-sm-max) {
     }


### PR DESCRIPTION
Problem
--------

In some move somewhere we lost the center/center for thumbnails in
search results.

Solution
----------

Add center/center styling

|before|after|
|------|-----|
|<img width="445" alt="Screen Shot 2022-06-20 at 1 41 36 PM" src="https://user-images.githubusercontent.com/427380/174675324-8ebc85da-7bc8-4d5e-b6a6-6ada78602426.png">|<img width="578" alt="Screen Shot 2022-06-20 at 1 40 46 PM" src="https://user-images.githubusercontent.com/427380/174675323-82402458-d310-413d-9574-a886ff5fb0fa.png">|
