### PR TITLE
Update resize values for large images

### DIFF
--- a/app/lib/mau_image/paperclip.rb
+++ b/app/lib/mau_image/paperclip.rb
@@ -10,7 +10,7 @@ module MauImage
     VARIANT_RESIZE_ARGUMENTS = {
       small: { resize_to_fill: [200, 200, { crop: :centre }] },
       medium: { resize_to_fill: [400, 400, { crop: :centre }] },
-      large: { resize_to_fill: [800, 800, { crop: :centre }] },
+      large: { resize_to_fit: [800, 800] },
       original: {},
     }.freeze
   end

--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -1,0 +1,21 @@
+OLD_LARGE_VARIANT = { resize_to_fill: [800, 800, { crop: :centre }] }.freeze
+
+namespace :paperclip do
+  desc 'one off - remove old large variant blobs'
+  task purge_old_large_variants: [:environment] do
+    [Studio, Artist, ArtPiece].each do |clz|
+      Rails.logger.warn("Purging old large variants from #{clz.name}")
+      clz.find_in_batches(batch_size: 200).each do |batch|
+        batch.each do |item|
+          atts = item.send(:attachments_by_name, 'photo')
+          atts.each do |att|
+            variant = att.variant(OLD_LARGE_VARIANT)
+
+            att.service.delete(variant.key)
+          end
+        end
+      end
+      Rails.logger.warn("Done purging old large variants from #{clz.name}")
+    end
+  end
+end


### PR DESCRIPTION
Problem
--------

We mis-computed the image-resize for large images.  It was doing
`resize_to_fill` intead of `resize_to_fit` leading to cropped
images showing in the art pieces gallery.

Solution
---------

Update the VARIANT settings which will lead to generating new variants