### PR TITLE
Trigger webhook on multi artwork delete

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -116,6 +116,7 @@ class ArtistsController < ApplicationController
 
     ids = destroy_art_params.reject { |_kk, vv| vv == '0' }.keys
     ArtPiece.where(id: ids, artist_id: current_user.id).destroy_all
+    BryantStreetStudiosWebhook.artist_updated(current_user.id)
     redirect_to(artist_path(current_user))
   end
 

--- a/config/vite.json
+++ b/config/vite.json
@@ -11,6 +11,6 @@
   "test": {
     "autoBuild": true,
     "publicOutputDir": "vite-test",
-    "port": 3037
+    "port": 3038
   }
 }

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -117,8 +117,9 @@ end
 
 Then(/my "(.*?)" is "(.*?)" in the "(.*?)" section of the form/) do |form_field_label, value, section|
   step "I click on \"#{section}\""
-  expect(page).to have_selector 'form.formtastic'
-  expect(find_field(form_field_label).value).to eql value
+  within '.panel-body' do
+    expect(find_field(form_field_label).value).to eql value
+  end
 end
 
 Then(/^I see that the studio "(.*?)" has an artist called "(.*?)"$/) do |studio_name, user_login|

--- a/features/users/edit.feature
+++ b/features/users/edit.feature
@@ -32,7 +32,7 @@ Scenario: I can edit my links
   When I click on "Links"
   And I change "Website" to "http://my.website.com"
   And I change "Instagram" to "http://instagram.com/my_instagram"
-  And I click on "Save Changes"
+  And I click on the first "Save Changes"
   Then my "Website" is "http://my.website.com" in the "Links" section of the form
   And my "Instagram" is "http://instagram.com/my_instagram" in the "Links" section of the form
 

--- a/spec/controllers/artists_controller_spec.rb
+++ b/spec/controllers/artists_controller_spec.rb
@@ -371,6 +371,7 @@ describe ArtistsController, elasticsearch: :stub do
     context 'when trying to destroy art that is yours' do
       let(:art_pieces) { artist.art_pieces }
       before do
+        allow(BryantStreetStudiosWebhook).to receive(:artist_updated)
         # For some reason the elasticsearch mocks were not working as of
         # rspec 3.10, so we just mock things higher for this test
         allow(ArtPiece).to receive(:where).and_return(double('ArRelation', destroy_all: true))
@@ -387,6 +388,9 @@ describe ArtistsController, elasticsearch: :stub do
         }
         expect(ArtPiece).to have_received(:where).with(expected_where_clause)
         expect(ArtPiece.where).to have_received(:destroy_all)
+      end
+      it 'calls the bryant webhook' do
+        expect(BryantStreetStudiosWebhook).to have_received(:artist_updated).with(artist.id)
       end
     end
   end


### PR DESCRIPTION
problem
--------

we need to hit the webhook when we use the `destroyart` endpoint.

solution
-------

add webhook call.

for later
-------

move delete art into a service where we could have handled this better.
