### PR TITLE
Fix admin artist list page when no os

### DIFF
--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -18,7 +18,7 @@
           th Art
           th Info
           th
-            = OpenStudiosEventService.current.for_display(reverse: true)
+            = OpenStudiosEventService.current&.for_display(reverse: true) || "OS"
           th.admin-controls data-orderable="false"
 
       tbody
@@ -60,7 +60,9 @@
 
             td data-order=(a.active? && a.doing_open_studios?).to_s
               / this make sure that all os settings are sent to the controller
-              - if a.active?
+              - if OpenStudiosEventService.current.nil?
+                .no-address N/A
+              - elsif a.active?
                 - checked = a.doing_open_studios?
                 - name = "os[#{a.id}]"
                 = hidden_field_tag name, "0"

--- a/features/admin/artists/admin_list.feature
+++ b/features/admin/artists/admin_list.feature
@@ -1,0 +1,32 @@
+@javascript
+Feature: Show Artists'
+
+Background:
+  Given there are future open studios events
+  And there are artists with art in the system
+  And there is a pending artist
+  And there is a suspended artist
+  And there is a studio named "The Rock House"
+  And an "admin" account has been created
+  And I login
+
+Scenario: List artists
+  When I click on "artists" in the admin menu
+  Then I see the admin artists list
+
+  When I click on "Suspended"
+  Then I see the suspended list
+
+  When I click on "Not Yet Activated"
+  Then I see the pending list
+
+Scenario: List artists when there is no current OS
+  When The site preferences open studio switch is off
+  And I click on "artists" in the admin menu
+  Then I see the admin artists list
+
+  When I click on "Suspended"
+  Then I see the suspended list
+
+  When I click on "Not Yet Activated"
+  Then I see the pending list

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -187,3 +187,13 @@ Then('I see the new image') do
   expect(page).not_to have_content 'new-art-piece.jpg'
   expect(page).to have_content 'art.png'
 end
+
+Then('I see the pending list') do
+  expect(page).not_to have_css '#spinner'
+  expect(page).to have_content @pending_artist.email
+end
+
+Then('I see the suspended list') do
+  expect(page).not_to have_css '#spinner'
+  expect(page).to have_content @suspended_artist.email
+end

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -50,6 +50,14 @@ Given /the following artists who aren't ready to sign up for os are in the syste
   @art_pieces = @artists.map(&:art_pieces).flatten
 end
 
+Given /there is a pending artist/ do
+  @pending_artist = FactoryBot.create(:artist, :pending)
+end
+
+Given /there is a suspended artist/ do
+  @suspended_artist = FactoryBot.create(:artist, :suspended)
+end
+
 Given /the following admins are in the system:/ do |table|
   table.hashes.each do |user_params|
     FactoryBot.create(:artist, :admin, :active, user_params)


### PR DESCRIPTION
problem
-------

when there is no active open studios, the admin artists' list was broken because it was trying to display the current open studios name/date and the artists' participation.

solution
--------

Don't blow up if open studios current is not available. Added feature spec