### PR TITLE
Fix issue with favorite images and attachments

### DIFF
--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,11 +1,14 @@
 module FavoritesHelper
   def get_favorite_image_and_path(fav, size = :small)
     title = fav.get_name
-    img = ''
-    path = ''
-    if fav.is_a? ArtPiece
+    img = nil
+    path = nil
+    case fav
+    when ArtPiece
       img = fav.path size
       path = art_piece_path fav.id
+    when MauFan
+      img = asset_pack_path('media/images/default_user.svg')
     else
       img = fav.get_profile_image(size) || asset_pack_path('media/images/default_user.svg')
       path = user_path(fav)

--- a/app/views/users/_favorite_thumb.slim
+++ b/app/views/users/_favorite_thumb.slim
@@ -1,5 +1,10 @@
 li
   - img, path, title = get_favorite_image_and_path favorite_thumb
-  = link_to path, title: title do
-    .favorite-thumb style=background_image_style(img)
-    .favorite-thumb-icon.fa.fa-user
+  - if path
+    = link_to(path,title: title) do
+      .favorite-thumb style=background_image_style(img)
+      .favorite-thumb-icon.fa.fa-user
+  - else
+    span.not-a-link(title=title)
+      .favorite-thumb style=background_image_style(img)
+      .favorite-thumb-icon.fa.fa-user


### PR DESCRIPTION
problem
--------

With the new attachment mixin, `MauFan`s (which are now deprecated)
do not know how to find their image.  This lead to breaking pages
where there was an fan favorite trying to render it's profile image.

solution
---------

Don't render a fan's profile picture and don't link to their page
because it has the same issues.