### PR TITLE
Fix issue with art piece title with quotes busting meta tags

### DIFF
--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -93,7 +93,7 @@ class ArtPiecesController < ApplicationController
   end
 
   def build_page_description(art_piece)
-    return "Mission Artists Art : #{art_piece.title} by #{art_piece.artist.get_name(escape: true)}" if art_piece
+    HtmlEncoder.encode("Mission Artists Art : #{art_piece.title} by #{art_piece.artist.full_name}") if art_piece
   end
 
   def art_piece_params

--- a/spec/controllers/art_pieces_controller_spec.rb
+++ b/spec/controllers/art_pieces_controller_spec.rb
@@ -298,4 +298,18 @@ describe ArtPiecesController do
       end
     end
   end
+
+  describe 'protected .build_page_description' do
+    let(:artist) { create(:artist, nomdeplume: 'Heller, Gusikowski and Robel') }
+    let(:art_piece) do
+      FactoryBot.create(:art_piece,
+                        artist:,
+                        title: '"an.ä.log dumb > title with " quotes " by mr rogers')
+    end
+
+    it 'prove that page description is html safe' do
+      expect(described_class.new.send(:build_page_description, art_piece))
+        .to eq 'Mission Artists Art : &quot;an.&auml;.log dumb &gt; title with &quot; quotes &quot; by mr rogers by Heller, Gusikowski and Robel'
+    end
+  end
 end


### PR DESCRIPTION
problem
------

we found an artist that had a crazy art piece title that included a non
even number of quotes in the art piece title which screwed up the meta
description tag because it wasn't sufficiently escaped.

solution
-------

escape the whole description instead of the parts.

screenshots
----------

**This was the problem child**

<img width="1173" alt="Screen Shot 2024-01-08 at 7 46 10 PM" src="https://github.com/bunnymatic/mau/assets/427380/2643a20a-a84a-4f1c-b12b-f65a380e84b7">

