### PR TITLE
Force art piece generation of medium and large variants on create

### DIFF
--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -28,6 +28,7 @@ class ArtPiecesController < ApplicationController
     redirect_to(current_artist) && return if commit_is_cancel
 
     art_piece = CreateArtPieceService.call(current_artist, art_piece_params)
+
     if art_piece&.persisted?
       flash[:notice] = "You've got new art!"
       Messager.new.publish "/artists/#{current_artist.id}/art_pieces/create", 'added art piece'

--- a/app/services/create_art_piece_service.rb
+++ b/app/services/create_art_piece_service.rb
@@ -22,6 +22,10 @@ class CreateArtPieceService
     emails = WatcherMailerList.first&.formatted_emails
     WatcherMailer.notify_new_art_piece(art_piece, emails).deliver_now if art_piece.persisted? && emails.present?
 
+    # trigger create medium variant
+    art_piece&.image(:medium)
+    art_piece&.image(:large)
+
     art_piece
   end
 end


### PR DESCRIPTION
Problem
----------

with the whole redirect thing and active_storage, a page heavy with image variants causes a huge slowdown because each query *might* trigger building the variant before actually serving it up.  Since we don't really care about variants to be constructed on the fly, and we can get way better caching if we start to create these now, we build medium and large assets on create to avoid building those images later.

Solution
---------

Force trigger the variant creation during art piece creation.