### PR TITLE
Fix duplicate images in art piece sampler

### DIFF
--- a/app/presenters/art_sampler.rb
+++ b/app/presenters/art_sampler.rb
@@ -21,7 +21,11 @@ class ArtSampler
   end
 
   def random_pieces
-    ArtPiece.includes({ artist: :open_studios_events })
+    # Though including open studios events in this for AREL performance
+    # it ruins the random order and limit/offset so that we end up with duplicate
+    # art pieces in the samples.  So please leave it out
+    ArtPiece.distinct
+            .includes(:artist)
             .where(users: { state: :active })
             .where.not(id: new_pieces.pluck(:id))
             .order(Arel.sql("rand(#{seed})"))


### PR DESCRIPTION
Problem
----------

Far more visible on dev where there are fewer images, the sampler code that populates the site landing page was generating a query that brought back duplicates.

Solution
----------

By reducing the queries efficiency, we did fix the duplicate records showing up.

Hard to verify but I saw it on my local environment.