### PR TITLE
Update admin art piece edit page

### DIFF
--- a/app/views/admin/art_pieces/edit.html.slim
+++ b/app/views/admin/art_pieces/edit.html.slim
@@ -6,10 +6,13 @@
 .pure-g
   .pure-u-1-2.padded-content.admin-art-piece-edit-form
     .info-block
-      - url = @art_piece.image
+      - url = @art_piece.image('original')
+      h4 original image
       .image
         img.pure-img src=url
-      .url = url
+      .url
+        a href=url target="_blank"
+          | Link to image
 
       .form-update
         = semantic_form_for :art_piece, method: :patch, url: admin_art_piece_path(@art_piece) do |form|

--- a/app/webpack/stylesheets/admin.scss
+++ b/app/webpack/stylesheets/admin.scss
@@ -45,6 +45,7 @@
 @import "gto_admin/application_events.scss";
 @import "gto_admin/artists.scss";
 @import "gto_admin/artists_edit.scss";
+@import "gto_admin/art_pieces_edit.scss";
 @import "gto_admin/cms_documents/cms_documents.scss";
 @import "gto_admin/dashboard.scss";
 @import "gto_admin/email_lists.scss";

--- a/app/webpack/stylesheets/gto_admin/art_pieces_edit.scss
+++ b/app/webpack/stylesheets/gto_admin/art_pieces_edit.scss
@@ -1,0 +1,10 @@
+.admin-art-piece-edit-form {
+  .info-block {
+    & > * {
+      margin-bottom: 20px;
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/features/admin/art_pieces/update_art_piece.feature
+++ b/features/admin/art_pieces/update_art_piece.feature
@@ -7,7 +7,7 @@ Background:
   And there are artists with art in the system
   And I login
 
-Scenario: Viewing and cleaning out tags
+Scenario: Update art piece as an admin
   When I navigate to the first art piece admin edit path
   Then I see the edit admin art piece page
   When I add a new file

--- a/features/admin/favorites/view_favorites.feature
+++ b/features/admin/favorites/view_favorites.feature
@@ -6,6 +6,6 @@ Background:
   And there are artists and art pieces with favorites
   And I login
 
-Scenario: Viewing and cleaning out tags
+Scenario: Viewing favorites as an admin
   When I click on "favorites" in the admin menu
   Then I see all the favorites in a table

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -189,9 +189,9 @@ Then('I see the edit admin art piece page') do
 end
 
 Then('I see the new image') do
-  save_and_open_page
   expect(page).not_to have_content 'new-art-piece.jpg'
-  expect(page).to have_content 'art.png'
+  expect(page).to have_css('img')
+  expect(page).to have_link 'Link to image'
 end
 
 Then('I see the pending list') do

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -4,6 +4,7 @@ require 'uri'
 driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
 
 driver_hosts += [
+  'storage.googleapis.com',
   'chromedriver.storage.googleapis.com',
   'googlechromelabs.github.io',
   'edgedl.me.gvt1.com',

--- a/spec/support/test_es_server.rb
+++ b/spec/support/test_es_server.rb
@@ -1,6 +1,9 @@
 require 'elasticsearch/extensions/test/cluster'
 class TestEsServer
-  DEFAULT_TEST_ARGS = { number_of_nodes: 1, clear_cluster: true }.freeze
+  DEFAULT_TEST_ARGS = {
+    number_of_nodes: 1,
+    clear_cluster: true,
+  }.freeze
 
   def self.cluster
     Elasticsearch::Extensions::Test::Cluster


### PR DESCRIPTION
problem
------

we built an admin page to update art pieces.  i forgot about it.

but it shows only the not original image.

solution
------

update the image on that page to be the original so it's easily downloadable
by an admin so a fix can be made.