### PR TITLE
Remove unused parse_key method

### DIFF
--- a/app/helpers/open_studios_helper.rb
+++ b/app/helpers/open_studios_helper.rb
@@ -1,9 +1,9 @@
 module OpenStudiosHelper
   def open_studios_nav_title
-    OpenStudiosEventService.current.try(:for_display, reverse: true) || 'Open Studios'
+    OpenStudiosEventService.current.try(:for_display, month_first: true) || 'Open Studios'
   end
 
   def open_studios_page_title
-    ['Open Studios', OpenStudiosEventService.current.try(:for_display, reverse: true)].compact.join(' - ')
+    ['Open Studios', OpenStudiosEventService.current.try(:for_display, month_first: true)].compact.join(' - ')
   end
 end

--- a/app/mailers/artist_mailer.rb
+++ b/app/mailers/artist_mailer.rb
@@ -63,7 +63,7 @@ class ArtistMailer < MauMailer
 
   def welcome_to_open_studios(artist, current_os)
     setup_email(artist)
-    subject = "Welcome To Open Studios #{current_os.for_display(reverse: true)}"
+    subject = "Welcome To Open Studios #{current_os.for_display(month_first: true)}"
     @current_os = OpenStudiosEventPresenter.new(current_os)
     @upload_url = manage_art_artist_url(artist)
     @donation_url = edit_artist_url(artist, anchor: 'events')

--- a/app/models/open_studios_event.rb
+++ b/app/models/open_studios_event.rb
@@ -19,8 +19,8 @@ class OpenStudiosEvent < ApplicationRecord
   has_many :open_studios_participants, inverse_of: :open_studios_event, dependent: :destroy
   has_many :artists, through: :open_studios_participants, class_name: 'Artist', source: :user
 
-  def for_display(reverse: false)
-    if reverse
+  def for_display(month_first: false)
+    if month_first
       date = start_date.strftime(REVERSE_START_DATE_FORMAT)
       if start_date.month == end_date.month
         date + end_date.strftime(END_DATE_WITHIN_MONTH_FORMAT)

--- a/app/presenters/admin_artist_list.rb
+++ b/app/presenters/admin_artist_list.rb
@@ -25,11 +25,7 @@ class AdminArtistList < ViewPresenter
       'Email Address',
       'Phone',
     ]
-    if OpenStudiosEvent.current
-      headers << "Participating in Open Studios #{OpenStudiosEvent.current.for_display}" if OpenStudiosEvent.current
-    else
-      headers << 'No Current Open Studios'
-    end
+    headers << (current_os.present? ? "Participating in Open Studios #{current_os.for_display}" : 'No Current Open Studios')
     headers << 'Since'
     headers << 'Last Seen'
     headers << 'Last Updated Profile'
@@ -76,7 +72,7 @@ class AdminArtistList < ViewPresenter
   end
 
   def current_os
-    @current_os ||= OpenStudiosEvent.current
+    @current_os ||= OpenStudiosEventService.current
   end
 
   def artist_as_csv_row(artist)
@@ -100,9 +96,8 @@ class AdminArtistList < ViewPresenter
   end
 
   def open_studios_participant_as_csv_row(participant)
-    os = OpenStudiosEvent.current
     base_attrs = %i[show_phone_number show_email shop_url youtube_url video_conference_url]
-    available_time_slots = os&.special_event_time_slots || []
+    available_time_slots = current_os&.special_event_time_slots || []
 
     return Array.new(base_attrs.size + available_time_slots.size, '') unless participant
 

--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -111,11 +111,11 @@ class OpenStudiosEventPresenter < ViewPresenter
                                 model.special_event_end_time)
   end
 
-  def for_display(reverse: false)
+  def for_display(month_first: false)
     if available?
-      model.for_display(reverse:)
+      model.for_display(month_first:)
     else
-      OpenStudiosEventService.for_display(current_open_studios_key, reverse:)
+      OpenStudiosEventService.for_display(current_open_studios_key, month_first:)
     end
   end
 

