### PR TITLE
Bug - setting activation tasks via rake doesn't clear the cache

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_open_studios_active
-    @open_studios_active = OpenStudiosEventService.current
+    current = OpenStudiosEventService.current
+    @open_studios_active = current.present? ? OpenStudiosEventPresenter.new(current) : nil
   end
 
   protected

--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -149,6 +149,15 @@ class OpenStudiosEventPresenter < ViewPresenter
     !!(@model.special_event_start_date && @model.special_event_end_date)
   end
 
+  def active?
+    # currently default to always active if activation dates haven't been specified for
+    # backwards compatibility.  If activated_at/deactivated_at become required, this check can
+    # go away
+    return true unless @model.activated_at && @model.deactivated_at
+
+    Time.zone.now.to_date.between?(@model.activated_at, @model.deactivated_at)
+  end
+
   def with_activation_dates?
     !!(@model.activated_at && @model.deactivated_at)
   end

--- a/app/views/admin/open_studios_events/index.html.slim
+++ b/app/views/admin/open_studios_events/index.html.slim
@@ -12,14 +12,9 @@
   .pure-u-1-1.padded-content
     .os-events[class=(@open_studios_active ? "os-active__on" : "os-active__off")]
       - if !@open_studios_active
-        p &#9888; Open Studios is currently not active.
+        p &#9888; There is currently active Open Studios event.
       - else
-        p &#128077; Open Studios is currently active.
-      p
-        | If you want to change that, check the
-        '
-        a href=edit_admin_site_preferences_path
-          | Site Preferences page
+        p &#128077; Open Studios #{@open_studios_active.date_range_with_year} is currently activated
 
   .pure-u-1-1.padded-content
     table.os-events.pure-table.pure-table-striped.os-events__table
@@ -35,7 +30,7 @@
           th data-orderable="false"
       tbody
         - @os_events.each_with_index do |os_event|
-          tr.os-events__table-row
+          tr.os-events__table-row[class=(os_event.active? ? "os-events--active" : nil)]
             td.os-events__table-item.os-events__table-item--key = os_event.key
             td.os-events__table-item.os-events__table-item--title = os_event.title
             td.os-events__table-item.os-events__table-item--dates

--- a/app/views/admin/palettes/show.html.slim
+++ b/app/views/admin/palettes/show.html.slim
@@ -15,6 +15,7 @@ ruby:
     gto_red
     gto_teal
     gto_yellow
+    highlight-yellow
     light-gray-background
     light-gray
     lightbluegray

--- a/app/webpack/stylesheets/_colors.scss
+++ b/app/webpack/stylesheets/_colors.scss
@@ -1,3 +1,6 @@
+// NOTE: If you add a color here,
+// Add to all colors and update admin/pallettes/show page
+
 $black: #000;
 $bluegray: #738294;
 $darkbluegray: #223;
@@ -13,13 +16,17 @@ $gto_hot_pink: #ed2891;
 $lightbluegray: #c6c7d6;
 $white: #fff;
 
+// modified base colors
 $base-background-color: lighten($gto_gray, 60);
 $border-gray: darken($gto_gray, 9%);
 $darkgray: darken($gto_gray, 23%);
+$highlight-yellow: lighten($gto_yellow, 50%);
 $light-gray: lighten($gto_gray, 31%);
 $medium-gray: lighten($gto_gray, 24%);
 $x-light-gray: lighten($gto_gray, 47%);
 $xx-light-gray: lighten($gto_gray, 58%);
