### PR TITLE
Add notification banner model and view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
 
   before_action :init_body_classes, :set_controller_and_action_names
+  before_action :load_notifications
   before_action :check_browser, unless: :format_json?
   before_action :set_version
   before_action :set_meta_info
@@ -117,5 +118,9 @@ class ApplicationController < ActionController::Base
 
   def supported_browser?
     SupportedBrowserService.supported?(request.user_agent)
+  end
+
+  def load_notifications
+    @notifications = Notification.active
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,5 @@
+class Notification < ApplicationRecord
+  validates :message, presence: true
+
+  scope :active, -> { where.not(activated_at: nil).where(activated_at: ..Time.zone.now) }
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -23,8 +23,10 @@ html lang='en'
     - if current_user.try(:special?)
       = render '/admin_header'
     .body-highlight
+    - if @notifications.present?
+      .notifications
+        = render partial: :notifications, collection: @notifications
     .container
-
       aside.sidenav
         .sidenav__main
           a.brand href=root_path title="Mission Artists"

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,0 +1,3 @@
+/ expects notification
+.notification
+  = notification.message

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import "gto/_mau_modal.scss";
 @import "gto/_nav.scss";
 @import "gto/_notes.scss";
+@import "gto/_notifications.scss";
 @import "gto/_os_violators.scss";
 @import "gto/_paginator.scss";
 @import "gto/_palette.scss";

--- a/app/webpack/stylesheets/gto/_notifications.scss
+++ b/app/webpack/stylesheets/gto/_notifications.scss
@@ -1,0 +1,18 @@
+@use "../mixins" as *;
+@use "../colors" as *;
+
+.notifications {
+  @include flex-center-center;
+  @include round-corners();
+  background: $light-gray-background;
+  color: $gto_red;
+  border-bottom: 2px solid $gto_red !important;
+  padding: 20px;
+  flex-direction: column;
+  .notification {
+    margin-bottom: 10px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/db/migrate/20220712023834_create_notifications.rb
+++ b/db/migrate/20220712023834_create_notifications.rb
@@ -1,0 +1,10 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.string :message, null: false
+      t.datetime :activated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_05_234721) do
+ActiveRecord::Schema.define(version: 2022_07_12_023834) do
 
   create_table "application_events", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type"
@@ -156,6 +156,13 @@ ActiveRecord::Schema.define(version: 2021_09_05_234721) do
     t.datetime "updated_at"
     t.string "slug"
     t.index ["slug"], name: "index_media_on_slug", unique: true
+  end
+
+  create_table "notifications", charset: "utf8mb3", force: :cascade do |t|
+    t.string "message", null: false
+    t.datetime "activated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "open_studios_events", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -179,12 +179,12 @@ Given /^the email lists have been created with emails$/ do
     begin
       clz.create unless clz.first
     rescue Exception => e
-      ::Rails.logger.debug("Failed to create #{mailing_list} : #{e}")
+      ::Rails.logger.debug { "Failed to create #{mailing_list} : #{e}" }
     end
     clz.first.emails.create(name: Faker::Name.name, email: Faker::Internet.email)
   end
 end
 
-Given('there is some open studios catalog cms content') do
-  pending # Write code here that turns the phrase above into concrete actions
+Given('there is an active notification') do
+  @active_notification ||= FactoryBot.create(:notification, :active)
 end

--- a/features/step_definitions/notification_steps.rb
+++ b/features/step_definitions/notification_steps.rb
@@ -1,0 +1,3 @@
+Then('I see that notification') do
+  expect(page).to have_content @active_notification.message
+end

--- a/features/visitors/front_page.feature
+++ b/features/visitors/front_page.feature
@@ -24,3 +24,9 @@ Scenario:  Visiting the home page
   And I can get to the contact page from the footer
   And I can send feedback via the footer link
   And I can see the credits from the footer link
+
+@javascript
+Scenario:  Visiting the home page when there is an active notification
+  When there is an active notification
+  And I visit the home page
+  Then I see that notification

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :notification do
+    sequence(:message) { Faker::Lorem.words(number: 10).join(' ') }
+
+    trait :active do
+      activated_at { Time.zone.yesterday }
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  let(:active_notification) { create :notification, activated_at: Time.zone.yesterday }
+  let(:not_active_notifications) do
+    [
+      create(:notification, activated_at: Time.zone.tomorrow),
+      create(:notification),
+    ]
+  end
+  let(:notifications) { [active_notification, not_active_notifications].flatten }
+
+  describe 'scopes' do
+    before do
+      notifications
+    end
+
+    describe 'active' do
+      it 'includes only active notifications' do
+        expect(Notification.all).to have(3).notifications
+        expect(Notification.active).to eq [active_notification]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem
-----------

When we need to do maintenance and other thing, we need to notify our users
(the ones that check in often) with a notification that stuffs going go happen.

we could email them but that's through MailChimp and it's likely that 70% of them don't care.

So let's focus on the common users (and visitors).

Solution
---------

After a discussion with @rdavid1099 , I decided on a simple-ish approach.

Add a `Notification` model which can be easily added with some console logic.  And if there is an active `Notification` show it on the app.

Some day in the future (if we care) we can add an admin interface.

Screenshots
-------------
Run this on the console 
```
> Notification.create(message: "The site will be down for a bit.  Hold tight.  We'll b back soon", activated_at: Time.current)
```
then 

<img width="955" alt="Screen Shot 2022-07-12 at 12 31 19 AM" src="https://user-images.githubusercontent.com/427380/178434502-60b0a2ff-9dde-405e-a8d4-b8fe5f1b5131.png">

