### PR TITLE
Unflake cucumber specs

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
     email { "#{login}@example.com" }
     password { TestUsersHelper::DEFAULT_PASSWORD }
     password_confirmation { TestUsersHelper::DEFAULT_PASSWORD }
-    firstname { Faker::Name.first_name }
-    lastname { Faker::Name.first_name }
-    nomdeplume { Faker::Company.name }
+    firstname { Faker::Name.first_name.delete("'") }
+    lastname { Faker::Name.last_name.delete("'") }
+    nomdeplume { Faker::Company.name.delete("'") } # apostrophe's mess up Cucumber tests/finders
     website { Faker::Internet.url }
     trait :pending do
       state { :pending }


### PR DESCRIPTION
Problem
----------

Faker puts apostrophe's in company names and last names. Cucumber matchers get a little upset with that and can't find them on the page even though screenshots show they are there.

Solution
----------

Just rip apostrophe's out of names in the factory.  we can test apostrophe's if we care in unit tests.

This should unflake common flakes in cucumber.