### PR TITLE
Remove open_studios_active flag in favor of scheduled open studios events.

### DIFF
--- a/app/controllers/admin/site_preferences_controller.rb
+++ b/app/controllers/admin/site_preferences_controller.rb
@@ -20,7 +20,7 @@ module Admin
     end
 
     def site_preferences_params
-      params.require(:site_preferences).permit(:social_media_tags, :open_studios_active)
+      params.require(:site_preferences).permit(:social_media_tags)
     end
   end
 end

--- a/app/models/site_preferences.rb
+++ b/app/models/site_preferences.rb
@@ -8,7 +8,7 @@ class SitePreferences < ApplicationRecord
   CACHE_KEY = :site_preferences
 
   def self.instance(check_cache: false)
-    (check_cache && cached) || first || create(open_studios_active: true)
+    (check_cache && cached) || first || create
   end
 
   def self.cached

--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -2,6 +2,7 @@ class OpenStudiosEventPresenter < ViewPresenter
   attr_reader :model
 
   delegate :activated_at,
+           :artists,
            :deactivated_at,
            :end_time,
            :key,

--- a/app/services/open_studios_event_service.rb
+++ b/app/services/open_studios_event_service.rb
@@ -24,14 +24,12 @@ class OpenStudiosEventService
   end
 
   def self.current
-    return nil unless SitePreferences.instance(check_cache: true).open_studios_active?
-
-    cache = SafeCache.read(CURRENT_CACHE_KEY)
-    unless cache
-      cache = OpenStudiosEvent.current
-      SafeCache.write(CURRENT_CACHE_KEY, cache)
+    cached_event = SafeCache.read(CURRENT_CACHE_KEY)
+    unless cached_event
+      cached_event = OpenStudiosEvent.current
+      SafeCache.write(CURRENT_CACHE_KEY, cached_event)
     end
-    cache
+    cached_event
   end
 
   def self.future

--- a/app/views/admin/site_preferences/edit.html.slim
+++ b/app/views/admin/site_preferences/edit.html.slim
@@ -7,7 +7,6 @@
       = render partial: 'common/form_errors', locals: { form: f }
       = f.inputs do
         = f.input :social_media_tags, placeholder: 'e.g. #supertag, #anotherTag', hint: "Tags here will be the first tags shown in the new art email that goes out to all our new art watchers."
-        = f.input :open_studios_active, hint: "If set false, all Open Studios decorators will be suppressed"
       = f.actions do
         .form-controls
           = f.submit class: 'pure-button pure-button-primary'

--- a/db/migrate/20240513061645_remove_open_studios_active_flag.rb
+++ b/db/migrate/20240513061645_remove_open_studios_active_flag.rb
@@ -1,0 +1,5 @@
+class RemoveOpenStudiosActiveFlag < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :site_preferences, :open_studios_active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_07_014331) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_061645) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -270,7 +270,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_014331) do
     t.string "social_media_tags"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.boolean "open_studios_active"
   end
 
   create_table "studios", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/features/admin/artists/admin_list.feature
+++ b/features/admin/artists/admin_list.feature
@@ -20,14 +20,3 @@ Scenario: List artists
 
   When I click on "Not Yet Activated"
   Then I see the pending list
-
-Scenario: List artists when there is no current OS
-  When The site preferences open studio switch is off
-  And I click on "artists" in the admin menu
-  Then I see the admin artists list
-
-  When I click on "Suspended"
-  Then I see the suspended list
-
-  When I click on "Not Yet Activated"
-  Then I see the pending list

--- a/features/open_studios/open_studios_catalog.feature
+++ b/features/open_studios/open_studios_catalog.feature
@@ -91,6 +91,10 @@ Scenario: An artist sees their own pages
 
 
 Scenario: Open Studios is not active
-  When The site preferences open studio switch is off
+  When I login as an admin
+  And I click on "os dates" in the admin menu
+  And I click on the first "Edit"
+  And I deactivate the first open studios event
+  And I logout
   When I visit "/" in the catalog
   Then I see nothing is scheduled

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -72,9 +72,8 @@ Given /there are application events in the system/ do
   ]
 end
 
-Given /there is a scheduled Open Studios event/ do
-  step %(The site preferences open studio switch is on)
-  FactoryBot.create(:open_studios_event, :with_special_event)
+Given /there is a scheduled (active\s+)?Open Studios event/ do |_|
+  FactoryBot.create(:open_studios_event, :with_activation_dates, :with_special_event)
 rescue ActiveRecord::RecordInvalid
   Rails.logger.warn('Open studios event already exists in this feature.  No problem.')
 end

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -310,21 +310,8 @@ Then('I see the next artist in the catalog') do
   end
 end
 
-When('The site preferences open studio switch is on') do
-  SitePreferences.instance.update!(open_studios_active: true)
-end
-
-When('The site preferences open studio switch is off') do
-  SitePreferences.instance.update!(open_studios_active: false)
-end
-
 Then('I see an open studios violator') do
   expect(page).to have_css('.os-violator')
-end
-
-When('I toggle the open studios active toggle') do
-  uncheck 'site_preferences_open_studios_active'
-  click_on 'Update Site preferences'
 end
 
 Then('I don\'t see the open studios navigation') do

--- a/features/visitors/open_studios_active_toggle.feature
+++ b/features/visitors/open_studios_active_toggle.feature
@@ -4,21 +4,10 @@ Feature: Open Studios can be toggled by an admin
   When it's off, open studios features are not visible
 
 Background:
-  Given there is a scheduled Open Studios event
+  Given there is a scheduled active Open Studios event
   And there are open studios artists with art in the system
   And there is open studios cms content in the system
   When I visit the home page
-
-Scenario:  Admin can toggle the Open Studios Active flag
-  Then I see a "open studios" link
-  And I see an open studios violator
-  When I login as an admin
-  And I visit the "edit admin site preferences" page
-  And I toggle the open studios active toggle
-  Then I see "new preferences are in place" on the page
-  When I visit the home page
-  Then I don't see the open studios navigation
-  And I don't see any open studios violators
 
 Scenario:  Admin can deactivate the event by setting the deactivated date
   Then I see a "open studios" link

--- a/spec/services/open_studios_event_service_spec.rb
+++ b/spec/services/open_studios_event_service_spec.rb
@@ -26,19 +26,6 @@ describe OpenStudiosEventService do
     it 'returns the current os' do
       expect(service.current).to eq current_os
     end
-
-    context 'when the site preferences open_studios_active is off' do
-      before do
-        SitePreferences.instance.update!(open_studios_active: false)
-      end
-      after do
-        SitePreferences.instance.update!(open_studios_active: true)
-      end
-
-      it 'returns nil' do
-        expect(service.current).to be_nil
-      end
-    end
   end
 
   describe '.for_display' do


### PR DESCRIPTION
problem
-----

too many things control when/what we show when open studios is alive.

now that #448 and #449 are in, we're ready to fully support activated open studios events
and we don't need the `SitePreferences#open_studios_active` flag anymore.

solution
--------

* Remove the `SitePreferences#open_studios_active` flag
* replace the logic with the `OpenStudiosEventPresenter#active?`  which uses the activation dates on open studios events to decide.
* udpate specs as required
wip

Add feature specs
