### PR TITLE
Upate Open Studios Site CSS for Mobile

### DIFF
--- a/app/webpack/stylesheets/open_studios_subdomain/_no_scheduled_open_studios.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_no_scheduled_open_studios.scss
@@ -1,9 +1,16 @@
 @use "../colors" as c;
+@use "../gto/variables" as v;
 
 .nothing-scheduled {
   color: c.$gto-dark-blue;
+  @media (max-width: v.$screen-sm-min) {
+    max-width: 375px;
+  }
 }
 .nothing-scheduled--bg {
+  @media (max-width: v.$screen-sm-min) {
+    max-width: 375px;
+  }
   display: flex;
   justify-content: center;
   align-items: center;
@@ -11,6 +18,9 @@
   height: 90vh;
 }
 .nothing-scheduled--bg-img {
+  @media (max-width: v.$screen-sm-min) {
+    max-width: 375px;
+  }
 }
 .nothing-scheduled--contents {
   position: absolute;

--- a/app/webpack/stylesheets/open_studios_subdomain/_no_scheduled_open_studios.scss
+++ b/app/webpack/stylesheets/open_studios_subdomain/_no_scheduled_open_studios.scss
@@ -4,12 +4,12 @@
 .nothing-scheduled {
   color: c.$gto-dark-blue;
   @media (max-width: v.$screen-sm-min) {
-    max-width: 375px;
+    max-width: 90%;
   }
 }
 .nothing-scheduled--bg {
   @media (max-width: v.$screen-sm-min) {
-    max-width: 375px;
+    max-width: 100%;
   }
   display: flex;
   justify-content: center;
@@ -19,7 +19,7 @@
 }
 .nothing-scheduled--bg-img {
   @media (max-width: v.$screen-sm-min) {
-    max-width: 375px;
+    max-width: 350px;
   }
 }
 .nothing-scheduled--contents {


### PR DESCRIPTION
### Problem
Currently, the Open studios site when there are no open studios events is not responsive to mobile, and the image does not fit nicely on the mobile screens. 

### Solution
Update CSS to be responsive and get the image and text to fit nicely on smaller screens. 
<img width="878" alt="Screen Shot 2024-05-10 at 1 09 55 PM" src="https://github.com/bunnymatic/mau/assets/76715419/5eb39ea2-9449-4d27-a1c8-6300acbcb991">

