### PR TITLE
React 18 prep - use createRoot and render

### DIFF
--- a/app/webpack/reactjs/helpers/automount.tsx
+++ b/app/webpack/reactjs/helpers/automount.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import { lookup } from "../components";
 
@@ -17,7 +17,8 @@ export function automount() {
       const propsJSON = node.getAttribute("data-react-props") || "{}";
       const Component = lookup(componentClass);
       const props = JSON.parse(propsJSON);
-      render(<Component {...props} />, node);
+      const root = createRoot(node)
+      root.render(<Component {...props} />);
     });
   });
 }

--- a/app/webpack/reactjs/helpers/automount.tsx
+++ b/app/webpack/reactjs/helpers/automount.tsx
@@ -17,7 +17,7 @@ export function automount() {
       const propsJSON = node.getAttribute("data-react-props") || "{}";
       const Component = lookup(componentClass);
       const props = JSON.parse(propsJSON);
-      const root = createRoot(node)
+      const root = createRoot(node);
       root.render(<Component {...props} />);
     });
   });


### PR DESCRIPTION
problem
-----

React changed the way you're supposed to render components

solution
------

Follow instructions and fix it

use `createRoot` and `root.render`
