### PR TITLE
Support individual image fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Now, we have to tell Rails that we'll be accessing the dev server with the domai
 
 Run `rails s -p 3000 -b mau.local` and in your browser go to `mau.local:3000` for the Mission Artists site and `openstudios.mau.local:3000` for the Open Studios site.
 
+There are some issues with CORS and vite. This may not get you quite there.  Try starting the browser with `--disable-web-security`.  And you may need to add `host: 'mau.local:3000'` argument to all the `vite_javascript_tag` loaders.
+
 ### Running the test suite
 
 Once you think things are running, you can try running the test suite:

--- a/app/controllers/api/v2/art_pieces_controller.rb
+++ b/app/controllers/api/v2/art_pieces_controller.rb
@@ -13,6 +13,17 @@ module Api
         art = ArtPiece.find(params[:id])
         render jsonapi: art, include: %i[medium tags]
       end
+
+      def image
+        art = ArtPiece.find(params[:art_piece_id])
+        render json: { id: art.id, url: art.image(image_size_from_attrs) }
+      end
+
+      private
+
+      def image_size_from_attrs
+        params.require(:size)
+      end
     end
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,1 @@
+class ApplicationJob < ActiveJob::Base; end

--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -74,7 +74,7 @@ class ArtPiece < ApplicationRecord
     extras['title_ngram'] = title
     extras['medium'] = medium.try(:name)
     extras['tags'] = tags.map(&:name).join(' ')
-    extras['images'] = images
+    extras['images'] = { small: image(:small) }
     # guard against bad data
     extras['artist_name'] = artist.full_name
     extras['studio_name'] = artist.studio.name if artist.studio
@@ -115,13 +115,6 @@ class ArtPiece < ApplicationRecord
 
   def image(size = :medium)
     attached_photo(size)
-  end
-
-  def images
-    @images ||=
-      MauImage::ImageSize.allowed_sizes.index_with do |size|
-        image(size)
-      end
   end
 
   private

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -50,7 +50,7 @@ class Artist < User
     studio_name = studio.try(:name)
     extras['artist_name'] = full_name
     extras['studio_name'] = studio_name if studio_name.present?
-    extras['images'] = representative_piece.try(:images)
+    extras['images'] = { small: representative_piece&.image(:small) }
     extras['bio'] = bio if bio.present?
     extras['os_participant'] = doing_open_studios?
     idxd['artist'].merge!(extras)

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -80,7 +80,7 @@ class Studio < ApplicationRecord
     idxd = as_json(only: %i[name slug])
     extras = {}
     extras['address'] = address.to_s
-    extras['images'] = images
+    extras['images'] = { small: profile_image(:small) }
     extras['os_participant'] = artists.any? { |a| a.try(:doing_open_studios?) }
     idxd['studio'].merge!(extras)
     idxd

--- a/app/presenters/art_piece_presenter.rb
+++ b/app/presenters/art_piece_presenter.rb
@@ -2,7 +2,7 @@ class ArtPiecePresenter < ViewPresenter
   include ActionView::Helpers::NumberHelper
   attr_reader :model
 
-  delegate :id, :year, :medium, :artist, :title, :dimensions, :updated_at, :images, :to_param, :image, to: :model
+  delegate :id, :year, :medium, :artist, :title, :dimensions, :updated_at, :to_param, :image, to: :model
 
   def initialize(model)
     super()

--- a/app/serializers/art_piece_serializer.rb
+++ b/app/serializers/art_piece_serializer.rb
@@ -7,16 +7,11 @@ class ArtPieceSerializer < MauSerializer
              :dimensions,
              :title,
              :artist_id,
-             :image_urls,
              :sold_at
 
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::NumberHelper
-
-  attribute :image_urls do
-    @object.images
-  end
 
   has_one :artist
 

--- a/app/services/search/jobs/art_piece.rb
+++ b/app/services/search/jobs/art_piece.rb
@@ -1,0 +1,17 @@
+module Search
+  module Jobs
+    class ArtPiece < ApplicationJob
+      queue_as :es_indexer
+
+      def perform(art_piece_id, method)
+        art_piece = ::ArtPiece.find_by(id: art_piece_id)
+        unless art_piece
+          Rails.logger.warn("Unable to find ArtPiece##{object_id} - skipping es indexing")
+          return
+        end
+
+        Search::Indexer::ArtPieceSearchService.new(art_piece).send(method)
+      end
+    end
+  end
+end

--- a/app/services/search/jobs/artist.rb
+++ b/app/services/search/jobs/artist.rb
@@ -1,0 +1,17 @@
+module Search
+  module Jobs
+    class Artist < ApplicationJob
+      queue_as :es_indexer
+
+      def perform(artist_id, method)
+        artist = ::Artist.find_by(id: artist_id)
+        unless artist
+          Rails.logger.warn("Unable to find Artist##{object_id} - skipping es indexing")
+          return
+        end
+
+        Search::Indexer::ArtistSearchService.new(artist).send(method)
+      end
+    end
+  end
+end

--- a/app/services/search/jobs/studio.rb
+++ b/app/services/search/jobs/studio.rb
@@ -1,0 +1,17 @@
+module Search
+  module Jobs
+    class Studio < ApplicationJob
+      queue_as :es_indexer
+
+      def perform(studio_id, method)
+        studio = ::Studio.find_by(id: studio_id)
+        unless studio
+          Rails.logger.warn("Unable to find Studio##{studio_id} - skipping es indexing")
+          return
+        end
+
+        Search::Indexer::StudioSearchService.new(studio).send(method)
+      end
+    end
+  end
+end

--- a/app/views/art_pieces/edit.html.slim
+++ b/app/views/art_pieces/edit.html.slim
@@ -5,7 +5,7 @@
       '
       span.italic = @art_piece.title
 .pure-g
-  .pure-u-1-1.pure-u-sm-1-2.art-piece-edit-form.padded-content
+  .pure-u-1-1.pure-u-lg-1-2.art-piece-edit-form.padded-content
     = semantic_form_for @art_piece do |f|
       = render '/common/form_errors', form: f
       = render '/flash_notice_error'

--- a/app/views/artists/manage_art.slim
+++ b/app/views/artists/manage_art.slim
@@ -14,7 +14,7 @@
         a href='#delete-art' data-toggle='tab' remove
 .pure-g.tab-content
   .pure-u-1-1#add-art.tab-pane.active
-    .pure-u-1-1.pure-u-sm-1-2.art-piece-new-form.padded-content
+    .pure-u-1-1.pure-u-lg-1-2.art-piece-new-form.padded-content
       - if @artist.at_art_piece_limit?
         .error-msg
           | You cannot have more than #{@artist.max_pieces} art pieces.

--- a/app/webpack/js/app/models/art_piece.model.js
+++ b/app/webpack/js/app/models/art_piece.model.js
@@ -2,6 +2,7 @@ import { some } from "@js/app/helpers";
 import { ArtPieceTag } from "@models/art_piece_tag.model";
 import { JsonApiModel } from "@models/json_api.model";
 import { Medium } from "@models/medium.model";
