### PR TITLE
Guard against active storage issues.

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -118,8 +118,12 @@ class ArtPiece < ApplicationRecord
   end
 
   def path(size = :medium)
-    att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-    return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    begin
+      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
+      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    rescue Aws::S3::Errors::BadRequest => e
+      Rails.logger.error(e.backtrace.join("\n"))
+    end
 
     photo(size) if photo?
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -111,8 +111,12 @@ class Artist < User
   end
 
   def get_profile_image(size = :medium)
-    att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-    return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    begin
+      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
+      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    rescue Aws::S3::Errors::BadRequest => e
+      Rails.logger.error(e.backtrace.join("\n"))
+    end
 
     super(size)
   end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -93,7 +93,7 @@ class Studio < ApplicationRecord
     IndependentStudio.new
   end
 
-  def get_profile_image(size: :medium)
+  def get_profile_image(size = :medium)
     begin
       att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
       if att

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -93,15 +93,18 @@ class Studio < ApplicationRecord
     IndependentStudio.new
   end
 
-  def get_profile_image(size)
-    att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-    if att
-      variant = att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed
-      # It seems the DiskService isn't great with `.url` so for cucumber we do this
-      Paperclip::Attachment.default_options[:storage].to_sym == :s3 ? variant.url : Rails.application.routes.url_helpers.url_for(variant)
-    else
-      photo(size)
+  def get_profile_image(size: :medium)
+    begin
+      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
+      if att
+        variant = att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed
+        # It seems the DiskService isn't great with `.url` so for cucumber we do this
+        return Paperclip::Attachment.default_options[:storage].to_sym == :s3 ? variant.url : Rails.application.routes.url_helpers.url_for(variant)
+      end
+    rescue Aws::S3::Errors::BadRequest => e
+      Rails.logger.error(e.backtrace.join("\n"))
     end
+    photo(size)
   end
 
   def image_paths

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,9 +117,12 @@ class User < ApplicationRecord
   end
 
   def get_profile_image(size = :medium)
-    att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-
-    return att.blob.url if att
+    begin
+      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
+      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    rescue Aws::S3::Errors::BadRequest => e
+      Rails.logger.error(e.backtrace.join("\n"))
+    end
 
     photo(size) if photo?
   end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -181,7 +181,7 @@ class UserPresenter < ViewPresenter
     model.photo?
   end
 
-  def profile_image(size = small)
+  def profile_image(size = :small)
     model.get_profile_image(size)
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,6 +85,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_storage.service = :amazon
 end
 
 Rails.application.routes.default_url_options[:host] = 'www.missionartists.org'


### PR DESCRIPTION
Problem
-------

The recent deploy is allowing uploads of images which successfully end
up in amazon but when requesting variants we get a Aws::S3::Errors::BadRequest.

Solution
----------

First cut will be to guard against that and fallback to the old image.
Also log when this happens loudly.

Then maybe we can figure out why variants are not working properly

Changes
--------

Wrap image fetchers with a begin/rescue