### PR TITLE
Force https for url protocol for images on acceptance

### DIFF
--- a/config/environments/acceptance.rb
+++ b/config/environments/acceptance.rb
@@ -3,6 +3,8 @@ require Rails.root.join('config/environments/production')
 Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: 'mau.rcode5.com',
+    protocol: 'https',
   }
 end
 Rails.application.routes.default_url_options[:host] = 'mau.rcode5.com'
+Rails.application.routes.default_url_options[:protocol] = 'https'


### PR DESCRIPTION
running on acceptance, there was a pile of warnings where the rails_representation_path wasn't using https.

this fixes that.  

tested with a branch push