### PR TITLE
Add ability for admin to upload profile image for artist

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -81,10 +81,13 @@ module Admin
         :show_email,
         { video_conference_schedule: {} },
       ]
-      params.require(:artist).permit(:firstname, :lastname,
+      params.require(:artist).permit(:firstname,
+                                     :lastname,
                                      :phone,
-                                     :email, :nomdeplume,
+                                     :email,
+                                     :nomdeplume,
                                      :studio_id,
+                                     :photo,
                                      links: allowed_links,
                                      artist_info_attributes: %i[studionumber street bio],
                                      open_studios_participants_attributes: open_studios_participant_fields).tap do |prms|

--- a/app/views/admin/users/_open_studios_participation.html.slim
+++ b/app/views/admin/users/_open_studios_participation.html.slim
@@ -20,12 +20,12 @@
     tr.admin-user__open-studios-participant-table__row
       td Video Conference URL
       td = open_studios_participant.video_conference_url
-    tr.admin-user__open-studios-participant-table__row
-      td Video Conference Schedule
-      td
-        - if open_studios_participant.video_conference_url?
-          - open_studios_participant.video_conference_time_slots.each do |slot|
-            .admin-user__open-studios-participant-table__time-slot
-              = display_time_slot(slot)
-        - else
-          | n/a
+    / tr.admin-user__open-studios-participant-table__row
+    /   td Video Conference Schedule
+    /   td
+    /     - if open_studios_participant.video_conference_url?
+    /       - open_studios_participant.video_conference_time_slots.each do |slot|
+    /         .admin-user__open-studios-participant-table__time-slot
+    /           = display_time_slot(slot)
+    /     - else
+    /       | n/a

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -66,6 +66,25 @@
   - if @user.artist?
     .pure-u-1-2.padded-content
       .info-block
+        - if @user.profile_image?
+          h4 Profile Picture
+          - url = @user.profile_image
+          .image
+            img.pure-img src=url
+          .url = url
+        - else
+          h4 No profile picture
+        = semantic_form_for :artist, method: :patch, url: admin_artist_path(@user) do |form|
+          = form.inputs do
+            .pure-g
+              .pure-u-1-1.pure-u-sm-1-2
+                = form.input :photo, as: :file, class: 'required', hint: "Your profile image should be a JPEG, GIF or PNG file and must not be more than 1MB."
+          .pure-g
+            .pure-u-1-1.pure-u-sm-1-2
+              = form.actions do
+                = form.submit 'Upload', class: 'pure-button button-large pure-button-primary'
+                = form.submit 'Cancel', class: 'pure-button button-large'
+      .info-block
         - if @user.art?
           h4
             = "Representative piece: " + @user.representative_piece.title

--- a/app/webpack/stylesheets/gto_admin/users.scss
+++ b/app/webpack/stylesheets/gto_admin/users.scss
@@ -9,6 +9,7 @@
   }
   .url {
     @include ellipsis;
+    margin: 20px auto;
   }
   .info-block {
     border-bottom: 1px solid colors.$medium-gray;

--- a/features/admin/artists/admin_edit.feature
+++ b/features/admin/artists/admin_edit.feature
@@ -33,7 +33,6 @@ Scenario: Updating artist links
   When I choose "The Rock House" from "Studio"
   And I click on "Update Artist"
   And I see that the admin artist pages shows that artist in studio "The Rock House"
-
 Scenario: Updating artists open studios info
   Given the current open studios event has a special event
   And there is an open studios artist
@@ -61,3 +60,12 @@ Scenario: Updating artists open studios info
   And as an admin I choose every other time slot for the video conference schedule
   And I click on "Update Artist"
   Then I see that the artist is scheduled for every other time slot
+
+
+Scenario: Updating artist's profile picture
+  When I go back
+  And I click on the first artist show button that's not me
+  Then I see that this artist has no profile picture
+  And I attach a new profile image file
+  And I click "Upload"
+  Then I see the new profile image for that artist

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -11,7 +11,7 @@ Background:
   And there is open studios catalog cms content
   And I'm logged out
 
-Scenario:
+Scenario: Browsing and viewing art modal
   When I visit "/" in the catalog
   Then I see pictures from all participating artists
   And I see the open studios catalog cms message

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -145,3 +145,21 @@ When('I see that the artist is scheduled for every other time slot') do
     end
   end
 end
+
+When('I click on the first artist show button that\'s not me') do
+  not_me = Artist.active.limit(2).detect { |a| a.login != (@artist.login || @user.login) }
+  cell = page.all('table tr').detect { |el| el.text.include? not_me.login }
+  cell.find('.admin-artist-link').click
+end
+
+When('I attach a new profile image file') do
+  attach_file 'Photo', Rails.root.join('spec/fixtures/files/profile.png')
+end
+
+Then('I see the new profile image for that artist') do
+  expect(page).to have_content 'small/profile.png'
+end
+
+Then('I see that this artist has no profile picture') do
+  expect(page).to have_content 'No profile picture'
+end

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -340,6 +340,10 @@ Then(/^I can see the credits from the footer link$/) do
   expect(page).not_to have_content 'Built at MAU Headquarters'
 end
 
+When(/^I go back/) do
+  page.go_back
+end
+
 When(/^I refresh the page$/) do
   visit current_path
 end


### PR DESCRIPTION
Problem
----------

Moving to active storage lead to some limitations based on weird
filenames etc causing the auto migration to fail.

Solution
-----------

Add the ability for an admin to upload a new profile picture for someone
so that we can manually fix the 2 artists who's profile image didn't
migrate smoothly.