### PR TITLE
Fix deploy issues with rails7

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
problem
------

environment had active_storage set to `local` but we only defined `amazon` in `storage.yml`

solution
-------

set `amazon` in the environment so it picks up the right option