--- a/app/services/open_studios_event_service.rb
+++ b/app/services/open_studios_event_service.rb
@@ -4,21 +4,9 @@ class OpenStudiosEventService
   FUTURE_CACHE_KEY = :future_os_events
   PAST_CACHE_KEY = :past_os_events
 
-  def self.for_display(os_key, reverse: false)
+  def self.for_display(os_key, month_first: false)
     os = find_by_key(os_key)
-    return os.for_display(reverse:) if os
-
-    parse_key(os_key, reverse:) || 'n/a'
-  end
-
-  def self.parse_key(os_key, reverse: false)
-    return nil if os_key.blank?
-
-    os_key = os_key.to_s
-    yr = os_key[0..3]
-    mo = os_key[4..]
-    seas = mo == '10' ? 'Oct' : 'Apr'
-    (reverse ? [seas, yr] : [yr, seas]).join(' ')
+    os ? os.for_display(month_first:) : 'n/a'
   end
 
   def self.all

--- a/app/services/update_artist_service.rb
+++ b/app/services/update_artist_service.rb
@@ -66,7 +66,7 @@ class UpdateArtistService
 
   def trigger_os_signup_event(participating)
     msg = "#{artist.full_name} set their os status to " \
-          "#{participating} for #{@current_os.for_display(reverse: true)} open studios"
+          "#{participating} for #{@current_os.for_display(month_first: true)} open studios"
     data = { user: artist.login, user_id: artist.id }
     OpenStudiosSignupEvent.create(message: msg,
                                   data:)

--- a/app/views/admin/artists/_admin_artists_table.html.slim
+++ b/app/views/admin/artists/_admin_artists_table.html.slim
@@ -18,7 +18,7 @@
           th Art
           th Info
           th
-            = OpenStudiosEventService.current&.for_display(reverse: true) || "OS"
+            = OpenStudiosEventService.current&.for_display(month_first: true) || "OS"
           th.admin-controls data-orderable="false"
 
       tbody

--- a/app/views/artist_mailer/welcome_to_open_studios.html.erb
+++ b/app/views/artist_mailer/welcome_to_open_studios.html.erb
@@ -2,7 +2,7 @@
   Hello, <%= @artist.get_name %>
 </p>
 <p>
-  Thanks for registering for Open Studios <%= @current_os.for_display(reverse: true) %>.
+  Thanks for registering for Open Studios <%= @current_os.for_display(month_first: true) %>.
   We're so excited you're participating!
 </p>
 
@@ -12,7 +12,7 @@
 <p>
   <ol>
     <li> Hang some art at your studio.</li>
-    <li> Have your studio open on <%= @current_os.for_display(reverse: true) %> from <% @current_os.time_range_for_display %>.</li>
+    <li> Have your studio open on <%= @current_os.for_display(month_first: true) %> from <% @current_os.time_range_for_display %>.</li>
     <li> Promote the event to your mailing list and social fans.</li>
   </ol>
 </p>

--- a/app/views/artists/index.html.slim
+++ b/app/views/artists/index.html.slim
@@ -5,7 +5,7 @@
       '
       span.letter #{@gallery.letter&.html_safe}
       - if @os_only
-        = " in #{OpenStudiosEvent.current.try(:for_display,true)} Open Studios"
+        = " in #{OpenStudiosEvent.current.try(:for_display, month_first: true)} Open Studios"
     .search.js-in-page-search
       a href="/search" title="search"
         = fa_icon "search"

--- a/features/step_definitions/artist_steps.rb
+++ b/features/step_definitions/artist_steps.rb
@@ -224,7 +224,7 @@ end
 
 Then(/^I see open studios artists on the artists list$/) do
   expect(page).to have_css '.artist-card'
