### PR TITLE
Fix config for webhook

### DIFF
--- a/app/services/bryant_street_studios_webhook.rb
+++ b/app/services/bryant_street_studios_webhook.rb
@@ -19,8 +19,11 @@ class BryantStreetStudiosWebhook
         'bss-api-authorization' => Conf.bryant_street_studios_api_key,
       }
       response = conn.post(url(path), nil, headers)
-      response.status == 200
+      success = response.status == 200
+      Rails.logger.warn("Failed to update artist: http code #{response.status}") unless success
+      success
     rescue Errno::ECONNREFUSED, Faraday::ConnectionFailed
+      Rails.logger.error('Connection failed trying to post to the webhook')
       false
     rescue StandardError => e
       Rails.logger.error('Something went wrong posting the webhook')

--- a/config/config.yml
+++ b/config/config.yml
@@ -54,6 +54,7 @@ production:
     objects: 0
     new_art: 86400
   subdomain: openstudios
+  bryant_street_studios_webhook_url: https://www.1890bryant.com/webhook
 
 common:
   # bryant_street_studios_webhook_url: https://ghost-stunning-leech.ngrok.io/webhook


### PR DESCRIPTION
problem
------

we forgot that when we deploy, the base `config.yml` gets pushed.

this record didn't have the correct url for the webhook.

solution
-----

fix the deployed config.

notes
----

i manually fixed this on the server so this change isn't required right now but
will get picked up with our next deploy
