### PR TITLE
Move from direct email address to helper dialog for secret word

### DIFF
--- a/app/controllers/admin/email_lists_controller.rb
+++ b/app/controllers/admin/email_lists_controller.rb
@@ -2,15 +2,17 @@ module Admin
   class EmailListsController < ::BaseAdminController
     def index
       @all_lists = {
-        feedback: FeedbackMailerList.first,
-        admin: AdminMailerList.first,
-        watcher: WatcherMailerList.first,
+        feedback: FeedbackMailerList.instance,
+        admin: AdminMailerList.instance,
+        watcher: WatcherMailerList.instance,
+        sign_up_support: SignUpSupportMailerList.instance,
       }
       @purpose = {
         feedback: 'This list is used to notify MAU staff that someone ' \
                   'submitted feedback via the Feedback popup dialog.',
         admin: 'This list is used to notify MAU Admins - typically for system issues.',
         watcher: 'We notify this list when new art has been created',
+        sign_up_support: 'Requests for the secret word and other sign up queries',
       }
     end
   end

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -20,7 +20,7 @@ module Api
         :os,
         :browser,
         :device,
-        :version,
+        #        :version,
       )
     end
   end

--- a/app/forms/feedback_mail.rb
+++ b/app/forms/feedback_mail.rb
@@ -12,7 +12,7 @@ class FeedbackMail
                 :browser,
                 :device
 
-  VALID_NOTE_TYPES = %w[help inquiry feedback].freeze
+  VALID_NOTE_TYPES = %w[help inquiry feedback secretWord].freeze
 
   validates :note_type,
             presence: true,
@@ -73,7 +73,13 @@ class FeedbackMail
                      login:,
                      comment:)
     success = f.save
-    FeedbackMailer.feedback(f).deliver_later if success
+    if success
+      if note_type == 'secretWord'
+        SignUpSupportMailer.secret_word_request(f).deliver_later
+      else
+        FeedbackMailer.feedback(f).deliver_later
+      end
+    end
     success
   end
 end

--- a/app/mailers/mau_mailer.rb
+++ b/app/mailers/mau_mailer.rb
@@ -9,7 +9,7 @@ class MauMailer < ApplicationMailer
   default content_type: 'multipart/alternative'
 
   def mailer_list
-    Object.const_get("#{self.class.name}List").first
+    Object.const_get("#{self.class.name}List").instance
   end
 
   protected

--- a/app/mailers/sign_up_support_mailer.rb
+++ b/app/mailers/sign_up_support_mailer.rb
@@ -1,0 +1,15 @@
+class SignUpSupportMailer < MauMailer
+  def secret_word_request(feedback)
+    emails = mailer_list.formatted_emails
+    emails = ['jon+mausignup@bunnymatic.com', 'trish@trishtunney.com'] if emails.blank?
+
+    from = 'info@missionartists.org'
+    reply_to = NO_REPLY_FROM_ADDRESS
+    subject = "[Mission Artists Support] Someone's trying to sign up"
+    @feedback = feedback
+
+    mail(to: emails, from:, reply_to:, subject:) do |fmt|
+      fmt.html { render 'secret_word_request' }
+    end
+  end
+end

--- a/app/models/admin_mailer_list.rb
+++ b/app/models/admin_mailer_list.rb
@@ -1,2 +1,5 @@
 class AdminMailerList < EmailList
+  def self.instance
+    first || create
+  end
 end

--- a/app/models/feedback_mailer_list.rb
+++ b/app/models/feedback_mailer_list.rb
@@ -1,2 +1,5 @@
 class FeedbackMailerList < EmailList
+  def self.instance
+    first || create
+  end
 end

--- a/app/models/recruiting_mailer_list.rb
+++ b/app/models/recruiting_mailer_list.rb
@@ -1,2 +1,5 @@
 class RecruitingMailerList < EmailList
+  def self.instance
+    first || create
+  end
 end

