### PR TITLE
Allow API calls with a feature flag

### DIFF
--- a/app/services/api_authorizor.rb
+++ b/app/services/api_authorizor.rb
@@ -1,7 +1,7 @@
 class ApiAuthorizor
   def self.authorize(request)
     auth_key = request.headers['HTTP_AUTHORIZATION']
-    check_authorization_key(auth_key) || internal_request?(request)
+    FeatureFlags.skip_api_authorization? || check_authorization_key(auth_key) || internal_request?(request)
   end
 
   class << self

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -4,4 +4,8 @@ class FeatureFlags
   def self.virtual_open_studios?
     Conf.features['virtual_open_studios']
   end
+
+  def self.skip_api_authorization?
+    Conf.features['skip_api_authorization']
+  end
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,7 @@ test:
   min_artists_per_studio: 1
   features:
     virtual_open_studios: true
+    skip_api_authorization: true
   pagination:
     media:
       per_page: 12
@@ -18,6 +19,7 @@ test:
 development:
   features:
     virtual_open_studios: true
+    skip_api_authorization: true
   S3_REGION: 'us-west-1'
   cache_expiry:
     feed: 300

--- a/spec/controllers/api/v2/artists_controller_spec.rb
+++ b/spec/controllers/api/v2/artists_controller_spec.rb
@@ -4,6 +4,8 @@ describe Api::V2::ArtistsController do
   let(:studio) { create(:studio, :with_artists) }
   let(:headers) { {} }
   before do
+    allow(FeatureFlags).to receive(:skip_api_authorization?).and_return(false)
+
     studio
     studio.artists.last.update(state: :susspended)
   end

--- a/spec/controllers/api/v2/studios_controller_spec.rb
+++ b/spec/controllers/api/v2/studios_controller_spec.rb
@@ -4,6 +4,8 @@ describe Api::V2::StudiosController do
   let(:studio) { create(:studio, :with_artists) }
   let(:headers) { {} }
   before do
+    allow(FeatureFlags).to receive(:skip_api_authorization?).and_return(false)
+
     studio
   end
 


### PR DESCRIPTION
Problem
-----------

As we look at maybe dusting off Bryant Street Studios, developers should have an easy way to turn off the api authorization check.

Solution
-----------

Allow setting `features['skip_api_authorization']` in `config/config.yml` and once that's been set true, it shuts off the ApiAuthorizor.

Makes it easy for devs to turn on/off that requirement.