### PR TITLE
Add support to toggle OS on/off for the whole site

### DIFF
--- a/app/controllers/admin/site_preferences_controller.rb
+++ b/app/controllers/admin/site_preferences_controller.rb
@@ -20,7 +20,7 @@ module Admin
     end
 
     def site_preferences_params
-      params.require(:site_preferences).permit(:social_media_tags)
+      params.require(:site_preferences).permit(:social_media_tags, :open_studios_active)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :check_browser, unless: :format_json?
   before_action :set_version
   before_action :set_meta_info
+  before_action :set_open_studios_active
 
   helper_method :current_user_session, :current_user, :logged_in?, :current_artist
   helper_method :current_open_studios
@@ -68,6 +69,10 @@ class ApplicationController < ActionController::Base
     version = Mau::Version.new
     @revision = version.to_s
     @build = version.build
+  end
+
+  def set_open_studios_active
+    @open_studios_active = SitePreferences.instance(check_cache: true).open_studios_active?
   end
 
   protected

--- a/app/models/site_preferences.rb
+++ b/app/models/site_preferences.rb
@@ -8,7 +8,7 @@ class SitePreferences < ApplicationRecord
   CACHE_KEY = :site_preferences
 
   def self.instance(check_cache: false)
-    (check_cache && cached) || first || create
+    (check_cache && cached) || first || create(open_studios_active: true)
   end
 
   def self.cached

--- a/app/presenters/base_open_studios_presenter.rb
+++ b/app/presenters/base_open_studios_presenter.rb
@@ -1,5 +1,5 @@
 class BaseOpenStudiosPresenter < ViewPresenter
-  delegate :promote?, to: :current_os
+  delegate :promote?, to: :current_os, allow_nil: true
 
   def initialize(page, current_user)
     super()
@@ -54,6 +54,6 @@ class BaseOpenStudiosPresenter < ViewPresenter
   end
 
   def os_participants
-    @os_participants ||= current_os.artists
+    @os_participants ||= current_os&.artists || []
   end
 end

--- a/app/services/open_studios_event_service.rb
+++ b/app/services/open_studios_event_service.rb
@@ -36,6 +36,8 @@ class OpenStudiosEventService
   end
 
   def self.current
+    return nil unless SitePreferences.instance(check_cache: true).open_studios_active?
+
     cache = SafeCache.read(CURRENT_CACHE_KEY)
     unless cache
       cache = OpenStudiosEvent.current

--- a/app/views/admin/open_studios_events/index.html.slim
+++ b/app/views/admin/open_studios_events/index.html.slim
@@ -10,6 +10,18 @@
         = link_to clear_cache_admin_open_studios_events_path, title: 'clear os dates cache' do
           = fa_icon "refresh"
   .pure-u-1-1.padded-content
+    .os-events[class=(@open_studios_active ? "os-active__on" : "os-active__off")]
+      - if !@open_studios_active
+        p &#9888; Open Studios is currently not active.
+      - else
+        p &#128077; Open Studios is currently active.
+      p
+        | If you want to change that, check the
+        '
+        a href=edit_admin_site_preferences_path
+          | Site Preferences page
+
+  .pure-u-1-1.padded-content
     table.os-events.pure-table.pure-table-striped.os-events__table
       thead
         tr

--- a/app/views/admin/site_preferences/edit.html.slim
+++ b/app/views/admin/site_preferences/edit.html.slim
@@ -7,8 +7,8 @@
       = render partial: 'common/form_errors', locals: { form: f }
       = f.inputs do
         = f.input :social_media_tags, placeholder: 'e.g. #supertag, #anotherTag', hint: "Tags here will be the first tags shown in the new art email that goes out to all our new art watchers."
+        = f.input :open_studios_active, hint: "If set false, all Open Studios decorators will be suppressed"
       = f.actions do
         .form-controls
           = f.submit class: 'pure-button pure-button-primary'
           = link_to 'Cancel', edit_admin_site_preferences_path, class: 'pure-button'
