### PR TITLE
Support for an expiring event

### DIFF
--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -46,19 +46,21 @@ module Admin
     private
 
     def open_studios_event_params
-      params.require(:open_studios_event).permit(:title,
-                                                 :start_date,
-                                                 :end_date,
-                                                 :start_time,
-                                                 :end_time,
-                                                 :key,
-                                                 :promote,
-                                                 :special_event_start_date,
-                                                 :special_event_start_time,
-                                                 :special_event_end_date,
-                                                 :special_event_end_time,
-                                                 :activated_at,
-                                                 :deactivated_at).tap do |prms|
+      params.require(:open_studios_event).permit(
+        :title,
+        :start_date,
+        :end_date,
+        :start_time,
+        :end_time,
+        :key,
+        :promote,
+        :special_event_start_date,
+        :special_event_start_time,
+        :special_event_end_date,
+        :special_event_end_time,
+        :activated_at,
+        :deactivated_at,
+      ).tap do |prms|
         # coerce/force dates to be in Conf.event_time_zone
         Time.use_zone(Conf.event_time_zone) do
           %i[start_date end_date special_event_start_date special_event_end_date activated_at deactivated_at].each do |fld|

--- a/app/controllers/admin/open_studios_events_controller.rb
+++ b/app/controllers/admin/open_studios_events_controller.rb
@@ -56,10 +56,12 @@ module Admin
                                                  :special_event_start_date,
                                                  :special_event_start_time,
                                                  :special_event_end_date,
-                                                 :special_event_end_time).tap do |prms|
+                                                 :special_event_end_time,
+                                                 :activated_at,
+                                                 :deactivated_at).tap do |prms|
         # coerce/force dates to be in Conf.event_time_zone
         Time.use_zone(Conf.event_time_zone) do
-          %i[start_date end_date special_event_start_date special_event_end_date].each do |fld|
+          %i[start_date end_date special_event_start_date special_event_end_date activated_at deactivated_at].each do |fld|
             next unless prms[fld]
 
             prms[fld] = Time.zone.parse(prms[fld])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_open_studios_active
-    @open_studios_active = SitePreferences.instance(check_cache: true).open_studios_active?
+    @open_studios_active = OpenStudiosEventService.current
   end
 
   protected

--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -1,7 +1,9 @@
 class OpenStudiosEventPresenter < ViewPresenter
   attr_reader :model
 
-  delegate :end_time,
+  delegate :activated_at,
+           :deactivated_at,
+           :end_time,
            :key,
            :logo,
            :logo?,
@@ -90,14 +92,14 @@ class OpenStudiosEventPresenter < ViewPresenter
   end
 
   def special_event_date_range_with_year
-    return unless model.special_event_start_date && model.special_event_end_date
+    return unless with_special_event?
 
     DateRangeHelpers.date_range_with_year(model.special_event_start_date,
                                           model.special_event_end_date)
   end
 
   def special_event_date_range(separator: '-')
