### PR TITLE
Compartmentalize image attachment logic

### DIFF
--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -6,7 +6,11 @@ class ArtPiece < ApplicationRecord
 
   belongs_to :medium, optional: true
 
+  include HasAttachedImage
+  image_attachments(:photo)
+
   has_attached_file :photo, styles: MauImage::Paperclip::STANDARD_STYLES, default_url: ''
+
   validates_attachment_presence :photo
   validates_attachment_content_type :photo,
                                     content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'],
@@ -118,14 +122,7 @@ class ArtPiece < ApplicationRecord
   end
 
   def path(size = :medium)
-    begin
-      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
-    rescue Aws::S3::Errors::BadRequest => e
-      Rails.logger.error(e.backtrace.join("\n"))
-    end
-
-    photo(size) if photo?
+    photo_attachment(size)
   end
 
   def paths

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -85,6 +85,9 @@ class Artist < User
 
   has_many :art_pieces, -> { order(position: :asc, created_at: :desc) }, inverse_of: :artist
 
+  include HasAttachedImage
+  image_attachments(:photo)
+
   %i[
     bio
     bio=
@@ -111,14 +114,7 @@ class Artist < User
   end
 
   def get_profile_image(size = :medium)
-    begin
-      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
-    rescue Aws::S3::Errors::BadRequest => e
-      Rails.logger.error(e.backtrace.join("\n"))
-    end
-
-    super(size)
+    photo_attachment(size)
   end
 
   def in_the_mission?

--- a/app/models/concerns/has_attached_image.rb
+++ b/app/models/concerns/has_attached_image.rb
@@ -1,0 +1,63 @@
+module HasAttachedImage
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :_image_attachments, instance_accessor: false
+    self._image_attachments = Set.new
+  end
+
+  private
+
+  def attachments_by_name(name)
+    ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: name).order(:id)
+  end
+
+  def paperclip_attachment_exists?(name)
+    method = "#{name}?"
+    respond_to?(method) && public_send(method)
+  end
+
+  class_methods do
+    # rubocop:disable Style/DocumentDynamicEvalDefinition
+    #
+    # I followed rubocop rules and added comments documenting the methods but
+    # it's still not passing for some reason.  Something to figure out later.
+    def image_attachments(*attachment_names)
+      self._image_attachments = Set.new(attachment_names.map(&:to_s))
+      attachment_names.each do |name|
+        # def photo_attachment?
+        #   attachments_by_name('photo').exists? || paperclip_attachment_exists?('photo')
+        # end
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{name}_attachment?
+             attachments_by_name('#{name}').exists? || paperclip_attachment_exists?('#{name}')
+          end
+        RUBY
+
+        # def photo_attachment(size = :medium)
+        #   begin
+        #     att = attachments_by_name('photo').last
+        #     return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+        #   rescue Aws::S3::Errors::BadRequest => e
+        #     Rails.logger.error(e.backtrace.join("\\n"))
+        #   end
+        #
+        #   photo(size) if photo?
+        # end
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{name}_attachment(size = :medium)
+            begin
+              att = attachments_by_name('#{name}').last
+              return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+            rescue Aws::S3::Errors::BadRequest => e
+              Rails.logger.error(e.backtrace.join("\\n"))
+            end
+
+            #{name}(size) if #{name}?
+          end
+        RUBY
+      end
+    end
+    # rubocop:enable Style/DocumentDynamicEvalDefinition
+  end
+end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -100,8 +100,8 @@ class Studio < ApplicationRecord
     photo_attachment?
   end
 
-  def get_profile_image(_size = :medium)
-    photo_attachment
+  def get_profile_image(size = :medium)
+    photo_attachment(size)
   end
 
   def image_paths

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -53,6 +53,9 @@ class Studio < ApplicationRecord
 
   has_attached_file :photo, styles: MauImage::Paperclip::STANDARD_STYLES, default_url: ''
 
+  include HasAttachedImage
+  image_attachments(:photo)
+
   validates_attachment_presence :photo
   validates_attachment_content_type :photo, content_type: %r{\Aimage/.*\Z}, if: :photo?
   include DuplicateActiveStorage
@@ -93,18 +96,12 @@ class Studio < ApplicationRecord
     IndependentStudio.new
   end
 
-  def get_profile_image(size = :medium)
-    begin
-      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-      if att
-        variant = att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed
-        # It seems the DiskService isn't great with `.url` so for cucumber we do this
-        return Paperclip::Attachment.default_options[:storage].to_sym == :s3 ? variant.url : Rails.application.routes.url_helpers.url_for(variant)
-      end
-    rescue Aws::S3::Errors::BadRequest => e
-      Rails.logger.error(e.backtrace.join("\n"))
-    end
-    photo(size)
+  def profile_image?
+    photo_attachment?
+  end
+
+  def get_profile_image(_size = :medium)
+    photo_attachment
   end
 
   def image_paths

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,15 +116,20 @@ class User < ApplicationRecord
     state == 'pending'
   end
 
-  def get_profile_image(size = :medium)
-    begin
-      att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
-      return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
-    rescue Aws::S3::Errors::BadRequest => e
-      Rails.logger.error(e.backtrace.join("\n"))
-    end
+  def profile_image?
+    photo_attachment?
+  end
 
-    photo(size) if photo?
+  def get_profile_image(size = :medium)
+    photo_attachment(size)
+    # begin
+    #   att = ActiveStorage::Attachment.where(record_id: id, record_type: self.class.name, name: 'photo').order(:id).last
+    #   return att.variant(MauImage::Paperclip::VARIANT_RESIZE_ARGUMENTS[size.to_sym]).processed.url if att
+    # rescue Aws::S3::Errors::BadRequest => e
+    #   Rails.logger.error(e.backtrace.join("\n"))
+    # end
+
+    # photo(size) if photo?
   end
 
   def full_name

--- a/app/presenters/studio_presenter.rb
+++ b/app/presenters/studio_presenter.rb
@@ -30,9 +30,7 @@ class StudioPresenter < ViewPresenter
     @page_title ||= PageInfoService.title("Studio: #{name}")
   end
 
-  def profile_image?
-    studio.get_profile_image(:small).present?
-  end
+  delegate :profile_image?, to: :studio
 
   def image(size = 'small')
     studio.get_profile_image(size) || '/images/default-studio.png'

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -177,9 +177,7 @@ class UserPresenter < ViewPresenter
     end
   end
 
-  def profile_image?
-    model.photo?
-  end
+  delegate :profile_image?, to: :model
 
   def profile_image(size = :small)
     model.get_profile_image(size)

--- a/app/views/admin/studios/_form.html.slim
+++ b/app/views/admin/studios/_form.html.slim
@@ -12,7 +12,7 @@
           = f.input :phone
           = f.input :url
       .pure-u-1-1.pure-u-md-1-2
-        - if studio.photo?
+        - if studio.profile_image?
           .image.block
             h3 Current Photo
             p

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -69,7 +69,7 @@
         - if @user.art?
           h4
             = "Representative piece: " + @user.representative_piece.title
-          - url = @user.representative_piece.photo(:original)
+          - url = @user.representative_piece.path(:original)
           .image
             img.pure-img src=url
           .url = url


### PR DESCRIPTION
Problem
----------

Now that we've got the duplicate active storage and paperclip stuff
and we're going to try to unwind the paperclip,
i wanted to put all the attachment stuff together.

Solution
---------

Build a concern which User, Artist, Studio and ArtPiece can use
to compartmentalize the swapping between ActiveStorage attachments
and paperclip.

This way unwinding should be easier