+
+// aliases
 $light-gray-background: $xx-light-gray;
 
 $all_colors: (
@@ -39,6 +46,7 @@ $all_colors: (
   "gto_teal": $gto_teal,
   "gto_yellow": $gto_yellow,
   "gto_hot_pink": $gto_hot_pink,
+  "highlight-yellow": $highlight-yellow,
   "light-gray-background": $light-gray-background,
   "light-gray": $light-gray,
   "lightbluegray": $lightbluegray,

--- a/app/webpack/stylesheets/gto_admin/os_events.scss
+++ b/app/webpack/stylesheets/gto_admin/os_events.scss
@@ -1,5 +1,9 @@
 @use "./_mixins";
+@use "../colors";
 
+.os-events__table-row.os-events--active > td {
+  background-color: colors.$highlight-yellow !important; // override pure striped table
+}
 .os-events__table-item--time {
   white-space: nowrap;
 }

--- a/lib/tasks/mau.rake
+++ b/lib/tasks/mau.rake
@@ -140,9 +140,11 @@ namespace :mau do
     desc 'Set activation dates on open studios event without activation (set to os date boundaries + 1 day)'
     task set_activation_dates: :environment do
       OpenStudiosEvent.where(activated_at: nil).or(OpenStudiosEvent.where(deactivated_at: nil)).find_each do |ev|
-        activated_at = ev.activated_at || (ev.start_date - 1.day)
-        deactivated_at = ev.deactivated_at || (ev.end_date + 1.day)
-        ev.update!(activated_at:, deactivated_at:)
+        attrs = {
+          activated_at: ev.activated_at || (ev.start_date - 1.day),
+          deactivated_at: ev.deactivated_at || (ev.end_date + 1.day)
+        }
+        OpenStudiosEventService.update(ev, attrs)
       end
     end
   end

--- a/spec/presenters/open_studios_event_presenter_spec.rb
+++ b/spec/presenters/open_studios_event_presenter_spec.rb
@@ -117,4 +117,33 @@ describe OpenStudiosEventPresenter do
       expect(presenter.special_event_date_range_with_year).to eql 'Apr 30-May 1 2015'
     end
   end
+
+  describe '.active?' do
+    let(:today) { Time.current.to_date }
+    it 'returns true if there is no activated/deactivated date' do
+      event = described_class.new(os)
+      expect(event.active?).to eq true
+    end
+    it 'returns true if todays date is equal to the activated_at' do
+      event = described_class.new(build(:open_studios_event, activated_at: today, deactivated_at: today + 2.days))
+      expect(event.active?).to eq true
+    end
+    it 'returns true if todays date is equal to the deactivated_at' do
+      event = described_class.new(build(:open_studios_event, activated_at: today - 2.days, deactivated_at: today))
+      expect(event.active?).to eq true
+    end
+    it 'returns true if todays date is between activation dates' do
+      event = described_class.new(build(:open_studios_event, activated_at: today - 1.day, deactivated_at: today + 1.day))
+      expect(event.active?).to eq true
+    end
+    it 'returns false if todays date is before activated_at' do
+      event = described_class.new(build(:open_studios_event, activated_at: today + 2.days, deactivated_at: today - 4.days))
+      expect(event.active?).to eq false
+    end
+
+    it 'returns false if todays date is after deactivated_at' do
+      event = described_class.new(build(:open_studios_event, activated_at: today - 4.days, deactivated_at: today - 2.days))
+      expect(event.active?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
problem
------

with the introduction of #448, we added a rake task to set activation dates for
all events.  This plumbing did not use our `OpenStudiosEventService` which provides an update method to manage the cache clearing on update.

solution
-------

revamp the rake task to use the service so when the updates happen, the open studios event cache is cleared.  In addition, while doing this, for visibility, I updated the admin index page to show when one is active, show which one in words and by highlighting the table.

This also takes out the link to the site preferences page as after all this, the `SitePreferences#open_studios_active` link is kind of moot.  Follow up PR will remove it.

Changes
------

* update open_studios:set_activation_dates rake task to use OpenStudiosEventService.update
* update admin index for events to highlight the activated open studios if there is one
* update the `@open_studios_active` variable present in all requests via Application controller to return a presenter
* update the OpenStudiosEventPresenter to provide and `#active?` method to report if the current os is active or not

Screenshots
--------
<img width="1093" alt="Screenshot 2024-05-12 at 6 35 00 PM" src="https://github.com/bunnymatic/mau/assets/427380/a938e664-35c4-4a28-968a-51bc8bb2a62c">

