### PR TITLE
Remove link to help doc

### DIFF
--- a/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
+++ b/app/webpack/reactjs/components/open_studios/open_studios_info_form.tsx
@@ -144,13 +144,6 @@ export const OpenStudiosInfoForm: FC<OpenStudiosInfoFormProps> = ({
                   <p>Would you like to continue?</p>
                 </ConfirmModal>
               </div>
-              <div className="open-studios-info-form__help">
-                <p>
-                  <a href="https://bit.ly/v-openstudios" target="_blank">
-                    Help & more details on participating.
-                  </a>
-                </p>
-              </div>
             </Form>
           );
         }}


### PR DESCRIPTION
Remove link to help doc

Problem
------------

We had a help link to an old document that was about virtual OS.
we don't do that any more.

![Untitled](https://user-images.githubusercontent.com/427380/224585407-4a156327-969a-46f4-b3b6-50a754bf324c.jpg)

Solution
----------

Remove the link