--- a/app/models/sign_up_support_mailer_list.rb
+++ b/app/models/sign_up_support_mailer_list.rb
@@ -1,4 +1,4 @@
-class WatcherMailerList < EmailList
+class SignUpSupportMailerList < EmailList
   def self.instance
     first || create
   end

--- a/app/services/create_art_piece_service.rb
+++ b/app/services/create_art_piece_service.rb
@@ -19,7 +19,7 @@ class CreateArtPieceService
     art_piece.photo.attach(file)
     art_piece.save
 
-    emails = WatcherMailerList.first&.formatted_emails
+    emails = WatcherMailerList.instance.formatted_emails
     WatcherMailer.notify_new_art_piece(art_piece, emails).deliver_now if art_piece.persisted? && emails.present?
 
     # trigger create medium variant

--- a/app/views/feedback_mailer/feedback.html.erb
+++ b/app/views/feedback_mailer/feedback.html.erb
@@ -15,7 +15,9 @@
 </p>
 <p>
   Comment:
-  <%= @feedback.comment %>
+  <blockquote>
+    <%= @feedback.comment %>
+  </blockquote>
 </p>
 <p>
   Environment: <%= Rails.env %>

--- a/app/views/sign_up_support_mailer/secret_word_request.html.erb
+++ b/app/views/sign_up_support_mailer/secret_word_request.html.erb
@@ -1,0 +1,36 @@
+<p>
+  Dear Mission Artists Team member,
+</p>
+<p>
+  Someone is trying to sign up and they need the secret word.
+  Here's a little sample of what you might send to <%= @feedback.email %>.
+</p>
+<blockquote>
+  Hi,
+  <br/>
+  The secret word is
+  <br/>
+  <%= Conf.signup_secret_word %>
+  <br/>
+  Welcome to the site!
+  <br/>
+  Cheers,
+  <br/>
+  Mission Artists Web Team
+  <br/>
+</blockquote>
+
+<hr/>
+<p><strong>Raw details</strong></p>
+<p>
+  Subject: <%= @feedback.subject %>   <br/>
+  User's email: <%= @feedback.email %><br/>
+  URL: <%= @feedback.url %><br/>
+  Sent at: <%= Time.zone.now %><br/>
+</p>
+<p>
+  Comment: <%= @feedback.comment %>
+</p>
+<p>
+  Environment: <%= Rails.env %>
+</p>

--- a/app/views/users/_signup_form.slim
+++ b/app/views/users/_signup_form.slim
@@ -15,9 +15,9 @@
       label.label for="secret_word" What's the secret word?
       = text_field_tag :secret_word
       p.inline-hints
-        | If you don't know,
+        | If you don't know it,
         '
-        = react_component id: 'secret-word-mailer', component: "Mailer", props: {subject:"Send me the secret word please!", text:"contact us via email"}, wrapper_tag: "span"
+        = react_component id: 'secret-word-mailer', component: "NotifyMauDialog", wrapper_tag: "span", props: { note_type: 'secretWord', link_text: 'you can ask us'}
         '
         | and we'll let you in on the secret.
   = f.actions do

--- a/app/webpack/js/services/notification.service.test.ts
+++ b/app/webpack/js/services/notification.service.test.ts
@@ -1,13 +1,33 @@
 import { describe, expect, it } from "@jest/globals";
 import { api } from "@js/services/api";
+import Bowser from "bowser";
 
 import * as notificationService from "./notification.service";
 
