### PR TITLE
Small performance tuning around sampler and images

### DIFF
--- a/app/webpack/js/app/sampler.js
+++ b/app/webpack/js/app/sampler.js
@@ -3,10 +3,32 @@ import jQuery from "jquery";
 
 const NUM_IMAGES = 12;
 
+class RequestTracker {
+  constructor() {
+    this.requests = new Set();
+  }
+
+  static requestKey(seed, offset, count) {
+    return [seed, offset, count].join("_");
+  }
+
+  isInFlight(seed, offset, count) {
+    return this.requests.has(RequestTracker.requestKey(seed, offset, count));
+  }
+
+  start(seed, offset, count) {
+    return this.requests.add(RequestTracker.requestKey(seed, offset, count));
+  }
+
+  stop(seed, offset, count) {
+    return this.requests.delete(RequestTracker.requestKey(seed, offset, count));
+  }
+}
+
 class Sampler {
   constructor(containerSelector) {
     this.$container = jQuery(containerSelector);
-
+    this.requests = new RequestTracker();
     const $win = jQuery(window);
     $win.scroll(() => {
       if ($win.scrollTop() === jQuery(document).height() - $win.height()) {
@@ -16,17 +38,28 @@ class Sampler {
     this.fetchArtists();
   }
 
+  static requestKey(seed, offset, count) {
+    return [seed, offset, count].join("_");
+  }
+
   async fetchArtists() {
     if (!this.$container.find("#js-scroll-load-more").length) {
       return;
     }
     const seed = this.$container.data("seed");
     const offset = this.$container.data("offset") || 0;
+
+    if (this.requests.isInFlight(seed, offset, NUM_IMAGES)) {
+      return;
+    }
+
+    this.requests.start(seed, offset, NUM_IMAGES);
     const data = await post("/main/sampler", {
       seed: seed,
       offset: offset,
       number_of_images: NUM_IMAGES,
     });
+    this.requests.stop(seed, offset, NUM_IMAGES);
 
     if (data && !/^\s+$/.test(data)) {
       const $win = jQuery(window);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,15 +2706,10 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001449:
-  version "1.0.30001456"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz#734ec1dbfa4f3abe6e435b78ecf40d68e8c32ce4"
-  integrity sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==
-
-caniuse-lite@^1.0.30001359:
-  version "1.0.30001414"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz#5f1715e506e71860b4b07c50060ea6462217611e"
-  integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
+caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001359, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001449:
+  version "1.0.30001525"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
+  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Problem
---------

The active storage image handling is really slow partially because it adds a pile of redirects in the mix.

Also, we allow multiple sampler requests to happen simultaneously.

Solution
---------

First, if the image has already been processed, just return the url - in the has_attached_photo mixin.

Then keep track of sampler requests that are on a page so that we don't re-call sampler if we somehow triggered the same values twice.