### PR TITLE
Fix migrator skip_migration check

### DIFF
--- a/app/models/concerns/duplicate_active_storage.rb
+++ b/app/models/concerns/duplicate_active_storage.rb
@@ -37,7 +37,8 @@ module DuplicateActiveStorage
       # picture as failed and we'll have to deal with it later
       false
     else
-      !send(self.class.paperclip_attachment_name).exists?
+      photo_exists_method = "#{self.class.paperclip_attachment_name}?"
+      !public_send(photo_exists_method)
     end
   end
 


### PR DESCRIPTION
Problem
---------

We were mis-calling `photo.exists?` on a paperclip attachement instead
of using the provided `photo?`  method.

Solution
--------

Update the duplicate_active_storage function to fix that