### PR TITLE
Add custom auth header for api

### DIFF
--- a/app/services/api_authorizor.rb
+++ b/app/services/api_authorizor.rb
@@ -1,6 +1,6 @@
 class ApiAuthorizor
   def self.authorize(request)
-    auth_key = request.headers['HTTP_AUTHORIZATION']
+    auth_key = request.headers['mau-api-authorization'] || request.headers['HTTP_AUTHORIZATION']
     FeatureFlags.skip_api_authorization? || check_authorization_key(auth_key) || internal_request?(request)
   end
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,6 +2,7 @@
 #
 # note : no tabs and indent is ipmortant.
 test:
+  api_consumer_key: whatever
   mailchimp_api_key: bogus-key
   min_artists_per_studio: 1
   features:

--- a/spec/services/api_authorizor_spec.rb
+++ b/spec/services/api_authorizor_spec.rb
@@ -13,10 +13,25 @@ describe ApiAuthorizor do
       expect(ApiAuthorizor.authorize(request)).to be_truthy
     end
 
-    xit 'refuses external requests without the proper auth key' do
+    it 'allows external requests with the right Authorization header' do
+      expect(Rails.application.config.api_consumer_key).to be_present, 'You need config.api_consumer_key to be set in test env'
+
       request = instance_double(ActionDispatch::Request,
                                 headers: {
-                                  'HTTP_AUTHORIZATION' => 'Testing Testing 1 2',
+                                  'HTTP_AUTHORIZATION' => Rails.application.config.api_consumer_key,
+                                },
+                                host: 'other.host',
+                                env: { 'HTTP_REFERER' => 'http://somewhere.else.com' })
+      expect(ApiAuthorizor.authorize(request)).to be_truthy
+    end
+
+    it 'allows external requests with the cutom mau-api-authorization key even if Authorization header is also set' do
+      expect(Rails.application.config.api_consumer_key).to be_present, 'You need config.api_consumer_key to be set in test env'
+
+      request = instance_double(ActionDispatch::Request,
+                                headers: {
+                                  'HTTP_AUTHORIZATION' => 'Basic basic-auth-thing',
+                                  'mau-api-authorization' => Rails.application.config.api_consumer_key,
                                 },
                                 host: 'other.host',
                                 env: { 'HTTP_REFERER' => 'http://somewhere.else.com' })


### PR DESCRIPTION
problem
-------

With our dev server, we are behind basic auth.  We still want an api consumer key that will prevent folks from pulling from the api and that key should not be connected to the Basic Auth setup.

solution
--------

Add a secondary `mau-api-authorization` header that we can use for this case that will allow access to the api even through the basic auth using a separate key.