### PR TITLE
Add api to get studio ids

### DIFF
--- a/app/controllers/api/v2/artists_controller.rb
+++ b/app/controllers/api/v2/artists_controller.rb
@@ -10,6 +10,17 @@ module Api
         render jsonapi: artists
       end
 
+      def ids
+        artists = Artist.none
+        if params[:studio]
+          studio = Studio.find(params[:studio])
+          artists = Artist.active.where(studio_id: studio.id)
+        end
+        render json: { artist_ids: artists.pluck(:id) }
+      rescue ActiveRecord::RecordNotFound
+        render json: { artist_ids: [] }
+      end
+
       def show
         artist = Artist.active.friendly.find(params[:id])
         render jsonapi: artist

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Mau::Application.routes.draw do
     namespace :v2 do
       resources :studios, only: [:show]
       resources :artists, only: %i[index show] do
+        collection do
+          get :ids
+        end
+
         resources :art_pieces, only: %i[index show], shallow: true do
           resource :contact, only: [:create]
         end

--- a/spec/controllers/api/v2/artists_controller_spec.rb
+++ b/spec/controllers/api/v2/artists_controller_spec.rb
@@ -37,4 +37,31 @@ describe Api::V2::ArtistsController do
       end
     end
   end
+
+  describe '#ids' do
+    def make_request
+      headers.each { |k, v| header k, v }
+      get :ids, params: { format: :json, studio: studio.slug }
+    end
+
+    context 'without proper authorization' do
+      it 'fails' do
+        make_request
+        expect(response.status).to eql 401
+      end
+    end
+
+    context 'with proper authorization' do
+      render_views
+      before do
+        allow(controller).to receive(:require_authorization).and_return true
+        make_request
+      end
+      it_behaves_like 'successful json'
+      it 'returns ids for artists in the studio' do
+        artist_ids = JSON.parse(response.body)['artist_ids']
+        expect(artist_ids).to match_array studio.artists.active.pluck(:id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
problem
-------

for better caching, we'd like to just get a list of artist ids.  Then
when things get added or removed, it's easier to not have to pull the
whole set but just deal with the new items.

solution
---------

Add a new endpoint to get artist ids by studio

`/api/v2/artists/ids?studio=<studio>`

we have no need for *all* so studio is a required param.

And the endpoint is built to be resilient around bad studio ids.  just
return empty array if we can't figure it out.
