### PR TITLE
Better handling of studios without artists with art

### DIFF
--- a/app/views/studios/show.html.slim
+++ b/app/views/studios/show.html.slim
@@ -17,9 +17,8 @@
       - if @studio.artists_without_art?
         .pure-u-1-1.pure-u-md-1-2.pure-u-lg-1-3.pure-u-xl-1-4
           .studio-memberlist
-            - if @studio.artists_with_art?
-              h4 More Artists:
-              ul
-                - @studio.artists_without_art.map{|a| link_to(a.get_name, a )}.each do |link|
-                  li
-                    = link.html_safe
+            h4 More Artists:
+            ul
+              - @studio.artists_without_art.map{|a| link_to(a.get_name, a )}.each do |link|
+                li
+                  = link.html_safe


### PR DESCRIPTION
problem
-----

just ran into this odd case where we have a studio (development) with 1 artist who has no art.
the display was goofy because we didn't have the right clauses in place.

solution
------

show the 'more artists' *if* the studio has artists_without_art - it was likely a cut paste issue
and not too critical since most studios have artists with art.
