### PR TITLE
update next/prev icons in open studios catalog

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_catalog_paginator.scss
@@ -12,6 +12,6 @@
 }
 
 .catalog-paginator__link {
+  font-size: 1.8rem;
   padding: 0 12px;
-  font-size: 18px;
 }


### PR DESCRIPTION
problem
-------

Trish thought the next/previous chevrons/caret's were too small.

solution
-------

make them bigger


screenshots
--------

** BEFORE ** 

<img width="1496" alt="Screenshot 2024-03-17 at 5 02 17 PM" src="https://github.com/bunnymatic/mau/assets/427380/921c7224-717a-4644-a2e4-4efbfe173e3f">

** AFTER **

<img width="1496" alt="Screenshot 2024-03-17 at 5 02 05 PM" src="https://github.com/bunnymatic/mau/assets/427380/cd36e46d-cea5-42bb-9737-58fcd3b580ed">

