### PR TITLE
Remove site twitter/pinerest links

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -142,34 +142,3 @@
               | based on their MAU profile.
         .content
           = render "featured_on_instagram", artist: @user
-    .pure-u-1-2.padded-content
-      .featured-snippet.mod-twitter.info-block
-        h4
-          = link_to 'http://www.twitter.com/sfmau' do
-            .info-block-icon.fa.fa-ico-invert.fa-twitter
-          | For Twitter
-
-        .instructions
-          p
-            | Check for <span class="info-block-instructions-callout">#{@user.login}</span> and
-            |  <span class="info-block-instructions-callout">#{@user.full_name}</span> on
-            '
-            = link_to 'twitter', 'http://www.twitter.com', target: '_blank', class: "found-handle"
-            '
-            - if @user.twitter?
-              | We think it might be
-              '
-              = link_to @user.twitter_handle, @user.twitter
-              '
-              | based on their MAU profile.
-
-          p
-            | How to post pictures on twitter:
-            '
-            = link_to "https://support.twitter.com/articles/20156423", "https://support.twitter.com/articles/20156423"
-            '
-            | We loose some characters when we post a photo, so we don’t get quite 140. Delete from the end of the
-            | line as you go over character count.
-            | their handle.
-        .content
-          = render "featured_on_twitter", artist: @user

--- a/app/views/artist_mailer/activation.html.erb
+++ b/app/views/artist_mailer/activation.html.erb
@@ -15,7 +15,6 @@
     <li>make note of our next Open Studios event and give some thought to participating</li>
     <li>get connected with MissionArtists on
       <%= link_to "Facebook", Conf.social_links['facebook'] %>,
-      <%= link_to "Twitter", Conf.social_links['twitter'] %>,
       <%= link_to "Instagram", Conf.social_links['instagram'] %>.
     </li>
   </ul>

--- a/app/views/artist_mailer/welcome_to_open_studios.html.erb
+++ b/app/views/artist_mailer/welcome_to_open_studios.html.erb
@@ -44,6 +44,5 @@
 <p style="font-size: small;">
     Connect:
     <%= link_to "[Facebook]", Conf.social_links['facebook'], target: "_blank" %>
-    <%= link_to "[Twitter]", Conf.social_links['twitter'], target: "_blank" %>
     <%= link_to "[Instagram]", Conf.social_links['instagram'], target: "_blank" %>
 </p>

--- a/app/views/main/contact.html.slim
+++ b/app/views/main/contact.html.slim
@@ -16,11 +16,12 @@
     p
       | And you are always invited to follow us on
       '
-      <a href="#{Conf.social_links['twitter']}">twitter</a>,
-      '
-      <a href="#{Conf.social_links['instagram']}">instagram</a>
+      a href=Conf.social_links['instagram']
+        | instagram
       '
       | or find us on
-      a>< href=Conf.social_links['facebook'] facebook.
+      '
+      a href=Conf.social_links['facebook']
+        | facebook.
 
     = render '/main/info_footer'

--- a/config/config.yml
+++ b/config/config.yml
@@ -72,9 +72,7 @@ common:
       per_page: 28
   social_links:
     facebook: http://www.facebook.com/MissionArtists
-    twitter: http://www.twitter.com/sfmau
     instagram: https://www.instagram.com/missionartists
-    pinterest: http://pinterest.com/mausf/
 
   cache_server: localhost:11211
   signup_secret_word: eat-shit-hackers

--- a/spec/mailers/artist_mailer_spec.rb
+++ b/spec/mailers/artist_mailer_spec.rb
@@ -70,7 +70,6 @@ describe ArtistMailer, elasticsearch: :stub do
     end
     it "includes links to mau's social media sites" do
       expect(mail).to have_link_in_body 'Facebook', href: Conf.social_links['facebook']
-      expect(mail).to have_link_in_body 'Twitter', href: Conf.social_links['twitter']
       expect(mail).to have_link_in_body 'Instagram', href: Conf.social_links['instagram']
     end
     it "includes the artist's name" do


### PR DESCRIPTION
problem
------

no one cares about twitter and pinterest anymore.
also our links don't go anywhere useful.

solution
-----

remove our social_links to twitter and pinterest.

screenshots
-----
<img width="548" alt="Screenshot 2024-05-14 at 11 37 43 PM" src="https://github.com/bunnymatic/mau/assets/427380/aa7d6d57-7819-47d2-86f5-e891788258f1">


