### PR TITLE
Add ability for admin to update an art piece photo

### DIFF
--- a/app/controllers/admin/art_pieces_controller.rb
+++ b/app/controllers/admin/art_pieces_controller.rb
@@ -1,0 +1,26 @@
+module Admin
+  class ArtPiecesController < ::BaseAdminController
+    before_action :admin_required, only: %i[edit update]
+    before_action :set_art_piece, only: %i[edit update]
+
+    def edit; end
+
+    def update
+      if @art_piece.update(art_piece_params)
+        redirect_to edit_admin_art_piece_path(@art_piece)
+      else
+        render :edit, warning: 'There were problems updating the art piece'
+      end
+    end
+
+    private
+
+    def set_art_piece
+      @art_piece = ArtPiece.find(params[:id])
+    end
+
+    def art_piece_params
+      params.require(:art_piece).permit(:photo)
+    end
+  end
+end

--- a/app/views/admin/art_pieces/edit.html.slim
+++ b/app/views/admin/art_pieces/edit.html.slim
@@ -1,0 +1,24 @@
+.pure-g
+  .pure-u-1-1.padded-content.header.admin-art-piece-header
+    h2.title
+      = "Editing Art Piece: #{@art_piece.title}"
+
+.pure-g
+  .pure-u-1-2.padded-content.admin-art-piece-edit-form
+    .info-block
+      - url = @art_piece.path
+      .image
+        img.pure-img src=url
+      .url = url
+
+      .form-update
+        = semantic_form_for :art_piece, method: :patch, url: admin_art_piece_path(@art_piece) do |form|
+          = form.inputs do
+            .pure-g
+              .pure-u-1-1.pure-u-sm-1-2
+                = form.input :photo, as: :file, class: 'required', hint: "Your image should be a JPEG, GIF or PNG file and must not be more than 1MB."
+          .pure-g
+            .pure-u-1-1.pure-u-sm-1-2
+              = form.actions do
+                = form.submit 'Upload', class: 'pure-button button-large pure-button-primary'
+                = form.submit 'Cancel', class: 'pure-button button-large'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,7 @@ Mau::Application.routes.draw do
       resources :application_events, only: [:index]
       resources :favorites, only: [:index]
       resources :media, only: %i[index create new edit update destroy]
+      resources :art_pieces, only: %i[edit update]
       resources :artists, only: %i[index edit update] do
         collection do
           post :good_standing

--- a/features/admin/art_pieces/update_art_piece.feature
+++ b/features/admin/art_pieces/update_art_piece.feature
@@ -1,0 +1,16 @@
+@javascript
+Feature: Admin can update an art piece
+  I navigate directly to an art piece page and update the image
+
+Background:
+  Given an "admin" account has been created
+  And there are artists with art in the system
+  And I login
+
+Scenario: Viewing and cleaning out tags
+  When I navigate to the first art piece admin edit path
+  Then I see the edit admin art piece page
+  When I add a new file
+  And I click "Upload"
+  Then I see the edit admin art piece page
+  And I see the new image

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -163,3 +163,24 @@ end
 Then('I see that this artist has no profile picture') do
   expect(page).to have_content 'No profile picture'
 end
+
+When('I navigate to the first art piece admin edit path') do
+  @art_piece = ArtPiece.first
+  expect(@art_piece).to be_persisted
+  visit edit_admin_art_piece_path(@art_piece)
+  save_and_open_page
+end
+
+When('I add a new file') do
+  attach_file 'Photo', Rails.root.join('spec/fixtures/files/art.png')
+end
+
+Then('I see the edit admin art piece page') do
+  expect(page).to have_content 'Editing Art Piece:'
+end
+
+Then('I see the new image') do
+  save_and_open_page
+  expect(page).not_to have_content 'new-art-piece.jpg'
+  expect(page).to have_content 'art.png'
+end


### PR DESCRIPTION
Problem
---------

Our migrator was able to get almost all the images, but there are
a handful with bad filenames where we need to manually intervene.

Solution
----------

Add a page (with no links to it) where an admin can update the
photo for an art piece