### PR TITLE
Bump db/schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_23_184843) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_114049) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
problem
-----

with the rails 7 upgrade (i think) there were a few new migrations that were
never run and so the db/schema file is out of date.

solution
------

run the migrations and commit the schema

not a big deal since we just migrate on deploy and no one really uses db/schema so ...