-    return unless model.special_event_start_date && model.special_event_end_date
+    return unless with_special_event?
 
     DateRangeHelpers.date_range(model.special_event_start_date,
                                 model.special_event_end_date,
@@ -105,10 +107,16 @@ class OpenStudiosEventPresenter < ViewPresenter
   end
 
   def special_event_time_range
-    return unless model.special_event_start_date && model.special_event_end_date
+    return unless with_special_event?
 
     DateRangeHelpers.time_range(model.special_event_start_time,
                                 model.special_event_end_time)
+  end
+
+  def activation_date_range
+    return unless with_activation_dates?
+
+    DateRangeHelpers.date_range(model.activated_at, model.deactivated_at)
   end
 
   def for_display(month_first: false)
@@ -139,6 +147,10 @@ class OpenStudiosEventPresenter < ViewPresenter
 
   def with_special_event?
     !!(@model.special_event_start_date && @model.special_event_end_date)
+  end
+
+  def with_activation_dates?
+    !!(@model.activated_at && @model.deactivated_at)
   end
 
   def start_date

--- a/app/views/admin/open_studios_events/_form.html.slim
+++ b/app/views/admin/open_studios_events/_form.html.slim
@@ -15,6 +15,11 @@
             = f.input :start_time, as: :string, placeholder: 'choose a time', hint: "Something like 12noon or noon or 11a.  This is used for display only (not for date/time math)"
           .pure-u-1-2
             = f.input :end_time, as: :string, placeholder: 'choose a time', hint: "Something like 6p.  This is used for display only (not for date/time math)"
+        .pure-g
+          .pure-u-1-2
+            = f.input :activated_at, as: :date_picker, placeholder: 'choose a date', hint: "This date is when we'll start shown Open Studios stuff in the navigation, highlights on peoples profiles etc.", input_html: { value: os_event.activated_at.try(:to_fs,:admin_date_only) }
+          .pure-u-1-2
+            = f.input :deactivated_at, as: :date_picker, placeholder: 'choose a date', hint: "This date is when we'll stop showing Open Studios links and stuff.", input_html: { value: os_event.deactivated_at.try(:to_fs,:admin_date_only) }
         = f.input :key, placeholder: 'e.g. YYYYMM'
         = f.input :promote, as: :boolean, inline_label: true, label: false, hint: "If true, we'll remind artists in navigation to register when we're near (in time) this event."
 

--- a/app/views/admin/open_studios_events/index.html.slim
+++ b/app/views/admin/open_studios_events/index.html.slim
@@ -29,7 +29,8 @@
           th title
           th dates
           th special event dates
-          th promoted
+          th active range
+          th promoted to artists
           th participants
           th data-orderable="false"
       tbody
@@ -50,6 +51,11 @@
                   = os_event.special_event_time_range
               - else
                 | n/a
+            td.os-events__table-item.os-events__table-item--active
+              - if os_event.with_activation_dates?
+                = os_event.activation_date_range
+              - else
+                | always
             td.os-events__table-item.os-events__table-item--promoted = boolean_as_checkmark(os_event.promote?)
             td.os-events__table-item.os-events__table-item--participants = os_event.num_participants
             td.admin-controls

--- a/db/migrate/20240507014331_add_activated_at_deactivated_at_to_open_studios_event.rb
+++ b/db/migrate/20240507014331_add_activated_at_deactivated_at_to_open_studios_event.rb
@@ -1,0 +1,6 @@
+class AddActivatedAtDeactivatedAtToOpenStudiosEvent < ActiveRecord::Migration[7.1]
+  def change
+    add_column :open_studios_events, :activated_at, :date, null: true
+    add_column :open_studios_events, :deactivated_at, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_04_23_184843) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_07_014331) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -209,6 +209,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_04_23_184843) do
     t.string "special_event_start_time", default: "12:00 PM"
     t.string "special_event_end_time", default: "4:00 PM"
     t.text "special_event_time_slots"
+    t.date "activated_at"
+    t.date "deactivated_at"
     t.index ["key"], name: "index_open_studios_events_on_key", unique: true
   end
 

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -334,3 +334,11 @@ end
 Then('I don\'t see any open studios violators') do
   expect(page).to_not have_css('.os-violator')
 end
+
+When('I deactivate the first open studios event') do
+  within('form') do
+    fill_in 'Activated at', with: 2.days.ago
+    fill_in 'Deactivated at', with: 1.day.ago
+    click_on 'Update Open studios event'
+  end
+end

--- a/features/visitors/open_studios_active_toggle.feature
+++ b/features/visitors/open_studios_active_toggle.feature
@@ -19,3 +19,14 @@ Scenario:  Admin can toggle the Open Studios Active flag
   When I visit the home page
   Then I don't see the open studios navigation
   And I don't see any open studios violators
+
+Scenario:  Admin can deactivate the event by setting the deactivated date
+  Then I see a "open studios" link
+  And I see an open studios violator
+  When I login as an admin
+  And I click on "os dates" in the admin menu
+  And I click on the first "Edit"
+  And I deactivate the first open studios event
+  When I visit the home page
+  Then I don't see the open studios navigation
+  And I don't see any open studios violators