-

--- a/app/views/common/_navigation.html.slim
+++ b/app/views/common/_navigation.html.slim
@@ -15,17 +15,18 @@
       li.tab
         a href=studios_path title="group studios" studios
 
-  section.nav-section.open-studios
-    ul.tabs.tabs__nav
-      li.tab
-        a href=open_studios_path title="open studios #{open_studios_nav_title}"
-          = open_studios_nav_title
+  - if @open_studios_active
+    section.nav-section.open-studios
+      ul.tabs.tabs__nav
+        li.tab
+          a href=open_studios_path title="open studios #{open_studios_nav_title}"
+            = open_studios_nav_title
 
-        a.nav-secondary-link href=open_studios_path  title ="open studios #{open_studios_nav_title}" open studios
+          a.nav-secondary-link href=open_studios_path  title ="open studios #{open_studios_nav_title}" open studios
 
-        - if user_nav.remind_for_open_studios_register?
-          a.nav-secondary-link--emphasis href=register_for_current_open_studios_artists_path title = "register for open studios"
-            = "register now!"
+          - if user_nav.remind_for_open_studios_register?
+            a.nav-secondary-link--emphasis href=register_for_current_open_studios_artists_path title = "register for open studios"
+              = "register now!"
 
   - if logged_in?
     section.nav-section.users
@@ -57,9 +58,10 @@
     ul.tab-panel
       li.nav-mobile__title
         a href=search_path title="search" search
-    ul.tab-panel#open-studios
-      li.nav-mobile__title
-        a href=open_studios_path title="open studios #{open_studios_nav_title}" = open_studios_nav_title
+    - if @open_studios_active
+      ul.tab-panel#open-studios
+        li.nav-mobile__title
+          a href=open_studios_path title="open studios #{open_studios_nav_title}" = open_studios_nav_title
 
     - if logged_in?
       ul.tab-panel.signin__links

--- a/app/webpack/stylesheets/gto_admin/_mixins.scss
+++ b/app/webpack/stylesheets/gto_admin/_mixins.scss
@@ -1,0 +1,17 @@
+@use "../colors";
+
+@mixin admin-banner {
+  border: 2px solid colors.$bluegray;
+  padding: 5px 20px;
+  background-color: colors.$light-gray-background;
+}
+
+@mixin admin-warning-banner {
+  @include admin-banner;
+  border-color: colors.$gto_red;
+  background-color: lighten(colors.$error_red, 35);
+}
+
+@mixin admin-info-banner {
+  @include admin-banner;
+}

--- a/app/webpack/stylesheets/gto_admin/os_events.scss
+++ b/app/webpack/stylesheets/gto_admin/os_events.scss
@@ -1,6 +1,14 @@
+@use "./_mixins";
+
 .os-events__table-item--time {
   white-space: nowrap;
 }
 .os-events__table-item--dates--item + .os-events__table-item--dates--item {
   margin-top: 6px;
+}
+.os-active__off {
+  @include mixins.admin-warning-banner;
+}
+.os-active__on {
+  @include mixins.admin-info-banner;
 }

--- a/db/migrate/20221231201249_add_open_studios_active_switch_to_site_preferences.rb
+++ b/db/migrate/20221231201249_add_open_studios_active_switch_to_site_preferences.rb
@@ -1,0 +1,5 @@
+class AddOpenStudiosActiveSwitchToSitePreferences < ActiveRecord::Migration[6.1]
+  def change
+    add_column :site_preferences, :open_studios_active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_02_211137) do
+ActiveRecord::Schema.define(version: 2022_12_31_201249) do
 
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "application_events", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "application_events", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type"
     t.string "message"
     t.text "data"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.index ["user_id"], name: "index_cms_documents_on_user_id"
   end
 
-  create_table "denylist_domains", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "denylist_domains", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "domain"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.string "bugtype"
   end
 
