### PR TITLE
Update migrator to handle non-asii filenames

### DIFF
--- a/app/models/concerns/duplicate_active_storage.rb
+++ b/app/models/concerns/duplicate_active_storage.rb
@@ -56,7 +56,7 @@ module DuplicateActiveStorage
     if using_s3?
       s3_url = "https://#{Rails.application.config.s3_info[:bucket]}.s3.amazonaws.com/#{key(self.class.paperclip_attachment_name)}"
       ActiveStorage::Blob.create_after_upload!(
-        io: URI.open(URI.parse(s3_url)),
+        io: URI.open(Addressable::URI.parse(s3_url).display_uri.to_s),
         filename: send("#{self.class.paperclip_attachment_name}_file_name"),
         content_type: send("#{self.class.paperclip_attachment_name}_content_type"),
         service_name: :amazon,


### PR DESCRIPTION
Problem
---------

Ruby `URI.parse` doesn't like non-ascii filenames but amazon
has no problem with them and we have some in the system like

https://mission-artists-production.s3.amazonaws.com/art_pieces/photos/000/011/657/original/ファイル_001-2.jpeg

Solution
---------

Use `Addressable::URI.parse` because it can handle this.