--- a/lib/tasks/mau.rake
+++ b/lib/tasks/mau.rake
@@ -2,8 +2,6 @@ require 'find'
 require 'fileutils'
 require 'yaml'
 
-YAML.load_file(Rails.root.join('config/database.yml'))
-
 namespace :mau do
   desc 'show social link counts'
   task show_social_link_type_counts: [:environment] do

--- a/spec/controllers/admin/open_studios_events_controller_spec.rb
+++ b/spec/controllers/admin/open_studios_events_controller_spec.rb
@@ -43,7 +43,7 @@ describe Admin::OpenStudiosEventsController do
         expect(response).to redirect_to admin_open_studios_events_path
       end
 
-      it 'updates the event with new data a new open studios event' do
+      it 'updates the event with new data' do
         expect(event.reload.start_time).to eq 'whatever'
       end
     end

--- a/spec/controllers/admin/open_studios_events_controller_spec.rb
+++ b/spec/controllers/admin/open_studios_events_controller_spec.rb
@@ -9,7 +9,7 @@ describe Admin::OpenStudiosEventsController do
 
   describe '#create' do
     context 'with valid data' do
-      let(:attributes) { attributes_for(:open_studios_event) }
+      let(:attributes) { attributes_for(:open_studios_event, :with_activation_dates, :with_current_special_event) }
       def do_create
         post :create, params: { open_studios_event: attributes.except(:id) }
       end
@@ -23,6 +23,9 @@ describe Admin::OpenStudiosEventsController do
         expect do
           do_create
           expect(OpenStudiosEvent.last.start_time).to eq attributes[:start_time]
+          expect(OpenStudiosEvent.last.special_event_start_date).to be_present
+          expect(OpenStudiosEvent.last.special_event_start_date.to_date).to eq attributes[:start_date]
+          expect(OpenStudiosEvent.last.activated_at).to eq attributes[:activated_at]
         end.to change(OpenStudiosEvent, :count).by(1)
       end
     end
@@ -40,7 +43,7 @@ describe Admin::OpenStudiosEventsController do
         expect(response).to redirect_to admin_open_studios_events_path
       end
 
-      it 'creates a new open studios event' do
+      it 'updates the event with new data a new open studios event' do
         expect(event.reload.start_time).to eq 'whatever'
       end
     end
@@ -63,7 +66,7 @@ describe Admin::OpenStudiosEventsController do
         expect(response).to redirect_to admin_open_studios_events_path
       end
 
-      it 'creates a new open studios event' do
+      it 'updates the event' do
         event.reload
         expect(event.special_event_start_date).to eq Time.zone.parse('2020-10-10 00:00:00.000000000 -0700')
         expect(event.special_event_end_date).to eq Time.zone.parse('2020-10-11 00:00:00.000000000 -0700')

--- a/spec/factories/open_studios_events.rb
+++ b/spec/factories/open_studios_events.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :open_studios_event do
-    start_date { Time.zone.now }
+    start_date { Time.zone.now.to_date }
     end_date { start_date + 1.day }
     start_time { 'noon' }
     end_time { '6p' }
@@ -23,6 +23,11 @@ FactoryBot.define do
       end_date { start_date + 1.week }
       special_event_start_date { start_date + 1.day }
       special_event_end_date { special_event_start_date + 1.day }
+    end
+    trait :with_activation_dates do
+      end_date { start_date + 1.week }
+      activated_at { start_date - 1.day }
+      deactivated_at { end_date + 2.days }
     end
   end
 end


### PR DESCRIPTION
problem
-------

we want open studios treatments to expire given some settings in our models so we don't have to babysit every event after it's over.

solution
--------

Add `activated_at` and `deactivated_at` parameters to an open studios event.
Use those to help determine "current".  When there is a current open studios, we
serve up os treatments but if `current` is nil, then we don't

Changes
-------

* new fields `activated_at` and `deactivated_at`
* update scopes for `current` to honor these new fields
* add fields to the admin form so we can update them
* add a feature spec
* might have bumped rubocop and run some autofixes