-  create_table "friendly_id_slugs", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 40
@@ -195,7 +195,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "open_studios_events", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "open_studios_events", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
     t.datetime "created_at", null: false
@@ -229,7 +229,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.index ["user_id"], name: "index_open_studios_participants_on_user_id"
   end
 
-  create_table "open_studios_tallies", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "open_studios_tallies", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "count"
     t.string "oskey"
     t.date "recorded_on"
@@ -237,7 +237,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "promoted_events", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "promoted_events", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "event_id"
     t.datetime "publish_date"
     t.datetime "created_at"
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "scammers", id: :integer, charset: "utf8mb3", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "scammers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "email"
     t.text "name"
     t.integer "faso_id"
@@ -269,6 +269,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_211137) do
     t.string "social_media_tags"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "open_studios_active"
   end
 
   create_table "studios", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Given(/^an account has been created/) do
   @artist = Artist.where(login: TestUsersHelper::DEFAULT_LOGIN).first
   @artist ||= FactoryBot.create(:artist, :active, :with_art, :in_the_mission, login: TestUsersHelper::DEFAULT_LOGIN)
@@ -67,9 +65,10 @@ Given /there are application events in the system/ do
 end
 
 Given /there is a scheduled Open Studios event/ do
+  step %(The site preferences open studio switch is on)
   FactoryBot.create(:open_studios_event, :with_special_event)
 rescue ActiveRecord::RecordInvalid
-  # there's already one there
+  Rails.logger.warn('Open studios event already exists in this feature.  No problem.')
 end
 
 Given /the current open studios event has a special event/ do

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -309,3 +309,24 @@ Then('I see the next artist in the catalog') do
     expect(page).to have_content(@next_artist.get_name.upcase)
   end
 end
+
+When('The site preferences open studio switch is on') do
+  SitePreferences.instance.update!(open_studios_active: true)
+end
+
+Then('I see an open studios violator') do
+  expect(page).to have_css('.os-violator')
+end
+
+When('I toggle the open studios active toggle') do
+  uncheck 'site_preferences_open_studios_active'
+  click_on 'Update Site preferences'
+end
+
+Then('I don\'t see the open studios navigation') do
+  expect(page).to_not have_link('open studios')
+end
+
+Then('I don\'t see any open studios violators') do
+  expect(page).to_not have_css('.os-violator')
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 When(/^I change my password to "(.*?)"$/) do |new_pass|
   visit edit_artist_path(@artist)
   fill_in('Old Password', with: '8characters')
@@ -104,6 +102,13 @@ When(/^I login as a manager$/) do
   @manager = FactoryBot.create(:user, :manager, :active, studio: studios.first)
   step %(I visit the login page)
   fill_in_login_form @manager.login, '8characters'
+  step %(I click "Sign In")
+end
+
+When(/^I login as an admin$/) do
+  @administrator = FactoryBot.create(:user, :admin, :active)
+  step %(I visit the login page)
+  fill_in_login_form @administrator.login, '8characters'
   step %(I click "Sign In")
 end
 

--- a/spec/controllers/art_piece_tags_controller_spec.rb
+++ b/spec/controllers/art_piece_tags_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ArtPieceTagsController, stub_site_preferences: true do
+describe ArtPieceTagsController do
   describe '#index' do
     describe 'format=html' do
       before do
@@ -28,6 +28,8 @@ describe ArtPieceTagsController, stub_site_preferences: true do
   describe '#autosuggest' do
     let(:tags) { FactoryBot.create_list(:art_piece_tag, 3) }
     before do
+      allow(Rails.cache).to receive(:read).and_return(nil)
+      allow(Rails.cache).to receive(:write)
       get :autosuggest, params: { format: 'json', input: tags.first.name.downcase }
     end
     it_behaves_like 'successful json'
@@ -37,9 +39,9 @@ describe ArtPieceTagsController, stub_site_preferences: true do
     end
 
     it 'writes to the cache if theres nothing there' do