-  expect(page).to have_css 'h2', text: "Artists in #{OpenStudiosEventService.current.for_display(reverse: true)} Open Studios"
+  expect(page).to have_css 'h2', text: "Artists in #{OpenStudiosEventService.current.for_display(month_first: true)} Open Studios"
 end
 
 Then(/^the meta description includes the artist's bio$/) do

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -1,5 +1,5 @@
 When /I click on the current open studios link/ do
-  os_link_text = OpenStudiosEventService.current.for_display(reverse: true)
+  os_link_text = OpenStudiosEventService.current.for_display(month_first: true)
   click_on_first os_link_text
 end
 

--- a/spec/mailers/artist_mailer_spec.rb
+++ b/spec/mailers/artist_mailer_spec.rb
@@ -77,7 +77,7 @@ describe ArtistMailer, elasticsearch: :stub do
       expect(mail).to have_body_text artist.get_name
     end
     it 'includes the Open Studios date' do
-      expect(mail).to have_body_text open_studios.for_display(reverse: true)
+      expect(mail).to have_body_text open_studios.for_display(month_first: true)
     end
   end
 

--- a/spec/models/open_studios_event_spec.rb
+++ b/spec/models/open_studios_event_spec.rb
@@ -179,7 +179,7 @@ describe OpenStudiosEvent do
         context 'if the dates are within the same month' do
           it 'returns the pretty version for the current os' do
             expected = current_os.start_date.strftime('%b %-d-') + current_os.end_date.strftime('%-d %Y')
-            expect(current_os.for_display(reverse: true)).to eql expected
+            expect(current_os.for_display(month_first: true)).to eql expected
           end
         end
         context 'if the dates are across months' do
@@ -191,7 +191,7 @@ describe OpenStudiosEvent do
           it 'returns the pretty version for the current os' do
             expected = current_os.start_date.strftime('%b %-d-') +
                        current_os.end_date.strftime('%b %-d %Y')
-            expect(current_os.for_display(reverse: true)).to eql expected
+            expect(current_os.for_display(month_first: true)).to eql expected
           end
         end
       end

--- a/spec/services/open_studios_event_service_spec.rb
+++ b/spec/services/open_studios_event_service_spec.rb
@@ -42,18 +42,21 @@ describe OpenStudiosEventService do
   end
 
   describe '.for_display' do
-    it 'returns the pretty version for a given tag' do
-      expect(service.for_display('201104')).to eql '2011 Apr'
+    context 'when the event is in the db' do
+      before do
+        create(:open_studios_event, start_date: Date.new(2011, 4, 2))
+      end
+      it 'returns the pretty version for a given tag year first' do
+        expect(service.for_display('201104')).to eql '2011 Apr'
+      end
+      it 'returns month first the date given month_first = true' do
+        expect(service.for_display('201104', month_first: true)).to eql 'Apr 2-3 2011'
+      end
     end
-    it 'reverses the date given reverse = true' do
-      expect(service.for_display('201104', reverse: true)).to eql 'Apr 2011'
-    end
-  end
-
-  describe '.parse_key' do
-    it 'returns the year month as a string and can return it reversed' do
-      expect(service.parse_key('201410')).to eql '2014 Oct'
-      expect(service.parse_key('201410', reverse: true)).to eql 'Oct 2014'
+    context 'for a key that doesnt correspond to a known event' do
+      it 'returns n/a' do
+        expect(service.for_display('201104')).to eql 'n/a'
+      end
     end
   end
 


### PR DESCRIPTION
problem
-----

just digging around a bit and noticed this `parse_key` method which is
no longer used.  we used to not store open studios events but just pass
around some string keys.  those keys needed to be parsed to dates which
is what this function was for.

but for a long time we've been using the db (OpenStudiosEvent) and the
wrapper service (OpenStudiosEventService) so we don't need to handle
those string only keys anymore.

Also while in there i noticed that `for_display(reverse:)` seemed like
a weird parameter name.  So renamed it to `month_first` which is what
it actually means.

solution
----

* remove `parse_key` off the OpenStudiosEventService
* update all `for_display` methods around os services/objects to use `month_first:` instead of `reverse:` as the formatting argument
* replace a few direct calls to `OpenStudiosEvent.current in favor of wrapping with the EventService
