### PR TITLE
BSS Webhook called *after* art has been created

### DIFF
--- a/app/services/create_art_piece_service.rb
+++ b/app/services/create_art_piece_service.rb
@@ -19,15 +19,16 @@ class CreateArtPieceService
     art_piece.photo.attach(file)
     art_piece.save
 
+    # trigger create variants
+    art_piece.image(:small)
+    art_piece.image(:medium)
+    art_piece.image(:large)
+
     if art_piece.persisted?
       emails = WatcherMailerList.instance.formatted_emails
       WatcherMailer.notify_new_art_piece(art_piece, emails).deliver_now if emails.present?
       trigger_artist_update
     end
-
-    # trigger create medium variant
-    art_piece&.image(:medium)
-    art_piece&.image(:large)
 
     art_piece
   end


### PR DESCRIPTION
problem
-------

when an art piece is updated, we need to send the new data *after* the
image urls have been constructed because otherwise the data that goes to
BSS and gets cached is missing image urls.

solution
--------

push the webhook call to *after* images construction has been triggered.
