### PR TITLE
Call webhook when admin updates an artist

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -45,7 +45,7 @@ module Admin
     def edit; end
 
     def update
-      if @artist.update(artist_params)
+      if AdminArtistUpdateService.update(@artist, artist_params)
         redirect_to admin_user_path(@artist)
       else
         render :edit, warning: 'There were problems updating the artist'

--- a/app/services/admin_artist_update_service.rb
+++ b/app/services/admin_artist_update_service.rb
@@ -13,6 +13,14 @@ class AdminArtistUpdateService
     [true, { notice: msg }]
   end
 
+  def self.update(artist, artist_params)
+    return unless artist
+
+    result = artist.update(artist_params)
+    BryantStreetStudiosWebhook.artist_updated(artist.id) if result
+    result
+  end
+
   class << self
     private
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join 'spec/fixtures'
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # this should be false or else we run into thread deadlocks with elasticsearch
   config.use_transactional_fixtures = false #

--- a/spec/services/admin_artist_update_service_spec.rb
+++ b/spec/services/admin_artist_update_service_spec.rb
@@ -59,4 +59,37 @@ describe AdminArtistUpdateService do
       end
     end
   end
+
+  describe '.update' do
+    let(:artist) { create(:artist) }
+
+    before do
+      artist
+      allow(BryantStreetStudiosWebhook).to receive(:artist_updated)
+    end
+
+    it 'updates the artist' do
+      service.update(artist, firstname: 'whatever man')
+      expect(artist.reload.firstname).to eq 'whatever man'
+    end
+
+    it 'calls the webhook' do
+      service.update(artist, lastname: 'whosit')
+      expect(BryantStreetStudiosWebhook).to have_received(:artist_updated).with(artist.id)
+    end
+
+    context 'when there is a problem' do
+      it 'returns false' do
+        email = artist.email
+        result = service.update(artist, email: 'not a valid email')
+        expect(artist.reload.email).to eq email
+        expect(result).to eq false
+      end
+
+      it 'does not call the webhook' do
+        service.update(artist, email: 'not a valid email')
+        expect(BryantStreetStudiosWebhook).not_to have_received(:artist_updated)
+      end
+    end
+  end
 end


### PR DESCRIPTION
problem
------

before this when an admin updated an artist params, we didn't call the webhook to tell bryant st studios.

solution
------

move the update to the AdminArtistUpdateService and trigger the webhook