-      expect(Rails.cache).to receive(:read).and_return(nil)
-      expect(Rails.cache).to receive(:write)
       get :autosuggest, params: { format: :json, input: 'whateverdude' }
+      expect(Rails.cache).to have_received(:read).with(Conf.autosuggest['tags']['cache_key']).at_least(:once)
+      expect(Rails.cache).to have_received(:write).at_least(:once)
     end
 
     it 'returns tags using the input' do
@@ -48,17 +50,26 @@ describe ArtPieceTagsController, stub_site_preferences: true do
       expect(j).to be_present
     end
 
-    it 'uses the cache there is data' do
-      tag = ArtPieceTag.last
-      expect(Rails.cache).to receive(:read).with(Conf.autosuggest['tags']['cache_key'])
-                                           .and_return([{ 'name' => tag.name, 'id' => tag.id }])
-      expect(Rails.cache).not_to receive(:write)
-      get :autosuggest, params: { format: :json, input: 'tag' }
-      j = JSON.parse(response.body)
-      tags = j['art_piece_tags']
-      expect(tags).to have(1).tag
-      result = tags.first['art_piece_tag']
-      expect(result).to include({ 'name' => tag.name, 'id' => tag.id })
+    context 'when there is data' do
+      let(:tag) { ArtPieceTag.last }
+
+      before do
+        allow(Rails.cache).to receive(:read).and_return(nil)
+        allow(Rails.cache).to receive(:read).with(Conf.autosuggest['tags']['cache_key'])
+                                            .and_return([{ 'name' => tag.name, 'id' => tag.id }])
+        allow(Rails.cache).to receive(:write)
+      end
+
+      it 'uses the cache there is data' do
+        get :autosuggest, params: { format: :json, input: 'tag' }
+        j = JSON.parse(response.body)
+        tags = j['art_piece_tags']
+        expect(tags).to have(1).tag
+        result = tags.first['art_piece_tag']
+        expect(result).to include({ 'name' => tag.name, 'id' => tag.id })
+        expect(Rails.cache).to have_received(:read).with(Conf.autosuggest['tags']['cache_key']).at_least(:once)
+        expect(Rails.cache).not_to receive(:write)
+      end
     end
   end
 

--- a/spec/controllers/art_piece_tags_controller_spec.rb
+++ b/spec/controllers/art_piece_tags_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ArtPieceTagsController do
+describe ArtPieceTagsController, stub_site_preferences: true do
   describe '#index' do
     describe 'format=html' do
       before do

--- a/spec/services/open_studios_event_service_spec.rb
+++ b/spec/services/open_studios_event_service_spec.rb
@@ -22,6 +22,25 @@ describe OpenStudiosEventService do
     [past_oses, current_os, future_oses].flatten
   end
 
+  describe '.current' do
+    it 'returns the current os' do
+      expect(service.current).to eq current_os
+    end
+
+    context 'when the site preferences open_studios_active is off' do
+      before do
+        SitePreferences.instance.update!(open_studios_active: false)
+      end
+      after do
+        SitePreferences.instance.update!(open_studios_active: true)
+      end
+
+      it 'returns nil' do
+        expect(service.current).to be_nil
+      end
+    end
+  end
+
   describe '.for_display' do
     it 'returns the pretty version for a given tag' do
       expect(service.for_display('201104')).to eql '2011 Apr'


### PR DESCRIPTION
problem
--------

currently we preserve the "active" open studios as the last one by date. sometimes we might want to turn off the OS feature without specifying a new OS because we may not yet know the dates.

solution
----------

Add a site preferences toggle to just turn off open studios features for the site so we can shut things down without forcing us to add a new open studios entry before we're ready

changes
----------

* add SitePreferences#open_studios_active boolean
* add admin controls to toggle that
* toggle open studios features (nav, violators etc) based on that flag