+import { api } from "@services/api";
 
 export class ArtPiece extends JsonApiModel {
   constructor(data, included) {
@@ -13,6 +14,13 @@ export class ArtPiece extends JsonApiModel {
     if (some(this.tags)) {
       this.tags = this.tags.map((tag) => new ArtPieceTag(tag));
     }
+  }
+
+  async image(size) {
+    return api.artPieces
+      .image(this.id, size)
+      .catch(console.error)
+      .then(({ url, _id }) => url);
   }
 
   get hasSold() {

--- a/app/webpack/js/app/models/art_piece.model.test.js
+++ b/app/webpack/js/app/models/art_piece.model.test.js
@@ -10,10 +10,6 @@ describe("ArtPiece", () => {
           artistName: "Rosario AAabraham",
           year: 2001,
           title: "homer",
-          imageUrls: {
-            thumb: "thumb 1",
-            small: "thumb 2",
-          },
         },
         relationships: {
           artist: { meta: { included: false } },

--- a/app/webpack/js/app/models/art_piece.model.test.ts
+++ b/app/webpack/js/app/models/art_piece.model.test.ts
@@ -1,6 +1,7 @@
-import { ArtPiece } from "./art_piece.model";
 import { api } from "@services/api";
 import { mocked } from "ts-jest/utils";
+
+import { ArtPiece } from "./art_piece.model";
 
 jest.mock("@services/api");
 const mockApi = mocked(api, true);
@@ -61,14 +62,12 @@ describe("ArtPiece", () => {
     );
   });
 
-
   describe("#image", () => {
-
-    const mockApiImage = api.artPieces.image;
-
     beforeEach(() => {
-      mockApiImage.mockResolvedValue({ url: 'https://theimage.whatever.com/thing.jpg' })
-    })
+      mockApi.artPieces.image.mockResolvedValue({
+        url: "https://theimage.whatever.com/thing.jpg",
+      });
+    });
     it("fetches the image via the api", async () => {
       const data = {
         id: "36",
@@ -82,8 +81,8 @@ describe("ArtPiece", () => {
       const model = new ArtPiece(data);
       const url = await model.image("original");
 
-      expect(url).toEqual('https://theimage.whatever.com/thing.jpg')
-      expect(mockApiImage).toHaveBeenCalledWith(data.id, "original");
+      expect(url).toEqual("https://theimage.whatever.com/thing.jpg");
+      expect(mockApi.artPieces.image).toHaveBeenCalledWith(data.id, "original");
     });
   });
 });

--- a/app/webpack/js/app/models/art_piece.model.test.ts
+++ b/app/webpack/js/app/models/art_piece.model.test.ts
@@ -1,4 +1,9 @@
 import { ArtPiece } from "./art_piece.model";
+import { api } from "@services/api";
+import { mocked } from "ts-jest/utils";
+
+jest.mock("@services/api");
+const mockApi = mocked(api, true);
 
 describe("ArtPiece", () => {
   it("wraps nested items in models", () => {
@@ -54,5 +59,29 @@ describe("ArtPiece", () => {
         ]),
       })
     );
+  });
+
+
+  describe("#image", () => {
+
+    const mockApiImage = api.artPieces.image;
+
+    beforeEach(() => {
+      mockApiImage.mockResolvedValue('https://theimage.whatever.com/thing.jpg')
+    })
+    it("fetches the image via the api", async () => {
+      const data = {
+        id: "36",
+        type: "art_piece",
+        attributes: {
+          artistName: "Rosario AAabraham",
+          year: 2001,
+          title: "homer",
+        },
+      };
+      const model = new ArtPiece(data);
+      await model.image("original");
+      expect(mockApiImage).toHaveBeenCalledWith(data.id, "original");
+    });
   });
 });