+jest.mock("bowser");
 jest.mock("@services/api");
 
 describe("mau.services.notificationService", function () {
   beforeEach(() => {
     jest.resetAllMocks();
+    Bowser.parse = jest.fn().mockReturnValue({
+      os: {
+        name: "BunnymaticOS",
+        version: "12.01",
+        versionName: "RockStar",
+      },
+      platform: {
+        type: "Cartoon",
+      },
+      engine: {
+        name: "V8",
+        version: "1.2.3",
+      },
+      browser: {
+        name: "Mosaic",
+        version: "1100.12",
+      },
+    });
   });
   const successPayload = { success: true };
 
@@ -22,11 +42,13 @@ describe("mau.services.notificationService", function () {
       const response = await notificationService.sendInquiry(noteInfo);
       expect(api.notes.create).toHaveBeenCalledWith({
         feedback_mail: expect.objectContaining({
-          browser: { name: "Safari" },
+          browser: "Mosaic",
+          device: "Cartoon V8 v1.2.3",
           email: "jon@example.com",
-          engine: { name: "Blink" },
           noteType: "inquiry",
+          os: "BunnymaticOS 12.01 [RockStar]",
           question: "what's up?",
+          version: "1100.12",
         }),
       });
       expect(response).toEqual(successPayload);

--- a/app/webpack/js/services/notification.service.ts
+++ b/app/webpack/js/services/notification.service.ts
@@ -1,8 +1,19 @@
 import { api } from "@js/services";
 import Bowser from "bowser";
 
+const browserFromUserAgent = function (ua) {
+  const browser = Bowser.parse(ua);
+
+  return {
+    os: `${browser.os.name} ${browser.os.version} [${browser.os.versionName}]`,
+    browser: `${browser.browser.name}`,
+    device: `${browser.platform.type} ${browser.engine.name} v${browser.engine.version}`,
+    version: `${browser.browser.version}`,
+  };
+};
+
 export const sendInquiry = function ({ inquiry, ...rest }) {
-  const browser = Bowser.parse(window.navigator.userAgent);
+  const browser = browserFromUserAgent(window.navigator.userAgent);
   const extras = {
     ...browser,
   };

--- a/app/webpack/reactjs/components/notify_mau_dialog.po.tsx
+++ b/app/webpack/reactjs/components/notify_mau_dialog.po.tsx
@@ -1,0 +1,33 @@
+import { BasePageObject } from "@reactjs/test/base_page_object";
+import { sendInquiry } from "@services/notification.service";
+import { render } from "@testing-library/react";
+import React from "react";
+import { mocked } from "ts-jest/utils";
+
+import { NotifyMauDialog } from "./notify_mau_dialog";
+
+jest.mock("@services/notification.service");
+const mockSendInquiry = mocked(sendInquiry, true);
+
+export class NotifyMauDialogPageObject extends BasePageObject {
+  constructor({ debug, raiseOnFind } = {}) {
+    super({ debug, raiseOnFind });
+  }
+
+  renderComponent(props) {
+    const defaultProps = { noteType: "inquiry", linkText: "Here we go" };
+    return render(<NotifyMauDialog {...defaultProps} {...props} />);
+  }
+
+  setupApiMocks(success = true) {
+    if (success) {
+      mockSendInquiry.mockResolvedValue({ it: "worked" });
+    } else {
+      mockSendInquiry.mockRejectedValue("rats");
+    }
+  }
+
+  get sendInquiryMock() {
+    return mockSendInquiry;
+  }
+}

--- a/app/webpack/reactjs/components/notify_mau_dialog.test.tsx
+++ b/app/webpack/reactjs/components/notify_mau_dialog.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it } from "@jest/globals";
+import { act, waitFor } from "@testing-library/react";
+
+import { NotifyMauDialogPageObject } from "./notify_mau_dialog.po";
+
+describe("NotifyMauDialog", () => {
+  let po: NotifyMauDialogPageObject;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    po = new NotifyMauDialogPageObject();
+    po.setupApiMocks(true);
+  });
+
+  it("renders a button/link", function () {
+    po.renderComponent();
+    po.findButton("Here we go");
+  });
+
+  it("clicking the button shows the form and submits data on success", async function () {
+    po.renderComponent({
+      noteType: "inquiry",
+      linkText: "Click here to ask a question",
+      email: "whatever@somewhere.com",
+    });
+    const triggerButton = po.findButton("Click here to ask a question");
+    po.clickButton(triggerButton);
+
+    expect(po.find("Ask us a question?")).toBeInTheDocument();
+    expect(
+      po.find("We love to hear from you", { exact: false })
+    ).toBeInTheDocument();
+
+    const emailInput = po.findInput("Email");
+    expect(emailInput.value).toEqual("whatever@somewhere.com");
+
+    const confirmEmailInput = po.findInput("Confirm Email");
+    expect(confirmEmailInput.value).toEqual("whatever@somewhere.com");
+
+    act(() => {
+      const noteInput = po.findInput("Your Question");
+
+      po.fillInInput(noteInput, "this is my note to you");
+    });
+
+    await waitFor(() => {
+      const noteInput = po.findInput("Your Question");
+
+      expect(noteInput.value).toEqual("this is my note to you");
+    });
+
+    act(() => {
+      const submitButton = po.findButton("Send", { hidden: true });
+      po.clickButton(submitButton);
+    });
+    await waitFor(() => {
+      po.find("Thanks for your inquiry", { exact: false });
+      expect(po.sendInquiryMock).toHaveBeenCalledWith({
+        email: "whatever@somewhere.com",
+        emailConfirm: "whatever@somewhere.com",
+        inquiry: "this is my note to you",
+        noteType: "inquiry",
+      });
+    });
+  });
+});

--- a/app/webpack/reactjs/components/notify_mau_dialog.tsx
+++ b/app/webpack/reactjs/components/notify_mau_dialog.tsx
@@ -12,7 +12,8 @@ import { sendInquiry } from "@services/notification.service";
 import { Form, Formik } from "formik";
 import React, { FC } from "react";
 
-type NoteTypes = "inquiry" | "help" | "feedback";
+type NoteTypes = "inquiry" | "help" | "feedback" | "secretWord";
+type InputField = "inquiry" | "email" | "emailConfirm";
 
 interface NotifyMauFormProps {
   noteType: NoteTypes;
@@ -23,8 +24,9 @@ interface NotifyMauFormProps {
 
 interface NoteInfo {
   message: string;
-  questionLabel: string;
+  questionLabel?: string;
   title?: string;
+  requiredFields: InputField[];
 }
 
 const NOTE_INFO_LUT: Record<NoteTypes, NoteInfo> = {
@@ -42,6 +44,13 @@ const NOTE_INFO_LUT: Record<NoteTypes, NoteInfo> = {
       "We love to hear from you.  Please let us know your thoughts, questions, rants." +
       " We'll do our best to respond in a timely manner.",
     questionLabel: "Your Question",
+  },
+  secretWord: {
+    title: "Looking to sign up?",
+    message:
+      "Give us your email and we'll send you the secret word to get signed up." +
+      " We'll do our best to respond in a timely manner.",
+    questionLabel: "How did you find us and why do you want to sign up?",
   },
   help: {
     message:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,11 +32,6 @@
   Medium.find_or_create_by(name:)
 end
 
-# Not including RecruitingMailerList
-%w[FeedbackMailerList AdminMailerList WatcherMailerList].each do |type|
-  EmailList.find_or_create_by(type:)
-end
-
 %i[admin manager editor].each do |role|
   Role.find_or_create_by(role:)
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -20,7 +20,7 @@ When(/^I change my email to "(.*?)"$/) do |new_email|
 end
 
 Then('I see the secret word email link') do
-  expect(find('#secret-word-mailer a')).to be_present
+  expect(find('#secret-word-mailer button')).to be_present
 end
 
 When(/^I add a photo to upload$/) do
@@ -121,7 +121,7 @@ When(/^I login as "(.*?)"$/) do |login|
   path = current_path
   path = '/' if path.nil? || path == ',' # comma comes from some capybara startup thing
   visit login_path
-  @artist = User.find_by(login: login)
+  @artist = User.find_by(login:)
   fill_in_login_form login, '8characters'
   steps %(And I click "Sign In")
   steps %(Then I see a flash notice "You're in")

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -3,10 +3,18 @@ require 'uri'
 
 driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
 
+driver_hosts += [
+  'chromedriver.storage.googleapis.com',
+  'googlechromelabs.github.io',
+  'edgedl.me.gvt1.com',
+  'maps.googleapis.com',
+  'geocoder.us',
+  'mission-artists-test.s3.amazonaws.com',
+]
+
 VCR.configure do |c|
   c.ignore_localhost = true
-  c.ignore_hosts 'mission-artists-test.s3.amazonaws.com'
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   c.hook_into :webmock # or :fakeweb
-  c.ignore_hosts(*driver_hosts + ['maps.googleapis.com', 'geocoder.us'])
+  c.ignore_hosts(*driver_hosts)
 end

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.1.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/google.maps": "^3.52.5",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",

--- a/spec/factories/email_lists.rb
+++ b/spec/factories/email_lists.rb
@@ -9,4 +9,5 @@ FactoryBot.define do
   factory :watcher_email_list, parent: :email_list, class: 'WatcherMailerList'
   factory :admin_email_list, parent: :email_list, class: 'AdminMailerList'
   factory :feedback_email_list, parent: :email_list, class: 'FeedbackMailerList'
+  factory :sign_up_support_email_list, parent: :email_list, class: 'SignUpSupportMailerList'
 end

--- a/spec/mailers/sign_up_support_mailer_spec.rb
+++ b/spec/mailers/sign_up_support_mailer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe SignUpSupportMailer do
+  let(:fb) { FactoryBot.create(:feedback) }
+
+  subject(:email) { described_class.secret_word_request(fb) }
+
+  context 'if the mailing list has been set up' do
+    before do
+      FactoryBot.create(:sign_up_support_email_list, :with_member)
+    end
+
+    it 'sets up the right "to" addresses' do
+      SignUpSupportMailerList.first.emails.each do |expected|
+        expect(email.to).to include expected.email
+      end
+      expect(email.from).to include 'info@missionartists.org'
+    end
+
+    it 'sets the right subject' do
+      expect(email.subject).to eq "[Mission Artists Support] Someone's trying to sign up"
+    end
+  end
+
+  context 'if the mailing list has not been set up' do
+    it 'uses fallback to addresses' do
+      expect(email.to).to match_array([
+                                        'jon+mausignup@bunnymatic.com',
+                                        'trish@trishtunney.com',
+                                      ])
+    end
+  end
+end

--- a/spec/services/create_art_piece_service_spec.rb
+++ b/spec/services/create_art_piece_service_spec.rb
@@ -4,7 +4,7 @@ describe CreateArtPieceService do
   let(:artist) { create :artist, :active }
   let(:existing_tag) { create :art_piece_tag, name: 'existing tag' }
   let(:params) { {} }
-  let!(:watcher_list) { create(:watcher_email_list, :with_member) }
+  let(:watcher_list) { create(:watcher_email_list, :with_member) }
 
   subject(:service) { described_class.new(artist, params) }
 
@@ -13,73 +13,75 @@ describe CreateArtPieceService do
     allow(WatcherMailer).to receive(:notify_new_art_piece).and_call_original
   end
 
-  context 'with good data' do
-    let(:params) do
-      attributes_for(:art_piece).merge(photo: fixture_file_upload('art.png'))
+  context 'when the watcher list has members' do
+    before do
+      watcher_list
     end
-
-    it 'creates an art piece' do
-      expect { service.call }.to change(ArtPiece, :count).by(1)
-    end
-
-    it 'returns the art piece' do
-      ap = service.call
-      expect(ap.valid?).to eq true
-    end
-
-    it 'sends an email to the watchers' do
-      service.call
-      expect(WatcherMailer).to have_received(:notify_new_art_piece)
-    end
-
-    context 'when there is no WatchersMailerList' do
-      before do
-        allow(WatcherMailerList).to receive(:first).and_return nil
+    context 'with good data' do
+      let(:params) do
+        attributes_for(:art_piece).merge(photo: fixture_file_upload('art.png'))
       end
-      it 'does not send an email to the watchers because their are none' do
+
+      it 'creates an art piece' do
+        expect { service.call }.to change(ArtPiece, :count).by(1)
+      end
+
+      it 'returns the art piece' do
+        ap = service.call
+        expect(ap.valid?).to eq true
+      end
+
+      it 'sends an email to the watchers' do
+        service.call
+        expect(WatcherMailer).to have_received(:notify_new_art_piece)
+      end
+    end
+
+    context 'with tags' do
+      let(:tag_params) { ['mytag', 'YourTag', 'MyTag', existing_tag.name] }
+      let(:params) do
+        attributes_for(:art_piece).merge(tag_ids: tag_params)
+      end
+
+      it 'creates new tags as needed' do
+        existing_tag
+        expect do
+          service.call
+          ap = ArtPiece.last
+          expect(ap.tags.map(&:name)).to match_array ['mytag', 'yourtag', existing_tag.name]
+        end.to change(ArtPieceTag, :count).by(2)
+      end
+    end
+
+    context 'with invalid data' do
+      let(:tag_params) { ['supertag', existing_tag.name] }
+      let(:params) do
+        attrs = attributes_for(:art_piece).merge(tag_ids: tag_params)
+        attrs.delete :title
+        attrs.delete :photo_file_name
+        attrs
+      end
+
+      it 'returns the art piece with errors' do
+        ap = service.call
+        expect(ap).to be_present
+        expect(ap.errors).to have_at_least(1).error
+      end
+
+      it 'does not preserve tags' do
+        ap = service.call
+        expect(ap.tags).to be_empty
+      end
+
+      it 'does not send an email to the watchers' do
         service.call
         expect(WatcherMailer).not_to have_received(:notify_new_art_piece)
       end
     end
   end
 
-  context 'with tags' do
-    let(:tag_params) { ['mytag', 'YourTag', 'MyTag', existing_tag.name] }
-    let(:params) do
-      attributes_for(:art_piece).merge(tag_ids: tag_params)
-    end
-
-    it 'creates new tags as needed' do
-      existing_tag
-      expect do
-        service.call
-        ap = ArtPiece.last
-        expect(ap.tags.map(&:name)).to match_array ['mytag', 'yourtag', existing_tag.name]
-      end.to change(ArtPieceTag, :count).by(2)
-    end
-  end
-
-  context 'with invalid data' do
-    let(:tag_params) { ['supertag', existing_tag.name] }
-    let(:params) do
-      attrs = attributes_for(:art_piece).merge(tag_ids: tag_params)
-      attrs.delete :title
-      attrs.delete :photo_file_name
-      attrs
-    end
-
-    it 'returns the art piece with errors' do
-      ap = service.call
-      expect(ap).to be_present
-      expect(ap.errors).to have_at_least(1).error
-    end
-
-    it 'does not preserve tags' do
-      ap = service.call
-      expect(ap.tags).to be_empty
-    end
-
-    it 'does not send an email to the watchers' do
+  context 'when the WatchersMailerList has no member' do
+    it 'does not send an email to the watchers because their are none' do
       service.call
       expect(WatcherMailer).not_to have_received(:notify_new_art_piece)
     end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,6 @@
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+ALLOWED_REGEX = %r{^https://chromedriver.storage.googleapis.com/.*|^https://googlechromelabs.github.io/chrome-for-testing/*}
+WebMock.disable_net_connect!(
+  allow: ALLOWED_REGEX, allow_localhost: true,
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,6 +1846,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^14.5.1":
+  version "14.5.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
+  integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
Problem
-------

Our email addresses for www@missionartistsunited.org and
www@missionartists.org don't work - likely as we moved from GoDaddy to
CloudFlare for dns.

We don't have real email boxes behind these addresses so...
not that surprising.

Solution
----------

Let's instead use our other comm system - help, inquiry, feedback - to
let folks contact us.  In this way, we don't have to surface any
addresses and we can control who is on the list via the EmailLists in
MAU in the admin panels.

Changes
-------

* Adds a new `SignUpSupportMailer` list.
* update the notify mau dialog to support this new type
* add tests for notify mau dialog
* move this mailer to separate from the generic feedback mailer
* update the shape we send to notification service so that we have
  better info
* move email lists to use more like a singleton pattern so they manage
  find or create instead of having that outside
