### PR TITLE
Notify BSS webhook *after* transaction

### DIFF
--- a/app/services/update_artist_service.rb
+++ b/app/services/update_artist_service.rb
@@ -26,6 +26,7 @@ class UpdateArtistService
       trigger_user_change_event(changes) if changes.present?
     end
     refresh_in_search_index if success
+    notify_bryant_street_studios if success
     success
   end
 
@@ -61,7 +62,6 @@ class UpdateArtistService
     end
 
     UserChangedEvent.create(message: msg, data: { changes: formatted_changes, user: artist.login, user_id: artist.id })
-    BryantStreetStudiosWebhook.artist_updated(artist.id)
   end
 
   def trigger_os_signup_event(participating)
@@ -70,6 +70,10 @@ class UpdateArtistService
     data = { user: artist.login, user_id: artist.id }
     OpenStudiosSignupEvent.create(message: msg,
                                   data:)
+  end
+
+  def notify_bryant_street_studios
+    BryantStreetStudiosWebhook.artist_updated(artist.id)
   end
 
   def refresh_in_search_index


### PR DESCRIPTION
Problem
------

we noticed that it seemed the webhook update data was showing up
1 request behind.  I suspect it's because the update call happens within
a transaction, so if BSS calls back immediately, it might be getting
data back before the transaction has been applied.

solution
-------

move that call outside the transaction.