--- a/app/webpack/js/app/models/art_piece.model.test.ts
+++ b/app/webpack/js/app/models/art_piece.model.test.ts
@@ -67,7 +67,7 @@ describe("ArtPiece", () => {
     const mockApiImage = api.artPieces.image;
 
     beforeEach(() => {
-      mockApiImage.mockResolvedValue('https://theimage.whatever.com/thing.jpg')
+      mockApiImage.mockResolvedValue({ url: 'https://theimage.whatever.com/thing.jpg' })
     })
     it("fetches the image via the api", async () => {
       const data = {
@@ -80,7 +80,9 @@ describe("ArtPiece", () => {
         },
       };
       const model = new ArtPiece(data);
-      await model.image("original");
+      const url = await model.image("original");
+
+      expect(url).toEqual('https://theimage.whatever.com/thing.jpg')
       expect(mockApiImage).toHaveBeenCalledWith(data.id, "original");
     });
   });

--- a/app/webpack/js/app/models/json_api.model.test.js
+++ b/app/webpack/js/app/models/json_api.model.test.js
@@ -30,10 +30,6 @@ describe("JsonApiModel", () => {
           artistName: "Rosario AAabraham",
           year: 2001,
           title: "homer",
-          imageUrls: {
-            thumb: "thumb 1",
-            small: "thumb 2",
-          },
         },
         relationships: {
           artist: { meta: { included: false } },

--- a/app/webpack/js/services/api.ts
+++ b/app/webpack/js/services/api.ts
@@ -29,11 +29,10 @@ export const api = {
     contact: (id: types.IdType, formData: types.ContactArtistFormData) => {
       return post(`/api/v2/art_pieces/${id}/contact`, formData).then(camelize);
     },
-    image: (id, size) => {
-      const resp = get(`/api/v2/art_pieces/${id}/image.json?size=${size}`);
-      return resp.then((data) => {
-        return data;
-      });
+    image: (id: types.IdType, size: types.ImageSize) => {
+      const url = `/api/v2/art_pieces/${id}/image.json?size=${size}`;
+
+      return get(url).then(camelize);
     },
   },
   applicationEvents: {

--- a/app/webpack/js/services/api.ts
+++ b/app/webpack/js/services/api.ts
@@ -29,6 +29,12 @@ export const api = {
     contact: (id: types.IdType, formData: types.ContactArtistFormData) => {
       return post(`/api/v2/art_pieces/${id}/contact`, formData).then(camelize);
     },
+    image: (id, size) => {
+      const resp = get(`/api/v2/art_pieces/${id}/image.json?size=${size}`);
+      return resp.then((data) => {
+        return data;
+      });
+    },
   },
   applicationEvents: {
     index: ({ since }): Promise<types.ApplicationEventsListResponse> =>

--- a/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
+++ b/app/webpack/reactjs/components/__snapshots__/art_card.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ArtCard matches the snapshot with all the props 1`] = `
     <div>
       <div
         class="image"
-        style="background-image: url(original.png);"
+        style="background-image: url(https://theimage.whatever.com/thing.jpg);"
       />
       <span
         class="art-card__sold"
@@ -46,7 +46,7 @@ exports[`ArtCard matches the snapshot with minimal props 1`] = `
     <div>
       <div
         class="image"
-        style="background-image: url(original.png);"
+        style="background-image: url(https://theimage.whatever.com/thing.jpg);"
       />
       <span
         class="art-card__sold"

--- a/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
+++ b/app/webpack/reactjs/components/art_browser/__snapshots__/art_window.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ArtWindow if the art has not sold matches the snapshot 1`] = `
     >
       <div
         class="art-window__image"
-        style="background-image: url(original.png); background-size: contain; background-position: center center; background-repeat: no-repeat;"
+        style="background-image: url(https://theimage.whatever.com/thing.jpg); background-size: contain; background-position: center center; background-repeat: no-repeat;"
       >
         <span
           class="art-window__sold"
@@ -101,7 +101,7 @@ exports[`ArtWindow if the art has sold matches the snapshot 1`] = `
     >
       <div
         class="art-window__image"
-        style="background-image: url(original.png); background-size: contain; background-position: center center; background-repeat: no-repeat;"
+        style="background-image: url(https://theimage.whatever.com/thing.jpg); background-size: contain; background-position: center center; background-repeat: no-repeat;"
       >
         <span
           class="art-window__sold"

--- a/app/webpack/reactjs/components/art_browser/art_window.test.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.test.tsx
@@ -1,18 +1,28 @@
 import { ArtPiece } from "@models/art_piece.model";
 import { jsonApiArtPieceFactory as artPieceFactory } from "@test/factories";
-import { render } from "@testing-library/react";
+import { render, screen, waitFor} from "@testing-library/react";
+import { api } from "@services/api";
+import { mocked } from "ts-jest/utils";
 import React from "react";
 
 import { ArtWindow } from "./art_window";
 
+jest.mock("@services/api");
+const mockApi = mocked(api, true);
+
+
 describe("ArtWindow", () => {
   let artPiece;
+  beforeEach(() => {
+    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
+  });
   describe("if the art has sold", () => {
     beforeEach(() => {
       artPiece = new ArtPiece(artPieceFactory.build({ sold: undefined }));
     });
-    it("matches the snapshot", () => {
+    it("matches the snapshot", async () => {
       const { container } = render(<ArtWindow art={artPiece} />);
+      await waitFor (() => screen.getByText("Sold"))
       expect(container).toMatchSnapshot();
     });
   });
@@ -21,8 +31,9 @@ describe("ArtWindow", () => {
     beforeEach(() => {
       artPiece = new ArtPiece(artPieceFactory.build({ sold: new Date() }));
     });
-    it("matches the snapshot", () => {
+    it("matches the snapshot", async () => {
       const { container } = render(<ArtWindow art={artPiece} />);
+      await waitFor (() => screen.getByText("Sold"))
       expect(container).toMatchSnapshot();
     });
   });

--- a/app/webpack/reactjs/components/art_browser/art_window.test.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.test.tsx
@@ -1,20 +1,21 @@
 import { ArtPiece } from "@models/art_piece.model";
-import { jsonApiArtPieceFactory as artPieceFactory } from "@test/factories";
-import { render, screen, waitFor} from "@testing-library/react";
 import { api } from "@services/api";
-import { mocked } from "ts-jest/utils";
+import { jsonApiArtPieceFactory as artPieceFactory } from "@test/factories";
+import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { mocked } from "ts-jest/utils";
 
 import { ArtWindow } from "./art_window";
 
 jest.mock("@services/api");
 const mockApi = mocked(api, true);
 
-
 describe("ArtWindow", () => {
   let artPiece;
   beforeEach(() => {
-    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
+    mockApi.artPieces.image.mockResolvedValue({
+      url: "https://theimage.whatever.com/thing.jpg",
+    });
   });
   describe("if the art has sold", () => {
     beforeEach(() => {
@@ -22,7 +23,7 @@ describe("ArtWindow", () => {
     });
     it("matches the snapshot", async () => {
       const { container } = render(<ArtWindow art={artPiece} />);
-      await waitFor (() => screen.getByText("Sold"))
+      await waitFor(() => screen.getByText("Sold"));
       expect(container).toMatchSnapshot();
     });
   });
@@ -33,7 +34,7 @@ describe("ArtWindow", () => {
     });
     it("matches the snapshot", async () => {
       const { container } = render(<ArtWindow art={artPiece} />);
-      await waitFor (() => screen.getByText("Sold"))
+      await waitFor(() => screen.getByText("Sold"));
       expect(container).toMatchSnapshot();
     });
   });

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -4,7 +4,6 @@ import * as types from "@reactjs/types";
 import cx from "classnames";
 import React, { FC, useEffect, useState } from "react";
 
-
 interface AnnotationProps {
   label: string;
   value?: string | number;
@@ -30,16 +29,16 @@ interface ArtWindowProps {
 }
 
 export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
-  const [image, setImage] = useState<string|null>(null);
+  const [image, setImage] = useState<string | null>(null);
   useEffect(() => {
     if (!art?.id) {
-      return
+      return;
     }
-    (async () => art.image('original').then(setImage))().catch(console.error)
-  }, [art?.id])
+    (async () => art.image("original").then(setImage))().catch(console.error);
+  }, [art?.id]);
 
-  if(!image) {
-    return null
+  if (!image) {
+    return null;
   }
   return (
     <div className="art-window">

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -34,7 +34,7 @@ export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
     if (!art?.id) {
       return;
     }
-    (async () => art.image("original").then(setImage))().catch(console.error);
+    art.image("original").then((url) => setImage(url)).catch(console.error);
   }, [art?.id]);
 
   if (!image) {

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -34,7 +34,10 @@ export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
     if (!art?.id) {
       return;
     }
-    art.image("original").then((url) => setImage(url)).catch(console.error);
+    art
+      .image("original")
+      .then((url) => setImage(url))
+      .catch(console.error);
   }, [art?.id]);
 
   if (!image) {

--- a/app/webpack/reactjs/components/art_browser/art_window.tsx
+++ b/app/webpack/reactjs/components/art_browser/art_window.tsx
@@ -2,7 +2,8 @@ import { backgroundImageStyle } from "@js/services";
 import { ArtPiece } from "@models/art_piece.model";
 import * as types from "@reactjs/types";
 import cx from "classnames";
-import React, { FC } from "react";
+import React, { FC, useEffect, useState } from "react";
+
 
 interface AnnotationProps {
   label: string;
@@ -29,12 +30,23 @@ interface ArtWindowProps {
 }
 
 export const ArtWindow: FC<ArtWindowProps> = ({ art }) => {
+  const [image, setImage] = useState<string|null>(null);
+  useEffect(() => {
+    if (!art?.id) {
+      return
+    }
+    (async () => art.image('original').then(setImage))().catch(console.error)
+  }, [art?.id])
+
+  if(!image) {
+    return null
+  }
   return (
     <div className="art-window">
       <div className="art-window__image-container">
         <div
           className="art-window__image"
-          style={backgroundImageStyle(art.imageUrls.original, {
+          style={backgroundImageStyle(image, {
             backgroundSize: "contain",
             backgroundRepeat: "no-repeat",
           })}

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -1,31 +1,31 @@
 import { describe, expect, it } from "@jest/globals";
 import { ArtPiece } from "@models/art_piece.model";
+import { api } from "@services/api";
 import { jsonApiArtPieceFactory } from "@test/factories";
 import { render, screen, waitFor } from "@testing-library/react";
-import { api } from "@services/api";
-import { mocked } from "ts-jest/utils";
-
 import React from "react";
+import { mocked } from "ts-jest/utils";
 
 import { ArtCard } from "./art_card";
 
 jest.mock("@services/api");
 const mockApi = mocked(api, true);
 
-
 describe("ArtCard", () => {
   let artPiece;
 
   beforeEach(() => {
-    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
+    mockApi.artPieces.image.mockResolvedValue({
+      url: "https://theimage.whatever.com/thing.jpg",
+    });
     artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
   });
 
   it("matches the snapshot with all the props", async () => {
     const { container } = render(<ArtCard artPiece={artPiece} />);
     await waitFor(() => {
-      screen.getByText("Sold")
-    })
+      screen.getByText("Sold");
+    });
     expect(container).toMatchSnapshot();
   });
 
@@ -34,8 +34,8 @@ describe("ArtCard", () => {
     artPiece.price = undefined;
     const { container } = render(<ArtCard artPiece={artPiece} />);
     await waitFor(() => {
-      screen.getByText("Sold")
-    })
+      screen.getByText("Sold");
+    });
     expect(container).toMatchSnapshot();
   });
 });

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -2,14 +2,22 @@ import { describe, expect, it } from "@jest/globals";
 import { ArtPiece } from "@models/art_piece.model";
 import { jsonApiArtPieceFactory } from "@test/factories";
 import { render } from "@testing-library/react";
+import { api } from "@services/api";
+import { mocked } from "ts-jest/utils";
+
 import React from "react";
 
 import { ArtCard } from "./art_card";
+
+jest.mock("@services/api");
+const mockApi = mocked(api, true);
+
 
 describe("ArtCard", () => {
   let artPiece;
 
   beforeEach(() => {
+    api.artPieces.immge.mockResolvedValue('https://theimage.whatever.com/thing.jpg')
     artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
   });
 

--- a/app/webpack/reactjs/components/art_card.test.tsx
+++ b/app/webpack/reactjs/components/art_card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import { ArtPiece } from "@models/art_piece.model";
 import { jsonApiArtPieceFactory } from "@test/factories";
-import { render } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { api } from "@services/api";
 import { mocked } from "ts-jest/utils";
 
@@ -17,19 +17,25 @@ describe("ArtCard", () => {
   let artPiece;
 
   beforeEach(() => {
-    api.artPieces.immge.mockResolvedValue('https://theimage.whatever.com/thing.jpg')
+    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
     artPiece = new ArtPiece(jsonApiArtPieceFactory.build());
   });
 
-  it("matches the snapshot with all the props", () => {
+  it("matches the snapshot with all the props", async () => {
     const { container } = render(<ArtCard artPiece={artPiece} />);
+    await waitFor(() => {
+      screen.getByText("Sold")
+    })
     expect(container).toMatchSnapshot();
   });
 
-  it("matches the snapshot with minimal props", () => {
+  it("matches the snapshot with minimal props", async () => {
     artPiece.dimensions = undefined;
     artPiece.price = undefined;
     const { container } = render(<ArtCard artPiece={artPiece} />);
+    await waitFor(() => {
+      screen.getByText("Sold")
+    })
     expect(container).toMatchSnapshot();
   });
 });

--- a/app/webpack/reactjs/components/art_card.tsx
+++ b/app/webpack/reactjs/components/art_card.tsx
@@ -1,9 +1,7 @@
 import { ArtPiece } from "@models/art_piece.model";
 import { ArtModal } from "@reactjs/components/art_modal";
-import { ArtPiecesContext } from "@reactjs/contexts/art_pieces.context";
 import cx from "classnames";
-
-import React, { FC, useEffect, useContext, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 
 interface AttributionProps {
   artPiece: ArtPiece;
@@ -39,11 +37,11 @@ interface ArtCardProps {
 }
 
 export const ArtCard: FC<ArtCardProps> = ({ artPiece, classes }) => {
-  const [ image, setImage ] = useState<string|null>(null);
+  const [image, setImage] = useState<string | null>(null);
 
   useEffect(() => {
-    artPiece.image('original').then(url => setImage(url))
-  }, [artPiece?.id])
+    artPiece.image("original").then((url) => setImage(url));
+  }, [artPiece?.id]);
   return (
     <div className={cx("art-card", classes)}>
       <ArtModal artPiece={artPiece}>

--- a/app/webpack/reactjs/components/art_card.tsx
+++ b/app/webpack/reactjs/components/art_card.tsx
@@ -1,7 +1,9 @@
 import { ArtPiece } from "@models/art_piece.model";
 import { ArtModal } from "@reactjs/components/art_modal";
+import { ArtPiecesContext } from "@reactjs/contexts/art_pieces.context";
 import cx from "classnames";
-import React, { FC } from "react";
+
+import React, { FC, useEffect, useContext, useState } from "react";
 
 interface AttributionProps {
   artPiece: ArtPiece;
@@ -37,13 +39,18 @@ interface ArtCardProps {
 }
 
 export const ArtCard: FC<ArtCardProps> = ({ artPiece, classes }) => {
+  const [ image, setImage ] = useState<string|null>(null);
+
+  useEffect(() => {
+    artPiece.image('original').then(url => setImage(url))
+  }, [artPiece?.id])
   return (
     <div className={cx("art-card", classes)}>
       <ArtModal artPiece={artPiece}>
-        {artPiece.imageUrls.original ? (
+        {image ? (
           <div
             className="image"
-            style={{ backgroundImage: `url("${artPiece.imageUrls.original}")` }}
+            style={{ backgroundImage: `url("${image}")` }}
           ></div>
         ) : (
           <div className="image image--empty" />

--- a/app/webpack/reactjs/components/art_modal.test.tsx
+++ b/app/webpack/reactjs/components/art_modal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { ArtPiece } from "@models/art_piece.model";
+import { api } from "@services/api";
 import { jsonApiArtPieceFactory } from "@test/factories";
 import {
   act,
@@ -8,9 +9,8 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { api } from "@services/api";
-import { mocked } from "ts-jest/utils";
 import React from "react";
+import { mocked } from "ts-jest/utils";
 
 import { ArtModal } from "./art_modal";
 
@@ -19,8 +19,9 @@ const mockApi = mocked(api, true);
 
 describe("ArtModal", () => {
   beforeEach(() => {
-    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
-    jest.resetAllMocks();
+    mockApi.artPieces.image.mockResolvedValue({
+      url: "https://theimage.whatever.com/thing.jpg",
+    });
   });
 
   const renderComponent = (props) => {

--- a/app/webpack/reactjs/components/art_modal.test.tsx
+++ b/app/webpack/reactjs/components/art_modal.test.tsx
@@ -8,14 +8,21 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { api } from "@services/api";
+import { mocked } from "ts-jest/utils";
 import React from "react";
 
 import { ArtModal } from "./art_modal";
 
+jest.mock("@services/api");
+const mockApi = mocked(api, true);
+
 describe("ArtModal", () => {
   beforeEach(() => {
+    api.artPieces.image.mockResolvedValue({url:'https://theimage.whatever.com/thing.jpg'})
     jest.resetAllMocks();
   });
+
   const renderComponent = (props) => {
     return render(
       <ArtModal {...props}>

--- a/app/webpack/reactjs/components/art_modal.tsx
+++ b/app/webpack/reactjs/components/art_modal.tsx
@@ -15,7 +15,7 @@ import React, { FC, useCallback, useContext } from "react";
 
 interface ArtModalWindowProps {
   artPiece: ArtPiece;
-  handleClose: (MouseEvent) => void;
+  handleClose: React.MouseEventHandler<HTMLAnchorElement>;
 }
 
 const ArtModalWindow: FC<ArtModalWindowProps> = ({ artPiece, handleClose }) => {
@@ -27,29 +27,34 @@ const ArtModalWindow: FC<ArtModalWindowProps> = ({ artPiece, handleClose }) => {
     isOpen: isFormVisible,
     open: showForm,
     close: hideForm,
-  } = useModalState(false);
+  } = useModalState();
 
   const contactArtistTitle = `Contact the artist directy ${artPiece.title}`;
-  const keyDownHandler = useCallback((e) => {
-    if (e.key === ARROW_LEFT_KEY) {
-      previous();
-    }
-    if (e.key === ARROW_RIGHT_KEY) {
-      next();
-    }
-  });
+  const keyDownHandler = useCallback(
+    (e) => {
+      if (e.key === ARROW_LEFT_KEY) {
+        previous();
+      }
+      if (e.key === ARROW_RIGHT_KEY) {
+        next();
+      }
+    },
+    [previous, next]
+  );
 
   useEventListener("keydown", keyDownHandler);
 
-  const handleNext = (e: MouseEvent) => {
+  const handleNext: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault();
     next();
   };
-  const handlePrevious = (e: MouseEvent) => {
+  const handlePrevious: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault();
     previous();
   };
-  const handleShowContactForm = (e: MouseEvent) => {
+  const handleShowContactForm: React.MouseEventHandler<HTMLAnchorElement> = (
+    e
+  ) => {
     e.preventDefault();
     showForm();
   };
@@ -114,10 +119,12 @@ interface ArtModalProps {
 }
 
 export const ArtModal: FC<ArtModalProps> = ({ artPiece, children }) => {
-  const { isOpen, open, close } = useModalState(false);
+  const { isOpen, open, close } = useModalState("closed");
   return (
     <>
-      {isOpen && <ArtModalWindow artPiece={artPiece} handleClose={close} />}
+      {isOpen && (
+        <ArtModalWindow artPiece={artPiece} handleClose={() => close()} />
+      )}
       <div
         onClick={(ev) => {
           ev.preventDefault();

--- a/app/webpack/reactjs/components/art_piece_browser.tsx
+++ b/app/webpack/reactjs/components/art_piece_browser.tsx
@@ -114,11 +114,10 @@ const ArtPieceBrowser: FC<ArtPieceBrowserProps> = ({
     if (artImages && artImages[current?.id]) {
       return;
     }
-    const fetchImage = async () => {
-      current.image("large").then(setCurrentImage);
-    };
-
-    fetchImage().catch(console.error);
+    current
+      .image("large")
+      .then((url) => setCurrentImage(url))
+      .catch(console.error);
   }, [current?.id, artImages && JSON.stringify(Object.keys(artImages))]);
 
   /* load thumbnails */
@@ -325,7 +324,9 @@ const ArtPieceBrowserWrapper: FC<ArtPieceBrowserWrapperProps> = ({
         });
       })
       .catch((err) => {
-        new Flash().show({ error: "rats" + err });
+        new Flash().show({
+          error: "Rats! Something seems to have gone wrong. " + err,
+        });
       });
   }, [artistId]);
 

--- a/app/webpack/reactjs/components/art_piece_browser.tsx
+++ b/app/webpack/reactjs/components/art_piece_browser.tsx
@@ -1,5 +1,6 @@
 import Flash from "@js/app/flash";
 import { isEmpty } from "@js/app/helpers";
+import { Artist, ArtPiece, Studio } from "@js/app/models";
 import { ARROW_LEFT_KEY, ARROW_RIGHT_KEY } from "@js/event_constants";
 import { routing } from "@js/services";
 import { ArtPieceTagLink } from "@reactjs/components/art_piece_tag_link";
@@ -10,7 +11,6 @@ import { MediumLink } from "@reactjs/components/medium_link";
 import { ShareButton } from "@reactjs/components/share_button";
 import { Spinner } from "@reactjs/components/spinner";
 import { useCarouselState, useEventListener } from "@reactjs/hooks";
-import { Artist, ArtPiece, Studio } from "@reactjs/models";
 import * as types from "@reactjs/types";
 import { api } from "@services/api";
 import { jsonApi } from "@services/json_api";
@@ -29,7 +29,7 @@ const OpenStudiosViolator: FC = () => (
 );
 
 interface ArtPieceBrowserProps {
-  artPieceId: number;
+  artPieceId: types.IdType;
   artPieces: ArtPiece[];
   studio: Studio;
   artist: Artist;
@@ -51,7 +51,7 @@ const ArtPieceBrowser: FC<ArtPieceBrowserProps> = ({
     setCurrent: _setCurrent,
   } = useCarouselState<ArtPiece>(artPieces, initialArtPiece);
 
-  const [artImages, setArtImages] = useState<string | null>(null);
+  const [artImages, setArtImages] = useState<Record<types.IdType, string>>({});
   const [thumbnails, setThumbnails] = useState<Record<types.IdType, string>>(
     {}
   );
@@ -87,14 +87,17 @@ const ArtPieceBrowser: FC<ArtPieceBrowserProps> = ({
     updateHash(newCurrent);
   };
 
-  const keyDownHandler = useCallback((e) => {
-    if (e.key === ARROW_LEFT_KEY) {
-      previous();
-    }
-    if (e.key === ARROW_RIGHT_KEY) {
-      next();
-    }
-  });
+  const keyDownHandler = useCallback(
+    (e) => {
+      if (e.key === ARROW_LEFT_KEY) {
+        previous();
+      }
+      if (e.key === ARROW_RIGHT_KEY) {
+        next();
+      }
+    },
+    [previous, next]
+  );
 
   useEventListener("keydown", keyDownHandler);
 

--- a/app/webpack/reactjs/components/art_piece_browser.tsx
+++ b/app/webpack/reactjs/components/art_piece_browser.tsx
@@ -112,7 +112,7 @@ const ArtPieceBrowser: FC<ArtPieceBrowserProps> = ({
       return;
     }
     const fetchImage = async () => {
-      current.image('large').then(setCurrentImage)
+      current.image("large").then(setCurrentImage);
     };
 
     fetchImage().catch(console.error);

--- a/app/webpack/reactjs/components/art_piece_tag_link.tsx
+++ b/app/webpack/reactjs/components/art_piece_tag_link.tsx
@@ -1,5 +1,5 @@
+import { ArtPieceTag } from "@js/app/models";
 import { routing } from "@js/services";
-import { ArtPieceTag } from "@reactjs/models";
 import React, { FC } from "react";
 
 interface ArtPieceTagLinkProps {

--- a/app/webpack/reactjs/components/mau_checkbox_field.tsx
+++ b/app/webpack/reactjs/components/mau_checkbox_field.tsx
@@ -1,7 +1,7 @@
 import { MauHint } from "@reactjs/components/mau_hint";
 import cx from "classnames";
 import { Field } from "formik";
-import React, { FC, ElementType } from "react";
+import React, { ElementType, FC } from "react";
 
 interface MauCheckboxFieldProps {
   name: string;

--- a/app/webpack/reactjs/components/mau_checkbox_field.tsx
+++ b/app/webpack/reactjs/components/mau_checkbox_field.tsx
@@ -1,12 +1,12 @@
 import { MauHint } from "@reactjs/components/mau_hint";
 import cx from "classnames";
 import { Field } from "formik";
-import React, { FC, JSX } from "react";
+import React, { FC, ElementType } from "react";
 
 interface MauCheckboxFieldProps {
   name: string;
   label: string;
-  hint?: string | JSX.Element;
+  hint?: string | ElementType;
   id?: string;
   classes?: string;
   disabled?: boolean;

--- a/app/webpack/reactjs/components/mau_text_area_field.tsx
+++ b/app/webpack/reactjs/components/mau_text_area_field.tsx
@@ -1,7 +1,7 @@
 import { FieldError } from "@reactjs/components/field_error";
 import { MauHint } from "@reactjs/components/mau_hint";
 import { ErrorMessage, Field } from "formik";
-import React, { FC, ElementType } from "react";
+import React, { ElementType, FC } from "react";
 
 interface MauTextAreaFieldProps {
   id?: string;

--- a/app/webpack/reactjs/components/mau_text_area_field.tsx
+++ b/app/webpack/reactjs/components/mau_text_area_field.tsx
@@ -1,7 +1,7 @@
 import { FieldError } from "@reactjs/components/field_error";
 import { MauHint } from "@reactjs/components/mau_hint";
 import { ErrorMessage, Field } from "formik";
-import React, { FC, JSX } from "react";
+import React, { FC, ElementType } from "react";
 
 interface MauTextAreaFieldProps {
   id?: string;
@@ -9,7 +9,7 @@ interface MauTextAreaFieldProps {
   label: string;
   placeholder: string;
   className?: string;
-  hint?: string | JSX.Element;
+  hint?: string | ElementType;
 }
 
 export const MauTextAreaField: FC<MauTextAreaFieldProps> = ({

--- a/app/webpack/reactjs/components/mau_text_field.tsx
+++ b/app/webpack/reactjs/components/mau_text_field.tsx
@@ -1,7 +1,7 @@
 import { FieldError } from "@reactjs/components/field_error";
 import { MauHint } from "@reactjs/components/mau_hint";
 import { ErrorMessage, Field } from "formik";
-import React, { FC, ElementType } from "react";
+import React, { ElementType, FC } from "react";
 
 interface MauTextFieldProps {
   id?: string;

--- a/app/webpack/reactjs/components/mau_text_field.tsx
+++ b/app/webpack/reactjs/components/mau_text_field.tsx
@@ -1,15 +1,15 @@
 import { FieldError } from "@reactjs/components/field_error";
 import { MauHint } from "@reactjs/components/mau_hint";
 import { ErrorMessage, Field } from "formik";
-import React, { FC, JSX } from "react";
+import React, { FC, ElementType } from "react";
 
 interface MauTextFieldProps {
   id?: string;
   name: string;
   label: string;
-  placeholder: string;
+  placeholder?: string;
   className?: string;
-  hint?: string | JSX.Element;
+  hint?: string | ElementType;
   type?: "text" | "email";
   required?: boolean;
 }

--- a/app/webpack/reactjs/components/medium_link.tsx
+++ b/app/webpack/reactjs/components/medium_link.tsx
@@ -1,5 +1,5 @@
+import { Medium } from "@js/app/models";
 import { routing } from "@js/services";
-import { Medium } from "@reactjs/models";
 import React, { FC } from "react";
 
 interface MediumLinkProps {

--- a/app/webpack/reactjs/components/notify_mau_dialog.tsx
+++ b/app/webpack/reactjs/components/notify_mau_dialog.tsx
@@ -52,7 +52,7 @@ const NOTE_INFO_LUT: Record<NoteTypes, NoteInfo> = {
   },
 };
 
-const noteInfo: NoteInfo = (noteType: NoteTypes) => {
+const noteInfo = (noteType: NoteTypes): NoteInfo => {
   return NOTE_INFO_LUT[noteType];
 };
 

--- a/app/webpack/reactjs/components/react_test_component.tsx
+++ b/app/webpack/reactjs/components/react_test_component.tsx
@@ -12,9 +12,6 @@ const artPiece = {
   title: "whatever",
   artistName: "joe",
   id: 10,
-  imageUrls: {
-    large: "whatever.jpg",
-  },
 };
 
 const errorWithTimeout = (timeout?: number) => {

--- a/app/webpack/reactjs/components/search/search_form.tsx
+++ b/app/webpack/reactjs/components/search/search_form.tsx
@@ -35,7 +35,7 @@ export const SearchForm: FC<SearchFormProps> = () => {
       },
       250,
       false
-    )
+    ), [pageSize, page]
   );
 
   return (

--- a/app/webpack/reactjs/components/search/search_form.tsx
+++ b/app/webpack/reactjs/components/search/search_form.tsx
@@ -35,7 +35,8 @@ export const SearchForm: FC<SearchFormProps> = () => {
       },
       250,
       false
-    ), [pageSize, page]
+    ),
+    [pageSize, page]
   );
 
   return (

--- a/app/webpack/reactjs/components/share_button.test.tsx
+++ b/app/webpack/reactjs/components/share_button.test.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import { ShareButton } from "./share_button";
 
 describe("ShareButton", () => {
-  const renderComponent = (type, artPiece = undefined) => {
-    return render(<ShareButton artPiece={artPiece} type={type} />);
+  const renderComponent = (type, artPiece = undefined, image = undefined) => {
+    return render(<ShareButton artPiece={artPiece} image={image} type={type} />);
   };
 
   describe("when there is no art piece id", function () {
@@ -16,18 +16,16 @@ describe("ShareButton", () => {
     });
   });
 
+  let image = "the_image.jpg";
+
   describe("when it's a facebook share", function () {
     let artPiece = {
       id: 12,
       title: "Mona Lisa",
       artistName: "Leo",
-      imageUrls: {
-        large: "the_image.jpg",
-      },
     };
-
     beforeEach(() => {
-      renderComponent("facebook", artPiece);
+      renderComponent("facebook", artPiece, image);
     });
 
     it("includes the facebook icon", function () {
@@ -45,13 +43,10 @@ describe("ShareButton", () => {
       id: 12,
       title: "Mona Lisa",
       artistName: "Leo",
-      imageUrls: {
-        large: "the_image.jpg",
-      },
     };
 
     beforeEach(() => {
-      renderComponent("twitter", artPiece);
+      renderComponent("twitter", artPiece, image);
     });
 
     it("includes the twitter icon", function () {
@@ -73,13 +68,10 @@ describe("ShareButton", () => {
       id: 12,
       title: "Mona Lisa",
       artistName: "Leo",
-      imageUrls: {
-        large: "the_image.jpg",
-      },
     };
 
     beforeEach(() => {
-      renderComponent("pinterest", artPiece);
+      renderComponent("pinterest", artPiece, image);
     });
 
     it("includes the twitter icon", function () {

--- a/app/webpack/reactjs/components/share_button.test.tsx
+++ b/app/webpack/reactjs/components/share_button.test.tsx
@@ -6,7 +6,9 @@ import { ShareButton } from "./share_button";
 
 describe("ShareButton", () => {
   const renderComponent = (type, artPiece = undefined, image = undefined) => {
-    return render(<ShareButton artPiece={artPiece} image={image} type={type} />);
+    return render(
+      <ShareButton artPiece={artPiece} image={image} type={type} />
+    );
   };
 
   describe("when there is no art piece id", function () {

--- a/app/webpack/reactjs/components/share_button.tsx
+++ b/app/webpack/reactjs/components/share_button.tsx
@@ -7,12 +7,14 @@ type ShareTypes = "twitter" | "facebook" | "pinterest";
 
 interface ShareButtonProps {
   type: ShareTypes;
+  image?: string;
   artPiece: ArtPiece;
   target?: string;
 }
 
 export const ShareButton: FC<ShareButtonProps> = ({
   artPiece,
+  image,
   type,
   target,
 }) => {
@@ -24,7 +26,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
   const location = window.location;
 
   locationOrigin = location.protocol + "//" + location.hostname;
-  if (location.port != null && location.port !== 80) {
+  if (location.port != null && location.port !== '80') {
     locationOrigin += ":" + location.port;
   }
 
@@ -34,7 +36,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
 
   const safeArtPieceLink = artPieceLink;
   const safeDescription = description;
-  const safeArtPieceImage = "" + artPiece.imageUrls.large;
+  const safeArtPieceImage = "" + image;
   const safeTitle = artPiece.title;
 
   const linkInfo = {

--- a/app/webpack/reactjs/components/share_button.tsx
+++ b/app/webpack/reactjs/components/share_button.tsx
@@ -26,7 +26,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
   const location = window.location;
 
   locationOrigin = location.protocol + "//" + location.hostname;
-  if (location.port != null && location.port !== '80') {
+  if (location.port != null && location.port !== "80") {
     locationOrigin += ":" + location.port;
   }
 

--- a/app/webpack/reactjs/components/share_button.tsx
+++ b/app/webpack/reactjs/components/share_button.tsx
@@ -1,5 +1,5 @@
+import { ArtPiece } from "@js/app/models";
 import { hashToQueryString } from "@js/app/query_string_parser";
-import { ArtPiece } from "@reactjs/models";
 import cx from "classnames";
 import React, { FC } from "react";
 

--- a/app/webpack/reactjs/types/apiTypes.ts
+++ b/app/webpack/reactjs/types/apiTypes.ts
@@ -1,6 +1,6 @@
 /** api request/response shapes **/
 
-import { ApplicationEvent } from "./modelTypes";
+import { ApplicationEvent, IdType, OpenStudiosParticipant } from "./modelTypes";
 
 export interface ContactArtistFormData {
   name: string;
@@ -12,4 +12,10 @@ export interface ContactArtistFormData {
 
 export interface ApplicationEventsListResponse {
   applicationEvents: ApplicationEvent[];
+}
+
+export interface OpenStudiosParticipantUpdateRequest {
+  id: IdType;
+  artistId: IdType;
+  openStudiosParticipant: OpenStudiosParticipant;
 }

--- a/app/webpack/reactjs/types/apiTypes.ts
+++ b/app/webpack/reactjs/types/apiTypes.ts
@@ -19,3 +19,5 @@ export interface OpenStudiosParticipantUpdateRequest {
   artistId: IdType;
   openStudiosParticipant: OpenStudiosParticipant;
 }
+
+export type ImageSize = "small" | "medium" | "large" | "original";

--- a/app/webpack/reactjs/types/contextTypes.ts
+++ b/app/webpack/reactjs/types/contextTypes.ts
@@ -1,6 +1,5 @@
-import { ArtPiece } from "@models.art_piece.model";
+import { ArtPiece } from "@models/art_piece.model";
 
 export interface ArtPiecesContext {
-  artPiecesById: Record<number, ArtPiece>;
-  currentArtPieceId: number;
+  artPieces?: ArtPiece[];
 }

--- a/app/webpack/reactjs/types/index.ts
+++ b/app/webpack/reactjs/types/index.ts
@@ -3,6 +3,7 @@
 // so consumers can stay the same.
 
 export * from "./apiTypes";
+export * from "./contextTypes";
 export * from "./eventTypes";
 export * from "./modelTypes";
 export * from "./utilTypes";

--- a/app/webpack/reactjs/types/modelTypes.ts
+++ b/app/webpack/reactjs/types/modelTypes.ts
@@ -8,6 +8,7 @@ interface ActiveRecordModel {
 }
 
 export interface CmsDocument {
+  id: IdType;
   page: string;
   section: string;
   cmsid: number;

--- a/app/webpack/stylesheets/gto/components/search_results.scss
+++ b/app/webpack/stylesheets/gto/components/search_results.scss
@@ -55,6 +55,7 @@
       width: 100%;
       height: 100%;
       background-position: center center;
+      background-size: cover;
     }
     @media screen and (min-width: v.$screen-sm-max) {
     }

--- a/app/webpack/test/factories/art_piece.factory.ts
+++ b/app/webpack/test/factories/art_piece.factory.ts
@@ -13,12 +13,6 @@ const jsonApiArtPieceAttributesFactory =
     .attr("dimensions", "10x 20")
     .attr("title", "the title goes here")
     .attr("artistId", 45)
-    .attr("imageUrls", {
-      small: "small.png",
-      medium: "medium.png",
-      large: "large.png",
-      original: "original.png",
-    })
     .attr("soldAt", "a time stamp");
 
 export const jsonApiArtPieceFactory = Factory.define<types.JsonApiArtPiece>(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Mau::Application.routes.draw do
       resources :studios, only: [:show]
       resources :artists, only: %i[index show] do
         resources :art_pieces, only: %i[index show], shallow: true do
+          get :image
           resource :contact, only: [:create]
         end
       end

--- a/features/artists/add_and_edit_art.feature
+++ b/features/artists/add_and_edit_art.feature
@@ -29,11 +29,11 @@ Scenario: "Editing Art"
   And I update the art piece tags to:
     | new tag | other tag |
   And I click "Update"
-  Then I see that my art title was updated to "Gobbledy Goop"
+  Then I see a flash notice "art has been updated"
+  And I see that my art title was updated to "Gobbledy Goop"
   And I see that my art medium was updated to the last medium
   And I see that my art tags are:
     | new tag | other tag |
-  And I see a flash notice "art has been updated"
 
   When I click on "My Art" in the sidebar menu
   And I click on "edit"

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -224,7 +224,7 @@ Then('I see details about the art on each art card') do
   pieces = @artist.art_pieces
   expect(pieces).to have_at_least(1).piece
   pieces.each do |piece|
-    expect(page).to have_content(piece.price)
+    expect(page).to have_content(ActionController::Base.helpers.number_to_currency(piece.price))
     expect(page).to have_content(piece.dimensions)
   end
 end
@@ -242,7 +242,7 @@ end
 Then('I see that art in a modal') do
   within '.art-modal__content' do
     expect(page).to have_content(@art_piece.title)
-    expect(page).to have_content(@art_piece.price)
+    expect(page).to have_content(ActionController::Base.helpers.number_to_currency(@art_piece.price))
     expect(page).to have_content(@art_piece.dimensions)
     expect(page).to have_content(@art_piece.medium.name)
   end
@@ -254,7 +254,7 @@ Then('I see the next art piece in the modal') do
 
   within '.art-modal__content' do
     expect(page).to have_content(next_piece.title)
-    expect(page).to have_content(next_piece.price)
+    expect(page).to have_content(ActionController::Base.helpers.number_to_currency(next_piece.price))
     expect(page).to have_content(next_piece.dimensions)
     expect(page).to have_content(next_piece.medium.name)
   end

--- a/spec/factories/art_pieces.rb
+++ b/spec/factories/art_pieces.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     dimensions { "#{Random.rand(10..50)} x #{Random.rand(10..50)}" }
     year { (Time.zone.now - Random.rand(10).years).year }
     medium
-    price { rand(1..1000) + rand.round(2) }
+    price { rand(1000..2000) + rand.round(2) }
     artist do
       FactoryBot.create(:artist, :active)
     end

--- a/spec/serializers/art_piece_serializer_spec.rb
+++ b/spec/serializers/art_piece_serializer_spec.rb
@@ -11,7 +11,7 @@ describe ArtPieceSerializer do
 
   describe 'to_json' do
     it 'includes the fields we care about' do
-      %i[title artist_id year image_urls artist_name price sold_at].each do |expected|
+      %i[title artist_id year artist_name price sold_at].each do |expected|
         expect(parsed_art_piece).to have_key expected
       end
     end
@@ -21,14 +21,14 @@ describe ArtPieceSerializer do
       expect(parsed_art_piece[:display_price]).to eq number_to_currency(art_piece.price)
     end
 
-    it 'includes paths to the images' do
-      sizes = %i[large medium original small]
-      files = parsed_art_piece[:image_urls]
-      expect(files.keys.sort).to eql sizes
-      sizes.each do |sz|
-        expect(files[sz]).to include art_piece.attached_photo(sz)
-      end
-    end
+    # it 'includes paths to the images' do
+    #   sizes = %i[large medium original small]
+    #   files = parsed_art_piece[:image_urls]
+    #   expect(files.keys.sort).to eql sizes
+    #   sizes.each do |sz|
+    #     expect(files[sz]).to include art_piece.attached_photo(sz)
+    #   end
+    # end
 
     it 'includes the tags' do
       expect(relationships[:tags]).to be_present

--- a/spec/serializers/art_piece_serializer_spec.rb
+++ b/spec/serializers/art_piece_serializer_spec.rb
@@ -21,15 +21,6 @@ describe ArtPieceSerializer do
       expect(parsed_art_piece[:display_price]).to eq number_to_currency(art_piece.price)
     end
 
-    # it 'includes paths to the images' do
-    #   sizes = %i[large medium original small]
-    #   files = parsed_art_piece[:image_urls]
-    #   expect(files.keys.sort).to eql sizes
-    #   sizes.each do |sz|
-    #     expect(files[sz]).to include art_piece.attached_photo(sz)
-    #   end
-    # end
-
     it 'includes the tags' do
       expect(relationships[:tags]).to be_present
     end

--- a/spec/services/search/indexer_spec.rb
+++ b/spec/services/search/indexer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Search::Indexer, elasticsearch: :stub do
+  include ActiveJob::TestHelper
+
   subject(:service) { Search::Indexer }
   let(:artist) { create :artist, :with_art }
   let(:art_piece) { artist.art_pieces.first }
@@ -13,12 +15,14 @@ describe Search::Indexer, elasticsearch: :stub do
       it 'indexes the artist' do
         expect(object.__elasticsearch__).to receive(:index_document)
         service.index(object)
+        perform_enqueued_jobs
       end
       it 'indexes all the artists art pieces' do
         object.art_pieces.each do |art|
           expect(art.__elasticsearch__).to receive(:index_document)
         end
         service.index(object)
+        perform_enqueued_jobs
       end
     end
     describe '.reindex' do
@@ -26,6 +30,7 @@ describe Search::Indexer, elasticsearch: :stub do
         expect(object.__elasticsearch__).to receive(:delete_document)
         expect(object.__elasticsearch__).to receive(:index_document)
         service.reindex(object)
+        perform_enqueued_jobs
       end
       it 'reindexes all the artists art pieces' do
         object.art_pieces.each do |art|
@@ -33,30 +38,35 @@ describe Search::Indexer, elasticsearch: :stub do
           expect(art.__elasticsearch__).to receive(:index_document)
         end
         service.reindex(object)
+        perform_enqueued_jobs
       end
     end
     describe '.update' do
       it 'updates the artist' do
         expect(object.__elasticsearch__).to receive(:update_document)
         service.update(object)
+        perform_enqueued_jobs
       end
       it 'updates all the artists art pieces' do
         object.art_pieces.each do |art|
           expect(art.__elasticsearch__).to receive(:update_document)
         end
         service.update(object)
+        perform_enqueued_jobs
       end
     end
     describe '.remove' do
       it 'removes the artist' do
         expect(object.__elasticsearch__).to receive(:delete_document)
         service.remove(object)
+        perform_enqueued_jobs
       end
       it 'removes all the artists art pieces' do
         object.art_pieces.each do |art|
           expect(art.__elasticsearch__).to receive(:delete_document)
         end
         service.remove(object)
+        perform_enqueued_jobs
       end
     end
   end
@@ -68,10 +78,12 @@ describe Search::Indexer, elasticsearch: :stub do
       it 'indexes the art piece document' do
         expect(object.__elasticsearch__).to receive(:index_document)
         service.index(object)
+        perform_enqueued_jobs
       end
       it 'indexes all the artists art pieces' do
         expect(object.artist.__elasticsearch__).to receive(:index_document)
         service.index(object)
+        perform_enqueued_jobs
       end
     end
     describe '.reindex' do
@@ -79,27 +91,32 @@ describe Search::Indexer, elasticsearch: :stub do
         expect(object.__elasticsearch__).to receive(:delete_document)
         expect(object.__elasticsearch__).to receive(:index_document)
         service.reindex(object)
+        perform_enqueued_jobs
       end
       it 'reindexes all the artists art pieces' do
         expect(object.artist.__elasticsearch__).to receive(:delete_document)
         expect(object.artist.__elasticsearch__).to receive(:index_document)
         service.reindex(object)
+        perform_enqueued_jobs
       end
     end
     describe '.update' do
       it 'updates the art piece document' do
         expect(object.__elasticsearch__).to receive(:update_document)
         service.update(object)
+        perform_enqueued_jobs
       end
       it 'updates all the artists art pieces' do
         expect(object.artist.__elasticsearch__).to receive(:update_document)
         service.update(object)
+        perform_enqueued_jobs
       end
     end
     describe '.remove' do
       it 'removes the art piece document' do
         expect(object.__elasticsearch__).to receive(:delete_document)
         service.remove(object)
+        perform_enqueued_jobs
       end
     end
   end
@@ -110,6 +127,7 @@ describe Search::Indexer, elasticsearch: :stub do
       it 'indexes the studio' do
         expect(object.__elasticsearch__).to receive(:index_document)
         service.index(object)
+        perform_enqueued_jobs
       end
     end
     describe '.reindex' do
@@ -117,18 +135,21 @@ describe Search::Indexer, elasticsearch: :stub do
         expect(object.__elasticsearch__).to receive(:delete_document)
         expect(object.__elasticsearch__).to receive(:index_document)
         service.reindex(object)
+        perform_enqueued_jobs
       end
     end
     describe '.update' do
       it 'updates the studio' do
         expect(object.__elasticsearch__).to receive(:update_document)
         service.update(object)
+        perform_enqueued_jobs
       end
     end
     describe '.remove' do
       it 'removes the studio' do
         expect(object.__elasticsearch__).to receive(:delete_document)
         service.remove(object)
+        perform_enqueued_jobs
       end
     end
   end
@@ -140,6 +161,7 @@ describe Search::Indexer, elasticsearch: :stub do
     it 'reindexes successfully even if the item is not in the bucket' do
       expect do
         subject.reindex
+        perform_enqueued_jobs
       end.not_to raise_error
     end
   end

--- a/spec/services/search/jobs/art_piece_spec.rb
+++ b/spec/services/search/jobs/art_piece_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Search::Jobs::ArtPiece, elasticsearch: :stub do
+  before do
+    allow(Search::Indexer::ArtPieceSearchService).to receive(:new).and_return(indexer_service)
+  end
+
+  let(:indexer_service) { instance_double(Search::Indexer::ArtPieceSearchService, index: true, reindex: true, update: true, remove: true) }
+
+  context 'when the art_piece exists' do
+    let(:art_piece) { create(:art_piece) }
+
+    %i[index reindex update remove].each do |method|
+      describe ".#{method}" do
+        it "runs search #{method} for the art_piece" do
+          described_class.perform_now(art_piece.id, method)
+          expect(Search::Indexer::ArtPieceSearchService).to have_received(:new).with(art_piece)
+          expect(indexer_service).to have_received(method)
+        end
+      end
+    end
+  end
+
+  context 'when we cannot find the art_piece' do
+    it 'does nothing' do
+      described_class.perform_now(1_000_000, :index)
+      expect(Search::Indexer::ArtPieceSearchService).not_to have_received(:new)
+    end
+  end
+end

--- a/spec/services/search/jobs/artist_spec.rb
+++ b/spec/services/search/jobs/artist_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Search::Jobs::Artist, elasticsearch: :stub do
+  before do
+    allow(Search::Indexer::ArtistSearchService).to receive(:new).and_return(indexer_service)
+  end
+
+  let(:indexer_service) { instance_double(Search::Indexer::ArtistSearchService, index: true, reindex: true, update: true, remove: true) }
+
+  context 'when the artist exists' do
+    let(:artist) { create(:artist) }
+
+    %i[index reindex update remove].each do |method|
+      describe ".#{method}" do
+        it "runs search #{method} for the artist" do
+          described_class.perform_now(artist.id, method)
+          expect(Search::Indexer::ArtistSearchService).to have_received(:new).with(artist)
+          expect(indexer_service).to have_received(method)
+        end
+      end
+    end
+  end
+
+  context 'when we cannot find the artist' do
+    it 'does nothing' do
+      described_class.perform_now(1_000_000, :index)
+      expect(Search::Indexer::ArtistSearchService).not_to have_received(:new)
+    end
+  end
+end

--- a/spec/services/search/jobs/studio_spec.rb
+++ b/spec/services/search/jobs/studio_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Search::Jobs::Studio, elasticsearch: :stub do
+  before do
+    allow(Search::Indexer::StudioSearchService).to receive(:new).and_return(indexer_service)
+  end
+
+  let(:indexer_service) { instance_double(Search::Indexer::StudioSearchService, index: true, reindex: true, update: true, remove: true) }
+
+  context 'when the studio exists' do
+    let(:studio) { create(:studio) }
+
+    %i[index reindex update remove].each do |method|
+      describe ".#{method}" do
+        it "runs search #{method} for the studio" do
+          described_class.perform_now(studio.id, method)
+          expect(Search::Indexer::StudioSearchService).to have_received(:new).with(studio)
+          expect(indexer_service).to have_received(method)
+        end
+      end
+    end
+  end
+
+  context 'when we cannot find the studio' do
+    it 'does nothing' do
+      described_class.perform_now(1_000_000, :index)
+      expect(Search::Indexer::StudioSearchService).not_to have_received(:new)
+    end
+  end
+end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -22,8 +23,13 @@
     }
   },
   "exclude": [
-    "**/*.spec.ts",
-    "**/*.spec.tsx",
+    "vite.config.ts",
+    "**/*.spec.js*",
+    "**/*.test.js*",
+    "**/*.spec.ts*",
+    "**/*.test.ts*",
+    "**/*.po.tsx",
+    "app/webpack/test/*",
     "node_modules",
     "vendor",
     "public"


### PR DESCRIPTION
problem
---------

The site is slow because when we ask for images, we were running the serializer for different models and that serializer was asking for *all* active storage sizes which meant it had to process all iamges even if we didn't need them all.

Solution
---------

Because we don't (usually) need all versions, we can instead surface a new endpoint that just surfaces the image and size that we want at the time.

This PR introduces that new backend controller and moves the frontend to connect to there when it needs an image.

Additionally, this impacts the data that goes in to the search index. So we updated the way search indexing happens by first only indexing the image sizes used by search results and also moving the 'reindexing' to a job because when you update art, the ActiveStorage may not be immediately available.  This makes sure that reindexing happens a short time after any model updates so we can be more certain that the indexer will properly pick up any changes from ActiveStorage.

Changes
--------

* remove images from models and presenters and serializers
* add new controller method to get an image by size for a model
* update frontend components to instead of looking for `images[size]` - fetch just the one you need
* Moved typing from JSX.Element to ElementType
* Add active job configuration
* Add jobs to index Artist, ArtPiece, Studio