### PR TITLE
Build in support to move to opensearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,14 @@ executors:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ""
           MYSQL_DATABASE: mau_test
-      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
+      - image: opensearchproject/opensearch:2.14.0
         environment:
+          TEST_CLUSTER_URL: 'http://localhost:9200'
+          TEST_CLUSTER_PORT: 9200
           TEST_CLUSTER_NODES: 1
           discovery.type: single-node
+          plugins.security.disabled: true
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: Stay-outa-my-searches-3
 
 commands:
   vips_install:
@@ -40,7 +44,7 @@ commands:
             # match .nvmrc
             nvm install v18.19.1
             nvm alias default 18.19.1
-      
+
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 
@@ -133,6 +137,7 @@ jobs:
       RAILS_ENV: test
       RACK_ENV: test
       CI: true
+      TEST_CLUSTER_URL: 'http://localhost:9200'
       TEST_CLUSTER_PORT: 9200
     executor: ruby_node
     steps:
@@ -150,6 +155,7 @@ jobs:
       RAILS_ENV: test
       RACK_ENV: test
       CI: true
+      TEST_CLUSTER_URL: 'http://localhost:9200'
       TEST_CLUSTER_PORT: 9200
     executor: ruby_node
     steps:
@@ -178,6 +184,7 @@ jobs:
       RAILS_ENV: test
       RACK_ENV: test
       CI: true
+      TEST_CLUSTER_URL: 'http://localhost:9200'
       TEST_CLUSTER_PORT: 9200
     executor: ruby_node_mysql_elasticsearch
     steps:
@@ -216,6 +223,7 @@ jobs:
       RACK_ENV: test
       CI: true
       TEST_CLUSTER_PORT: 9200
+      TEST_CLUSTER_URL: 'http://localhost:9200'
     executor: ruby_node_mysql_elasticsearch
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ AllCops:
     - log/**/*
     - lib/tasks/mau.rake
     - lib/tasks/debug.rake
+    - local_gems/**/*
     - app/lib/app_config.rb
     - config/environment.rb
     - config/initializers/filter_parameter_logging.rb
@@ -83,7 +84,7 @@ Lint/StructNewOverride:
 Lint/SuppressedException:
   Exclude:
     - lib/tasks/*.rake
-    - app/services/search/indexer.rb
+    - app/services/search/elasticsearch/search_service.rb
 
 Metrics/AbcSize:
   Max: 38

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'mojo_magick'
 gem 'mysql2'
 gem 'newrelic_rpm' # moitoring
 gem 'nokogiri'
+gem 'opensearch-ruby'
 gem 'paperclip'
 gem 'postmark'
 gem 'postmark-rails'
@@ -87,10 +88,11 @@ group :test, :development do
   gem 'byebug'
   gem 'database_cleaner'
   gem 'dotenv-rails'
-  gem 'elasticsearch-extensions', require: nil
+  gem 'elasticsearch-extensions', require: false
   gem 'factory_bot', require: false
   gem 'factory_bot_rails', require: false
   gem 'faker'
+  gem 'opensearch-extensions', require: false, path: './local_gems/opensearch-extensions'
   gem 'rails-controller-testing'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+PATH
+  remote: local_gems/opensearch-extensions
+  specs:
+    opensearch-extensions (0.0.1)
+      ansi
+      opensearch-ruby
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -378,6 +385,9 @@ GEM
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    opensearch-ruby (3.3.0)
+      faraday (>= 1.0, < 3)
+      multi_json (>= 1.0)
     paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -663,6 +673,8 @@ DEPENDENCIES
   mysql2
   newrelic_rpm
   nokogiri
+  opensearch-extensions!
+  opensearch-ruby
   paperclip
   postmark
   postmark-rails

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If like docker, you can run the search server with docker like this:
 $ docker run -it -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=Doesnt1MatterSecurity-Disabled -e "discovery.type=single-node" -e "plugins.security.disabled=true" --name opensearch-node  opensearchproject/opensearch:latest
 
 ```
-You may need to restart it occasionally. 
+You may need to restart it occasionally.
 ```
 $ docker stop opensearch-node && docker remove opensearch-node
 
@@ -122,6 +122,13 @@ if you know docker better, maybe we can build some better helpers with `colima` 
 If you don't care about docker, you can `brew install opensearch` and manage it yourself.
 
 Either way, for testing you'll probably need to `brew install opensearch` until we can figure out how to get tests to fire up docker.
+
+
+#### With docker compose
+
+`brew install docker-compose`
+
+`docker compose up
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow the post-install instructions to get your MySQL server running.  For easy
 
 Use `homebrew` to install the following packages:
 
-    brew install markdown imagemagick memcached elasticsearch@6
+    brew install markdown imagemagick memcached opensearch
 
 At this point, you should have all the binary resources you'll need (hopefully).
 
@@ -103,9 +103,29 @@ Once you think things are running, you can try running the test suite:
 
 ## Development
 
+### Search server
+
+We depend on having a search server.  We used to use elasticsearch and are moving to open search.
+
+If like docker, you can run the search server with docker like this:
+```
+$ docker run -it -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=Doesnt1MatterSecurity-Disabled -e "discovery.type=single-node" -e "plugins.security.disabled=true" --name opensearch-node  opensearchproject/opensearch:latest
+
+```
+You may need to restart it occasionally. 
+```
+$ docker stop opensearch-node && docker remove opensearch-node
+
+```
+if you know docker better, maybe we can build some better helpers with `colima` or `docker-compose`.
+
+If you don't care about docker, you can `brew install opensearch` and manage it yourself.
+
+Either way, for testing you'll probably need to `brew install opensearch` until we can figure out how to get tests to fire up docker.
+
 ### Testing
 
-We use RSpec and Cucumber.  We have some test code that will auto start Elasticsearch on port 9250.
+We use RSpec and Cucumber.  We have some test code that will auto start Elasticsearch/OpenSearch on port 9250.
 
 You shouldn't need to do anything to get things rolling.  Tests that need elastic search know they do and they will start up a server for testing.
 

--- a/app/models/art_piece.rb
+++ b/app/models/art_piece.rb
@@ -74,7 +74,7 @@ class ArtPiece < ApplicationRecord
     extras['title_ngram'] = title
     extras['medium'] = medium.try(:name)
     extras['tags'] = tags.map(&:name).join(' ')
-    extras['images'] = images
+    extras['images'] = images.as_json
     # guard against bad data
     extras['artist_name'] = artist.full_name
     extras['studio_name'] = artist.studio.name if artist.studio

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -47,14 +47,17 @@ class Artist < User
 
     idxd = as_json(only: %i[firstname lastname nomdeplume slug])
     extras = {}
+    images = representative_piece.try(:images)
+    return {} if images.blank?
+
     studio_name = studio.try(:name)
     extras['artist_name'] = full_name
     extras['studio_name'] = studio_name if studio_name.present?
-    extras['images'] = representative_piece.try(:images)
     extras['bio'] = bio if bio.present?
     extras['os_participant'] = doing_open_studios?
+    extras['images'] = images.as_json
     idxd['artist'].merge!(extras)
-    active? && extras['images'].present? ? idxd : {}
+    idxd
   end
 
   # note, if this is used with count it doesn't work properly - group_by is dumped from the sql

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -1,6 +1,10 @@
 class FeatureNotAvailableError < StandardError; end
 
 class FeatureFlags
+  def self.use_open_search?
+    Conf.features['use_open_search']
+  end
+
   def self.virtual_open_studios?
     Conf.features['virtual_open_studios']
   end

--- a/app/services/search/elasticsearch/search_service.rb
+++ b/app/services/search/elasticsearch/search_service.rb
@@ -36,7 +36,7 @@ module Search
       end
 
       def self.reindex_all(clz)
-        clz.import(force: true)
+        clz.all.map { |obj| reindex(obj) }
       end
 
       def self.delete_index(clz)

--- a/app/services/search/elasticsearch/search_service.rb
+++ b/app/services/search/elasticsearch/search_service.rb
@@ -1,0 +1,81 @@
+module Search
+  module Elasticsearch
+    class SearchService
+      def self.index(object)
+        object.__elasticsearch__.index_document
+      rescue ::Elasticsearch::Transport::Transport::Errors::Forbidden => e
+        Rails.logger.error('Failed to index')
+        Rails.logger.error(e)
+      rescue ::Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+      end
+
+      def self.reindex(object)
+        remove(object)
+        index(object)
+      rescue ::Elasticsearch::Transport::Transport::Errors::Forbidden => e
+        Rails.logger.error('Failed to reindex')
+        Rails.logger.error(e)
+      rescue ::Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+      end
+
+      def self.remove(object)
+        object.__elasticsearch__.delete_document
+      rescue ::Elasticsearch::Transport::Transport::Errors::Forbidden => e
+        Rails.logger.error('Failed to remove')
+        Rails.logger.error(e)
+      rescue ::Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+      end
+
+      def self.update(object)
+        object.__elasticsearch__.update_document
+      rescue ::Elasticsearch::Transport::Transport::Errors::Forbidden => e
+        Rails.logger.error('Failed to update')
+        Rails.logger.error(e)
+      rescue ::Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+        index(object)
+      end
+
+      def self.reindex_all(clz)
+        clz.import(force: true)
+      end
+
+      def self.delete_index(clz)
+        Search::EsClient.client.indices.delete index: clz.index_name
+      end
+
+      def self.create_index(clz)
+        Search::EsClient.client.indices.create index: clz.index_name, body: { settings: Search::Indexer::INDEX_SETTINGS }
+      end
+
+      def self.search(query)
+        query_body = {
+          query: {
+            multi_match: {
+              query:,
+              fields: Search::Indexer::MULTI_MATCH_QUERY_FIELDS,
+              type: 'most_fields',
+              fuzziness: 0,
+            },
+          },
+          size: 100,
+          # highlight: {
+          #   fields: {
+          #     'studio.name' => {},
+          #     'artist.artist_name' => {},
+          #     'art_piece.title' => {},
+          #     'art_piece.tags' => {},
+          #     'art_piece.medium' => {},
+          #     'art_piece.title' => {},
+          #     'artist.artist_name' => {},
+          #   },
+          # },
+        }
+
+        Search::EsClient.client.search(
+          index: %i[art_pieces studios artists].join(','),
+          body: query_body,
+        )
+      end
+    end
+  end
+end

--- a/app/services/search/es_client.rb
+++ b/app/services/search/es_client.rb
@@ -1,7 +1,7 @@
 module Search
   class EsClient
     def self.root_es_client
-      Elasticsearch::Client.new(url: Rails.application.config.elasticsearch_url)
+      ::Elasticsearch::Client.new(url: Rails.application.config.elasticsearch_url)
     end
 
     def self.client(model = nil)

--- a/app/services/search/indexer.rb
+++ b/app/services/search/indexer.rb
@@ -17,7 +17,7 @@ module Search
     }.freeze
     TOKENIZERS = {
       mau_ngram_tokenizer: {
-        type: 'ngram',
+        type: FeatureFlags.use_open_search? ? 'ngram' : 'nGram',
         min_gram: 3,
         max_gram: 6,
         token_chars: %i[letter digit],

--- a/app/services/search/indexer.rb
+++ b/app/services/search/indexer.rb
@@ -17,7 +17,7 @@ module Search
     }.freeze
     TOKENIZERS = {
       mau_ngram_tokenizer: {
-        type: 'nGram',
+        type: 'ngram',
         min_gram: 3,
         max_gram: 6,
         token_chars: %i[letter digit],
@@ -29,121 +29,105 @@ module Search
       tokenizer: TOKENIZERS,
     }.freeze
 
-    class ObjectSearchService
-      attr_reader :object
+    MULTI_MATCH_QUERY_FIELDS = [
+      'art_piece.title^10',
+      'studio.name^5',
+      'artist.artist_name^5',
+      'art_piece.title_ngram^3',
+      'art_piece.artist_name^3',
+      'artist.firstname',
+      'artist.lastname',
+      'art_piece.medium',
+      'art_piece.tags',
+    ].freeze
 
-      def initialize(object)
-        @object = object
+    KNOWN_SEARCH_INDICES = [Artist, Studio, ArtPiece].map { |clz| clz.name.underscore.downcase.pluralize }.freeze
+
+    class ArtPieceSearchService
+      # this class helps keep track updating artist information in the search index
+      # when we update art piece information
+      def self.index(object)
+        ::Search::SearchService.index(object)
+        ::Search::SearchService.index(object.artist)
       end
 
-      def index
-        object.__elasticsearch__.index_document
-      rescue Elasticsearch::Transport::Transport::Errors::Forbidden => e
-        Rails.logger.error('Failed to index')
-        Rails.logger.error(e)
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+      def self.reindex(object)
+        ::Search::SearchService.reindex(object)
+        ::Search::SearchService.reindex(object.artist)
       end
 
-      def reindex
-        remove
-        index
-      rescue Elasticsearch::Transport::Transport::Errors::Forbidden => e
-        Rails.logger.error('Failed to reindex')
-        Rails.logger.error(e)
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
+      def self.update(object)
+        ::Search::SearchService.update(object)
+        ::Search::SearchService.update(object.artist)
       end
 
-      def remove
-        object.__elasticsearch__.delete_document
-      rescue Elasticsearch::Transport::Transport::Errors::Forbidden => e
-        Rails.logger.error('Failed to remove')
-        Rails.logger.error(e)
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
-      end
-
-      def update
-        object.__elasticsearch__.update_document
-      rescue Elasticsearch::Transport::Transport::Errors::Forbidden => e
-        Rails.logger.error('Failed to update')
-        Rails.logger.error(e)
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed
-        index
+      def self.remove(object)
+        ::Search::SearchService.remove(object)
       end
     end
 
-    class ArtPieceSearchService < ObjectSearchService
-      def index
-        super
-        ObjectSearchService.new(object.artist).index
-      end
-
-      def reindex
-        super
-        ObjectSearchService.new(object.artist).reindex
-      end
-
-      def update
-        super
-        ObjectSearchService.new(object.artist).update
-      end
-    end
-
-    class ArtistSearchService < ObjectSearchService
-      def index
+    class ArtistSearchService
+      # this class helps keep track updating art_piece information in the search index
+      # when we update the artist
+      def self.index(object)
         return unless object.active?
 
-        super
+        ::Search::SearchService.index(object)
         object.art_pieces.each do |art|
-          ObjectSearchService.new(art).index
+          ::Search::SearchService.index(art)
         end
       end
 
-      def reindex
+      def self.reindex(object)
         return unless object.active?
 
-        super
+        ::Search::SearchService.reindex(object)
         object.art_pieces.each do |art|
-          ObjectSearchService.new(art).reindex
+          ::Search::SearchService.reindex(art)
         end
       end
 
-      def update
+      def self.update(object)
         return unless object.active?
 
-        super
+        ::Search::SearchService.update(object)
         object.art_pieces.each do |art|
-          ObjectSearchService.new(art).update
+          ::Search::SearchService.update(art)
         end
       end
 
-      def remove
-        super
+      def self.remove(object)
+        ::Search::SearchService.remove(object)
         object.art_pieces.each do |art|
-          ObjectSearchService.new(art).remove
+          ::Search::SearchService.remove(art)
         end
       end
     end
 
-    class StudioSearchService < ObjectSearchService
+    class StudioSearchService < ::Search::SearchService
     end
 
     def self.run_es_method_on_object(method, object)
       case object.class.name
       when Studio.name
-        StudioSearchService.new(object).send(method)
+        StudioSearchService.public_send(method, object)
       when Artist.name
-        ArtistSearchService.new(object).send(method)
+        ArtistSearchService.public_send(method, object)
       when ArtPiece.name
-        ArtPieceSearchService.new(object).send(method)
+        ArtPieceSearchService.public_send(method, object)
       end
     end
 
-    def self.import(clz, opts = nil)
-      clz.import opts
+    def self.reindex_all(clz)
+      ::Search::SearchService.reindex_all(clz)
     end
 
-    def self.reindex_all(clz)
-      import(clz, force: true)
+    def self.create_index(clz)
+      ::Search::SearchService.create_index(clz)
+    end
+
+    def self.delete_index(clz)
+      ::Search::SearchService.delete_index(clz)
     end
 
     def self.index(object)

--- a/app/services/search/open_search/search_service.rb
+++ b/app/services/search/open_search/search_service.rb
@@ -1,0 +1,76 @@
+module Search
+  module OpenSearch
+    class SearchService
+      def self.index(object)
+        searchable = Search::SearchableObject.new(object)
+        return if searchable.document.blank?
+
+        Search::OpenSearchClient.index(
+          searchable.index_name,
+          searchable.id,
+          searchable.document,
+        )
+      end
+
+      def self.reindex(object)
+        remove(object)
+        index(object)
+      end
+
+      def self.remove(object)
+        searchable = Search::SearchableObject.new(object)
+
+        Search::OpenSearchClient.delete(
+          searchable.index_name,
+          searchable.id,
+        )
+      end
+
+      def self.update(object)
+        searchable = Search::SearchableObject.new(object)
+        return if searchable.document.blank?
+
+        Search::OpenSearchClient.update(
+          searchable.index_name,
+          searchable.id,
+          searchable.document,
+        )
+      end
+
+      def self.reindex_all(clz)
+        clz.all.map { |obj| reindex(obj) }
+      end
+
+      def self.delete_index(clz)
+        index = Search::SearchableObject.index_by_object_type(clz)
+        Search::OpenSearchClient.delete_index(index)
+      end
+
+      def self.create_index(clz)
+        index = Search::SearchableObject.index_by_object_type(clz)
+        Search::OpenSearchClient.create_index(index,
+                                              settings: Search::Indexer::INDEX_SETTINGS,
+                                              analysis: Search::Indexer::ANALYZERS_TOKENIZERS,
+                                              mappings: Search::SearchableObject.mappings_by_object_type(clz))
+      end
+
+      def self.search(query)
+        query_body = {
+          query: {
+            multi_match: {
+              query:,
+              fields: Search::Indexer::MULTI_MATCH_QUERY_FIELDS,
+              type: 'most_fields',
+              fuzziness: 0,
+            },
+          },
+          size: 100,
+        }
+        Search::OpenSearchClient.multi_index_search(
+          Search::SearchableObject.all_searchable_indices,
+          query_body,
+        )
+      end
+    end
+  end
+end

--- a/app/services/search/open_search_client.rb
+++ b/app/services/search/open_search_client.rb
@@ -1,0 +1,67 @@
+require 'opensearch'
+
+module Search
+  class OpenSearchClient
+    def self.index(index, id, document)
+      new.client.index(
+        index:,
+        id:,
+        body: document,
+        refresh: true,
+      )
+    end
+
+    def self.delete(index, id)
+      new.client.delete(
+        index:,
+        id:,
+        ignore: 404,
+      )
+    rescue ::OpenSearch::Transport::Transport::Errors::NotFound
+      nil
+    end
+
+    def self.update(index, id, document)
+      new.client.update(
+        index:,
+        id:,
+        body: { doc: document },
+      )
+    rescue ::OpenSearch::Transport::Transport::Errors::NotFound
+      nil
+    end
+
+    def self.create_index(index, settings:, analysis:, mappings:)
+      indices_client = new.client.indices
+
+      indices_client.create(index:,
+                            body: {
+                              settings: {
+                                **settings,
+                                analysis:,
+                              },
+                              mappings: {
+                                properties: mappings,
+                              },
+                            })
+    end
+
+    def self.delete_index(index)
+      new.client.indices.delete(index:, ignore: 404)
+    end
+
+    def self.multi_index_search(indices, query_body)
+      new.client.search(
+        index: indices.join(','),
+        body: query_body,
+      )
+    end
+
+    def client
+      client_params = {
+        hosts: [Rails.application.config.opensearch_url],
+      }
+      @client ||= ::OpenSearch::Client.new(**client_params)
+    end
+  end
+end

--- a/app/services/search/query_runner.rb
+++ b/app/services/search/query_runner.rb
@@ -3,8 +3,16 @@ module Search
     include ActiveModel::Model
     attr_accessor :_index, :_type, :_id, :_score, :_source, :_ignored
 
+    def ==(other)
+      self.class == other.class &&
+        _id == other._id &&
+        _index == other._index &&
+        _score == other._score &&
+        _source == other._source
+    end
+
     def as_json
-      { _type:, _id:, _score:, _source: }
+      { _type:, _id:, _score:, _source: }.as_json
     end
   end
 
@@ -16,15 +24,11 @@ module Search
     def search
       return [] if @query.blank?
 
-      results = service.search(@query)
+      results = Search::SearchService.search(@query)
       package_results(results)
     end
 
     private
-
-    def service
-      @service ||= FeatureFlags.use_open_search? ? Search::OpenSearch::SearchService : Search::Elasticsearch::SearchService
-    end
 
     def package_results(raw_results)
       return unless raw_results.key?('hits') && raw_results['hits'].key?('hits')

--- a/app/services/search/search_service.rb
+++ b/app/services/search/search_service.rb
@@ -1,0 +1,12 @@
+module Search
+  class SearchService
+    # API layer to switch between underlying search implementations
+    def self.service
+      FeatureFlags.use_open_search? ? Search::OpenSearch::SearchService : Search::Elasticsearch::SearchService
+    end
+
+    class << self
+      delegate :index, :update, :reindex, :remove, :reindex_all, :create_index, :delete_index, :multi_index_search, to: :service
+    end
+  end
+end

--- a/app/services/search/search_service.rb
+++ b/app/services/search/search_service.rb
@@ -6,7 +6,7 @@ module Search
     end
 
     class << self
-      delegate :index, :update, :reindex, :remove, :reindex_all, :create_index, :delete_index, :multi_index_search, to: :service
+      delegate :index, :update, :reindex, :remove, :reindex_all, :create_index, :delete_index, :multi_index_search, :search, to: :service
     end
   end
 end

--- a/app/services/search/searchable_object.rb
+++ b/app/services/search/searchable_object.rb
@@ -1,0 +1,79 @@
+module Search
+  class SearchableObject
+    class NotSearchableObject < StandardError; end
+
+    MAPPINGS_BY_OBJECT = {
+      artist: {
+        artist_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+        firstname: { type: 'text', analyzer: :mau_ngram_analyzer },
+        lastname: { type: 'text', analyzer: :mau_ngram_analyzer },
+        nomdeplume: { type: 'text', analyzer: :mau_ngram_analyzer },
+        studio_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+        bio: { type: 'text', index: false },
+      },
+      art_piece: {
+        title: { type: 'text', analyzer: 'english' },
+        title_ngram: { type: 'text', analyzer: :mau_ngram_analyzer },
+        year: { type: 'text' },
+        medium: { type: 'text', analyzer: 'english' },
+        artist_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+        studio_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+        tags: { type: 'text', analyzer: 'english' },
+      },
+      studio: {
+        name: { type: 'text', analyzer: :mau_ngram_analyzer },
+        address: { type: 'text', analyzer: :mau_ngram_analyzer },
+      },
+    }.freeze
+
+    attr_reader :object
+
+    delegate :id, to: :object
+
+    def initialize(object)
+      @object = object
+    end
+
+    def index_name
+      SearchableObject.index_by_object_type(object.class)
+    end
+
+    def document_type
+      object.class.name.underscore
+    end
+
+    def document
+      raise NotSearchableObject, 'the object must implement `as_indexed_json` to be searchable' unless object.respond_to?(:as_indexed_json)
+
+      object.as_indexed_json
+    end
+
+    def self.all_searchable_indices
+      %w[art_pieces artists studios].freeze
+    end
+
+    def self.index_by_object_type(clz)
+      index = clz.name.underscore.pluralize
+      unless all_searchable_indices.include?(index)
+        raise NotSearchableObject,
+              "#{index} is not included in our known indexes: #{all_searchable_indices}"
+      end
+
+      index
+    end
+
+    def self.mappings_by_object_type(clz)
+      document_type = clz.name.underscore
+      properties = MAPPINGS_BY_OBJECT[document_type.to_sym]
+      if properties
+        {
+          document_type => {
+            properties:,
+          },
+        }
+      else
+        {}
+      end
+    end
+  end
+end

--- a/app/webpack/js/app/models/search_hit.model.ts
+++ b/app/webpack/js/app/models/search_hit.model.ts
@@ -10,7 +10,7 @@ type SourceDetails = Record<
 type EsSearchSource = Record<string, SourceDetails>;
 
 interface EsSearchResult {
-  _type: string;
+  _type: string | null;
   _score: number;
   _id: string;
   _source: EsSearchSource;
@@ -33,8 +33,12 @@ export class SearchHit {
     if (this.hit._type === "_doc") {
       return Object.keys(this.src)[0];
     }
-    return this.hit._type;
+    if (this.hit._type) {
+      return this.hit._type;
+    }
+    return Object.keys(this.src)[0];
   }
+
   get score() {
     return this.hit._score;
   }

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,8 +44,6 @@ module Mau
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    config.elasticsearch_url = ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')
-
     config.action_mailer.delivery_method = :file
 
     config.s3_info = {
@@ -57,6 +55,7 @@ module Mau
 
     config.api_consumer_key = ENV.fetch('API_CONSUMER_KEY', ::Conf.api_consumer_key)
     config.elasticsearch_url = ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')
+    config.opensearch_url = config.elasticsearch_url
 
     config.active_support.test_order = :random
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess, Symbol, ActionController::Parameters]

--- a/config/config.yml
+++ b/config/config.yml
@@ -8,6 +8,7 @@ test:
   features:
     virtual_open_studios: true
     skip_api_authorization: true
+    use_open_search: true
   pagination:
     media:
       per_page: 12
@@ -17,11 +18,13 @@ test:
       per_page: 12
   subdomain: openstudios
   bryant_street_studios_api_key: testing man
+  opensearch_password: Stay-outa-my-searches-3
 
 development:
   features:
     virtual_open_studios: true
     skip_api_authorization: true
+    use_open_search: true
   S3_REGION: 'us-west-1'
   cache_expiry:
     feed: 300
@@ -47,6 +50,7 @@ acceptance:
 production:
   features:
     virtual_open_studios: true
+    use_open_search: false
   S3_REGION: 'us-west-1'
   cache_expiry:
     feed: 3600
@@ -63,6 +67,8 @@ common:
   open_studios_help_document_url: https://bit.ly/mission-fall2021
   features:
     virtual_open_studios: false
+    skip_authorization: false
+    use_open_search: true
   pagination:
     media:
       per_page: 24

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,7 +57,8 @@ Rails.application.configure do
     host: 'test.host',
   }
 
-  config.elasticsearch_url = "http://localhost:#{ENV.fetch('TEST_CLUSTER_PORT', 9250)}"
+  config.elasticsearch_url = ENV.fetch('TEST_CLUSTER_URL', 'http://localhost:9250')
+  config.opensearch_url = config.elasticsearch_url
 
   config.middleware.use DisableAnimations
 end

--- a/features/support/elasticsearch.rb
+++ b/features/support/elasticsearch.rb
@@ -1,12 +1,12 @@
-require_relative '../../spec/support/test_es_server'
+require_relative '../../spec/support/test_search_server'
 require_relative 'webmock'
 
 BeforeAll do
-  TestEsServer.start unless ENV['CI']
+  TestSearchServer.start unless ENV['CI']
 end
 
 at_exit do
-  TestEsServer.stop unless ENV['CI']
+  TestSearchServer.stop unless ENV['CI']
 rescue Exception => e
   puts "Failed to stop Elasticsearch: #{e}"
 end

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -11,7 +11,7 @@ namespace :es do
   task delete_indices: [:environment] do
     [Artist, Studio, ArtPiece].each do |model|
       puts "Deleting index: #{model.index_name}"
-      Search::EsClient.client.indices.delete index: model.index_name
+      Search::Indexer.delete_index(model)
     end
   end
 
@@ -19,7 +19,10 @@ namespace :es do
   task create_indices: [:environment] do
     [Artist, Studio, ArtPiece].each do |model|
       puts "Creating index: #{model.index_name}"
-      Search::EsClient.client.indices.create index: model.index_name, body: { settings: Search::Indexer::INDEX_SETTINGS }
+      Search::Indexer.create_index(model)
+    rescue OpenSearch::Transport::Transport::Errors::BadRequest => e
+      # swallow already exists errors
+      raise unless e.to_s.include? 'resource_already_exists_exception'
     end
   end
 end

--- a/local_gems/opensearch-extensions/.gitignore
+++ b/local_gems/opensearch-extensions/.gitignore
@@ -1,0 +1,17 @@
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/local_gems/opensearch-extensions/Gemfile
+++ b/local_gems/opensearch-extensions/Gemfile
@@ -1,0 +1,33 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in elasticsearch-extensions.gemspec
+gemspec
+
+gem 'opensearch-ruby'
+gem 'bundler'
+gem 'minitest', '~> 5'
+gem 'minitest-reporters', '~> 1'
+gem 'mocha'
+gem 'rake', '~> 12.3'
+gem 'ruby-prof'
+gem 'shoulda-context'
+gem 'simplecov'
+gem 'oj'
+gem 'patron'

--- a/local_gems/opensearch-extensions/LICENSE.txt
+++ b/local_gems/opensearch-extensions/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/local_gems/opensearch-extensions/LICENSE.txt
+++ b/local_gems/opensearch-extensions/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Jon Rogers <jon@rcode5.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/local_gems/opensearch-extensions/README.md
+++ b/local_gems/opensearch-extensions/README.md
@@ -1,0 +1,265 @@
+# OpenSearch::Extensions
+
+This library provides a set of extensions to the [`elasticsearch`](https://github.com/elasticsearch/elasticsearch-ruby) Rubygem.
+
+## Installation
+
+Install the package from [Rubygems](https://rubygems.org):
+
+    gem install elasticsearch-extensions
+
+To use an unreleased version, either add it to your `Gemfile` for [Bundler](http://gembundler.com):
+
+    gem 'elasticsearch-extensions', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'
+
+or install it from a source code checkout:
+
+    git clone https://github.com/elasticsearch/elasticsearch-ruby.git
+    cd elasticsearch-ruby/elasticsearch-extensions
+    bundle install
+    rake install
+
+
+## Extensions
+
+### Backup
+
+Backup OpenSearch indices as flat JSON files on the disk via integration
+with the [_Backup_](http://backup.github.io/backup/v4/) gem.
+
+Use the Backup gem's DSL to configure the backup:
+
+    require 'opensearch/extensions/backup'
+
+    Model.new(:elasticsearch_backup, 'OpenSearch') do
+
+      database OpenSearch do |db|
+        db.url     = 'http://localhost:9200'
+        db.indices = 'test'
+      end
+
+      store_with Local do |local|
+        local.path = '/tmp/backups'
+      end
+
+      compress_with Gzip
+    end
+
+Perform the backup with the Backup gem's command line utility:
+
+    $ backup perform -t elasticsearch_backup
+
+See more information in the [`Backup::Database::OpenSearch`](lib/opensearch/extensions/backup.rb)
+class documentation.
+
+### Reindex
+
+Copy documents from one index and cluster into another one, for example for purposes of changing
+the settings and mappings of the index.
+
+**NOTE:** OpenSearch natively supports re-indexing since version 2.3. This extension is useful
+          when you need the feature on older versions.
+
+When the extension is loaded together with the
+[Ruby client for OpenSearch](../elasticsearch/README.md),
+a `reindex` method is added to the client:
+
+    require 'elasticsearch'
+    require 'opensearch/extensions/reindex'
+
+    client = OpenSearch::Client.new
+    target_client = OpenSearch::Client.new url: 'http://localhost:9250', log: true
+
+    client.index index: 'test', type: 'd', body: { title: 'foo' }
+
+    client.reindex source: { index: 'test' },
+                   dest: { index: 'test', client: target_client },
+                   transform: lambda { |doc| doc['_source']['title'].upcase! },
+                   refresh: true
+    # => { errors: 0 }
+
+    target_client.search index: 'test'
+    # => ... hits ... "title"=>"FOO"
+
+The method takes similar arguments as the core API
+[`reindex`](http://www.rubydoc.info/gems/elasticsearch-api/OpenSearch/API/Actions#reindex-instance_method)
+method.
+
+You can also use the `Reindex` class directly:
+
+    require 'elasticsearch'
+    require 'opensearch/extensions/reindex'
+
+    client = OpenSearch::Client.new
+
+    reindex = OpenSearch::Extensions::Reindex.new \
+                source: { index: 'test', client: client },
+                dest: { index: 'test-copy' }
+
+    reindex.perform
+
+See more information in the [`OpenSearch::Extensions::Reindex::Reindex`](lib/opensearch/extensions/reindex.rb)
+class documentation.
+
+### ANSI
+
+Colorize and format selected  OpenSearch response parts in terminal:
+
+Display formatted search results:
+
+    require 'opensearch/extensions/ansi'
+    puts OpenSearch::Client.new.search.to_ansi
+
+Display a table with the output of the `_analyze` API:
+
+    require 'opensearch/extensions/ansi'
+    puts OpenSearch::Client.new.indices.analyze(text: 'Quick Brown Fox Jumped').to_ansi
+
+[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/ANSI)
+
+### Test::Cluster
+
+Allows to programatically start and stop an OpenSearch cluster suitable for isolating tests.
+
+The HTTP service is running on ports `9250-*` by default.
+
+Start and stop the default cluster:
+
+    require 'opensearch/extensions/test/cluster'
+
+    OpenSearch::Extensions::Test::Cluster.start
+    OpenSearch::Extensions::Test::Cluster.stop
+
+Start the cluster on specific port, with a specific OpenSearch version, number of nodes and cluster name:
+
+    require 'opensearch/extensions/test/cluster'
+
+    OpenSearch::Extensions::Test::Cluster.start \
+      cluster_name:    "my-testing-cluster",
+      command:         "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
+      port:            9350,
+      number_of_nodes: 3
+
+    # Starting 3 OpenSearch nodes.....................
+    # --------------------------------------------------------------------------------
+    # Cluster:            my-testing-cluster
+    # Status:             green
+    # Nodes:              3
+    #                     - node-1 | version: 1.0.0.Beta2, pid: 54469
+    #                     + node-2 | version: 1.0.0.Beta2, pid: 54470
+    #                     - node-3 | version: 1.0.0.Beta2, pid: 54468
+    # => true
+
+Stop this cluster:
+
+    require 'opensearch/extensions/test/cluster'
+
+    OpenSearch::Extensions::Test::Cluster.stop port: 9350
+
+    # Stopping OpenSearch nodes... stopped PID 54469. stopped PID 54470. stopped PID 54468.
+    # # => [54469, 54470, 54468]
+
+You can control the cluster configuration with environment variables as well:
+
+    TEST_CLUSTER_NAME=my-testing-cluster \
+    TEST_CLUSTER_COMMAND=/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch \
+    TEST_CLUSTER_PORT=9350 \
+    TEST_CLUSTER_NODES=3 \
+    TEST_CLUSTER_NAME=my_testing_cluster \
+    ruby -r elasticsearch -e "require 'opensearch/extensions/test/cluster'; OpenSearch::Extensions::Test::Cluster.start"
+
+To prevent deleting data and configurations when the cluster is started, for example in a development environment,
+use the `clear_cluster: false` option or the `TEST_CLUSTER_CLEAR=false` environment variable.
+
+[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/Cluster)
+
+### Test::StartupShutdown
+
+Allows to register `startup` and `shutdown` hooks for Test::Unit, similarly to RSpec's `before(:all)`,
+compatible with the [Test::Unit 2](https://github.com/test-unit/test-unit/blob/master/lib/test/unit/testcase.rb) syntax.
+
+The extension is useful for e.g. starting the testing OpenSearch cluster before the test suite is executed,
+and stopping it afterwards.
+
+** IMPORTANT NOTE ** You have to register the handler for `shutdown` hook before requiring 'test/unit':
+
+    # File: test_helper.rb
+    at_exit { MyTest.__run_at_exit_hooks }
+    require 'test/unit'
+
+Example of handler registration:
+
+    class MyTest < Test::Unit::TestCase
+      extend OpenSearch::Extensions::Test::StartupShutdown
+
+      startup  { puts "Suite starting up..." }
+      shutdown { puts "Suite shutting down..." }
+    end
+
+[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/StartupShutdown)
+
+Examples in the OpenSearch gem test suite: [1](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/integration/client_test.rb#L4-L6), [2](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/test_helper.rb#L44)
+
+### Test::Profiling
+
+Allows to define and execute profiling tests within [Shoulda](https://github.com/thoughtbot/shoulda) contexts.
+Measures operations and reports statistics, including code profile.
+
+Let's define a simple profiling test in a `profiling_test.rb` file:
+
+    require 'test/unit'
+    require 'shoulda/context'
+    require 'opensearch/extensions/test/profiling'
+
+    class ProfilingTest < Test::Unit::TestCase
+      extend OpenSearch::Extensions::Test::Profiling
+
+      context "Mathematics" do
+        measure "divide numbers", count: 10_000 do
+          assert_nothing_raised { 1/2 }
+        end
+      end
+
+    end
+
+Let's run it:
+
+    $ QUIET=y ruby profiling_test.rb
+
+    ...
+    ProfilingTest
+
+    -------------------------------------------------------------------------------
+    Context: Mathematics should divide numbers (10000x)
+    mean: 0.03ms | avg: 0.03ms | max: 0.14ms
+    -------------------------------------------------------------------------------
+         PASS (0:00:00.490) test: Mathematics should divide numbers (10000x).
+    ...
+
+When using the `QUIET` option, only the statistics on operation throughput are printed.
+When omitted, the full code profile by [RubyProf](https://github.com/ruby-prof/ruby-prof) is printed.
+
+[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/StartupShutdown)
+
+[Example in the OpenSearch gem](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/profile/client_benchmark_test.rb)
+
+
+## Development
+
+To work on the code, clone and bootstrap the main repository first --
+please see instructions in the main [README](../README.md#development).
+
+To run tests, launch a testing cluster -- again, see instructions
+in the main [README](../README.md#development) -- and use the Rake tasks:
+
+```
+time rake test:unit
+time rake test:integration
+```
+
+Unit tests have to use Ruby 1.8 compatible syntax, integration tests
+can use Ruby 2.x syntax and features.
+
+## License
+
+This software is licensed under the [Apache 2 license](./LICENSE).

--- a/local_gems/opensearch-extensions/README.md
+++ b/local_gems/opensearch-extensions/README.md
@@ -1,28 +1,16 @@
 # OpenSearch::Extensions
 
-This library provides a set of extensions to the [`elasticsearch`](https://github.com/elasticsearch/elasticsearch-ruby) Rubygem.
+This library provides a set of extensions to the [`opensearch`](https://github.com/opensearch-project/opensearch-ruby) Rubygem.
 
 ## Installation
 
-Install the package from [Rubygems](https://rubygems.org):
-
-    gem install elasticsearch-extensions
-
-To use an unreleased version, either add it to your `Gemfile` for [Bundler](http://gembundler.com):
-
-    gem 'elasticsearch-extensions', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'
-
-or install it from a source code checkout:
-
-    git clone https://github.com/elasticsearch/elasticsearch-ruby.git
-    cd elasticsearch-ruby/elasticsearch-extensions
-    bundle install
-    rake install
-
+Currently this is only available here as a subcomponent of Mission Artists.
 
 ## Extensions
 
 ### Backup
+
+NOTE: not tested with the move to opensearch - use with caution
 
 Backup OpenSearch indices as flat JSON files on the disk via integration
 with the [_Backup_](http://backup.github.io/backup/v4/) gem.
@@ -31,7 +19,7 @@ Use the Backup gem's DSL to configure the backup:
 
     require 'opensearch/extensions/backup'
 
-    Model.new(:elasticsearch_backup, 'OpenSearch') do
+    Model.new(:opensearch_backup, 'OpenSearch') do
 
       database OpenSearch do |db|
         db.url     = 'http://localhost:9200'
@@ -47,12 +35,15 @@ Use the Backup gem's DSL to configure the backup:
 
 Perform the backup with the Backup gem's command line utility:
 
-    $ backup perform -t elasticsearch_backup
+    $ backup perform -t opensearch_backup
 
 See more information in the [`Backup::Database::OpenSearch`](lib/opensearch/extensions/backup.rb)
 class documentation.
 
 ### Reindex
+
+NOTE: not tested with the move to opensearch - use with caution
+
 
 Copy documents from one index and cluster into another one, for example for purposes of changing
 the settings and mappings of the index.
@@ -103,6 +94,9 @@ class documentation.
 
 ### ANSI
 
+NOTE: not tested with the move to opensearch - use with caution
+
+
 Colorize and format selected  OpenSearch response parts in terminal:
 
 Display formatted search results:
@@ -136,7 +130,7 @@ Start the cluster on specific port, with a specific OpenSearch version, number o
 
     OpenSearch::Extensions::Test::Cluster.start \
       cluster_name:    "my-testing-cluster",
-      command:         "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
+      command:         "path/to/opensearch",
       port:            9350,
       number_of_nodes: 3
 
@@ -162,18 +156,17 @@ Stop this cluster:
 You can control the cluster configuration with environment variables as well:
 
     TEST_CLUSTER_NAME=my-testing-cluster \
-    TEST_CLUSTER_COMMAND=/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch \
+    TEST_CLUSTER_COMMAND=path/to/opensearch \
     TEST_CLUSTER_PORT=9350 \
     TEST_CLUSTER_NODES=3 \
     TEST_CLUSTER_NAME=my_testing_cluster \
-    ruby -r elasticsearch -e "require 'opensearch/extensions/test/cluster'; OpenSearch::Extensions::Test::Cluster.start"
+    ruby -r opensearch-ruby -e "require 'opensearch/extensions/test/cluster'; OpenSearch::Extensions::Test::Cluster.start"
 
 To prevent deleting data and configurations when the cluster is started, for example in a development environment,
 use the `clear_cluster: false` option or the `TEST_CLUSTER_CLEAR=false` environment variable.
 
-[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/Cluster)
-
 ### Test::StartupShutdown
+
 
 Allows to register `startup` and `shutdown` hooks for Test::Unit, similarly to RSpec's `before(:all)`,
 compatible with the [Test::Unit 2](https://github.com/test-unit/test-unit/blob/master/lib/test/unit/testcase.rb) syntax.
@@ -196,11 +189,9 @@ Example of handler registration:
       shutdown { puts "Suite shutting down..." }
     end
 
-[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/StartupShutdown)
-
-Examples in the OpenSearch gem test suite: [1](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/integration/client_test.rb#L4-L6), [2](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/test_helper.rb#L44)
-
 ### Test::Profiling
+
+NOTE: not tested with the move to opensearch - use with caution
 
 Allows to define and execute profiling tests within [Shoulda](https://github.com/thoughtbot/shoulda) contexts.
 Measures operations and reports statistics, including code profile.
@@ -238,10 +229,6 @@ Let's run it:
 
 When using the `QUIET` option, only the statistics on operation throughput are printed.
 When omitted, the full code profile by [RubyProf](https://github.com/ruby-prof/ruby-prof) is printed.
-
-[Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/OpenSearch/Extensions/Test/StartupShutdown)
-
-[Example in the OpenSearch gem](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-transport/test/profile/client_benchmark_test.rb)
 
 
 ## Development

--- a/local_gems/opensearch-extensions/Rakefile
+++ b/local_gems/opensearch-extensions/Rakefile
@@ -1,0 +1,50 @@
+require 'bundler/gem_tasks'
+
+desc 'Run unit tests'
+task default: 'test:unit'
+task test: 'test:unit'
+
+# ----- Test tasks ------------------------------------------------------------
+
+require 'rake/testtask'
+namespace :test do
+  Rake::TestTask.new(:unit) do |test|
+    test.libs << 'lib' << 'test'
+    test.test_files = FileList['test/**/unit/**/*_test.rb']
+    test.verbose = false
+    test.warning = false
+  end
+
+  Rake::TestTask.new(:integration) do |test|
+    test.libs << 'lib' << 'test'
+    test.test_files = FileList['test/**/integration/**/*_test.rb']
+    test.verbose = false
+    test.warning = false
+  end
+
+  Rake::TestTask.new(:all) do |test|
+    test.libs << 'lib' << 'test'
+    test.test_files = FileList['test/**/unit/**/*_test.rb', 'test/**/integration/**/*_test.rb']
+  end
+
+  Rake::TestTask.new(:profile) do |test|
+    test.libs << 'lib' << 'test'
+    test.test_files = FileList['test/profile/**/*_test.rb']
+  end
+
+  namespace :cluster do
+    desc 'Start OpenSearch nodes for tests'
+    task start: :environment do
+      $LOAD_PATH << File.expand_path('lib', __dir__) << File.expand_path('test', __dir__)
+      require 'opensearch/extensions/test/cluster'
+      OpenSearch::Extensions::Test::Cluster.start
+    end
+
+    desc 'Stop OpenSearch nodes for tests'
+    task stop: :environment do
+      $LOAD_PATH << File.expand_path('lib', __dir__) << File.expand_path('test', __dir__)
+      require 'opensearch/extensions/test/cluster'
+      OpenSearch::Extensions::Test::Cluster.stop
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions.rb
@@ -1,0 +1,26 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+require 'opensearch'
+require 'opensearch/extensions/version'
+
+module OpenSearch
+  module Extensions
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi.rb
@@ -1,0 +1,51 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+require 'opensearch/extensions'
+
+require 'ansi'
+require 'ansi/table'
+require 'ansi/terminal'
+
+require 'delegate'
+require 'opensearch/transport/transport/response'
+
+require 'opensearch/extensions/ansi/helpers'
+require 'opensearch/extensions/ansi/actions'
+require 'opensearch/extensions/ansi/response'
+
+module OpenSearch
+  module Extensions
+    # This extension provides a {ResponseBody#to_ansi} method for the OpenSearch response body,
+    # which colorizes and formats the output with the `ansi` gem.
+    #
+    # @example Display formatted search results
+    #
+    #     require 'opensearch/extensions/ansi'
+    #     puts OpenSearch::Client.new.search.to_ansi
+    #
+    # @example Display a table with the output of the `_analyze` API
+    #
+    #     require 'opensearch/extensions/ansi'
+    #     puts OpenSearch::Client.new.indices.analyze(text: 'Quick Brown Fox Jumped').to_ansi
+    #
+    module ANSI
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/actions.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/actions.rb
@@ -1,0 +1,239 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+module OpenSearch
+  module Extensions
+    module ANSI
+      module Actions
+        # Display shard allocation
+        #
+        def display_allocation_on_nodes(json, _options = {})
+          return unless json['routing_nodes']
+
+          output = [] << ''
+
+          json['routing_nodes']['nodes'].each do |id, shards|
+            output << ((json['nodes'][id]['name'] || id).to_s.ansi(:bold) + " [#{id}]".ansi(:faint))
+            output << if shards.empty?
+                        'No shards'.ansi(:cyan)
+                      else
+                        Helpers.table(shards.map do |shard|
+                          [
+                            shard['index'],
+                            shard['shard'].to_s.ansi(shard['primary'] ? :bold : :clear),
+                            shard['primary'] ? '◼'.ansi(:green) : '◻'.ansi(:yellow),
+                          ]
+                        end)
+                      end
+          end
+
+          unless json['routing_nodes']['unassigned'].empty?
+            output << ('Unassigned: '.ansi(:faint, :yellow) + "#{json['routing_nodes']['unassigned'].size} shards")
+            output << Helpers.table(json['routing_nodes']['unassigned'].map do |shard|
+              primary = shard['primary']
+
+              [
+                shard['index'],
+                shard['shard'].to_s.ansi(primary ? :bold : :clear),
+                primary ? '◼'.ansi(:red) : '◻'.ansi(:yellow),
+              ]
+            end,
+                                    border: false)
+          end
+
+          output.join("\n")
+        end
+
+        # Display search results
+        #
+        def display_hits(json, _options = {})
+          return unless json['hits'] && json['hits']['hits']
+
+          output = [] << ''
+          hits = json['hits']['hits']
+          source = json['hits']['hits'].any? { |h| h['fields'] } ? 'fields' : '_source'
+          properties = hits.filter_map { |h| h[source] ? h[source].keys : nil }.flatten.uniq
+          max_property_length = properties.filter_map { |d| d.to_s.size }.max.to_i + 1
+
+          hits.each_with_index do |hit, i|
+            title = hit[source] && hit[source].select { |k, _v| %w[title name].include?(k) }.to_a.first
+            size_length = hits.size.to_s.size + 2
+            padding = size_length
+
+            output << ("#{i + 1}. ".rjust(size_length).ansi(:faint) +
+                      " <#{hit['_id']}> " +
+                      (title ? title.last.to_s.ansi(:bold) : ''))
+            output << Helpers.___
+
+            %w[_score _index _type].each do |property|
+              output << ((' ' * padding) + "#{property}: ".rjust(max_property_length + 1).ansi(:faint) + hit[property].to_s) if hit[property]
+            end
+
+            hit[source]&.each do |property, value|
+              output << ((' ' * padding) + "#{property}: ".rjust(max_property_length + 1).ansi(:faint) + value.to_s)
+            end
+
+            # Highlight
+            if hit['highlight']
+              output << ''
+              output << ("#{' ' * (padding + max_property_length + 1)}#{'Highlights'.ansi(:faint)}\n#{' ' * (padding + max_property_length + 1)}#{('─' * 10).ansi(:faint)}")
+
+              hit['highlight'].each do |property, matches|
+                line = ''
+                line << ((' ' * padding) + "#{property}: ".rjust(max_property_length + 1).ansi(:faint))
+
+                matches.each_with_index do |match, e|
+                  line << ((' ' * padding) + ''.rjust(max_property_length + 1)) if e.positive?
+                  line << '…'.ansi(:faint) unless hit[source][property] && hit[source][property].size <= match.size
+                  line << match.strip.ansi(:faint).tr("\n", ' ')
+                               .gsub(%r{<em>([^<]+)</em>}, '\1'.ansi(:clear, :bold))
+                               .ansi(:faint)
+                  line << '…'.ansi(:faint) unless hit[source][property] && hit[source][property].size <= match.size
+                  line << ((' ' * padding) + ''.rjust(max_property_length + 1)) if e.positive?
+                  line << "\n"
+                end
+                output << line
+              end
+            end
+
+            output << ''
+          end
+          output << Helpers.___
+          output << "#{hits.size.to_s.ansi(:bold)} of #{json['hits']['total']['value'].to_s.ansi(:bold)} results".ansi(:faint)
+
+          output.join("\n")
+        end
+
+        # Display terms facets
+        #
+        def display_terms_facets(json, _options = {})
+          return unless json['facets']
+
+          output = [] << ''
+
+          facets = json['facets'].select { |_name, values| values['_type'] == 'terms' }
+
+          facets.each do |name, values|
+            longest = values['terms'].map { |t| t['term'].size }.max
+            max     = values['terms'].pluck('count').max
+            padding = longest.to_i + max.to_s.size + 5
+            ratio   = (Helpers.width - padding) / max.to_f
+
+            output << "#{'Facet: '.ansi(:faint)}#{Helpers.humanize(name)}" << Helpers.___
+            values['terms'].each_with_index do |value, _i|
+              output << (value['term'].ljust(longest).ansi(:bold) +
+                        ' [' + value['count'].to_s.rjust(max.to_s.size) + ']  ' \
+                                                                          '' + ('█' * (value['count'] * ratio).ceil))
+            end
+          end
+
+          output.join("\n")
+        end
+
+        # Display date histogram facets
+        #
+        def display_date_histogram_facets(json, options = {})
+          return unless json['facets']
+
+          output = [] << ''
+
+          facets = json['facets'].select { |_name, values| values['_type'] == 'date_histogram' }
+          facets.each do |name, values|
+            max     = values['entries'].pluck('count').max
+            padding = 27
+            ratio   = (Helpers.width - padding) / max.to_f
+
+            interval = options[:interval] || 'day'
+            output << "#{'Facet: '.ansi(:faint)}#{Helpers.humanize(name)} #{interval ? "(by #{interval})".ansi(:faint) : ''}"
+            output << Helpers.___
+            values['entries'].each_with_index do |value, _i|
+              output << (Helpers.date(Time.at(value['time'].to_i / 1000).utc, interval).rjust(21).ansi(:bold) +
+                        ' [' + value['count'].to_s.rjust(max.to_s.size) + ']  ' \
+                                                                          '' + ('█' * (value['count'] * ratio).ceil))
+            end
+          end
+
+          output.join("\n")
+        end
+
+        # Display histogram facets
+        #
+        def display_histogram_facets(json, _options = {})
+          return unless json['facets']
+
+          output = [] << ''
+
+          facets = json['facets'].select { |_name, values| values['_type'] == 'histogram' }
+          facets.each_value do |values|
+            max     = values['entries'].pluck('count').max
+            padding = 27
+            ratio   = (Helpers.width - padding) / max.to_f
+
+            histogram = values['entries']
+            histogram.each_with_index do |segment, i|
+              key = i.zero? ? "<#{histogram[1]['key']}ms" : "#{segment['key']}ms"
+
+              output << ("#{key.rjust(7)} #{'█' * (segment['count'] * ratio).ceil} [#{segment['count']}]")
+            end
+          end
+
+          output.join("\n")
+        end
+
+        # Display statistical facets
+        #
+        def display_statistical_facets(json, _options = {})
+          return unless json['facets']
+
+          output = [] << ''
+
+          facets = json['facets'].select { |_name, values| values['_type'] == 'statistical' }
+
+          facets.each do |name, facet|
+            output << "#{'Facet: '.ansi(:faint)}#{Helpers.humanize(name)}" << Helpers.___
+            output << Helpers.table(facet.except('_type').to_a.map do |pair|
+                                      [Helpers.humanize(pair[0]), pair[1]]
+                                    end)
+          end
+          output.join("\n")
+        end
+
+        # Display the analyze output
+        #
+        def display_analyze_output(json, _options = {})
+          return unless json['tokens']
+
+          output = [] << ''
+
+          max_length = json['tokens'].map { |d| d['token'].to_s.size }.max
+
+          output <<  Helpers.table(json['tokens'].map do |t|
+                                     [
+                                       t['position'],
+                                       t['token'].ljust(max_length + 5).ansi(:bold),
+                                       "#{t['start_offset']}–#{t['end_offset']}",
+                                       t['type'],
+                                     ]
+                                   end).to_s
+          output.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/helpers.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/helpers.rb
@@ -1,0 +1,75 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+module OpenSearch
+  module Extensions
+    module ANSI
+      module Helpers
+        # Shortcut for {::ANSI::Table.new}
+        #
+        def table(data, options = {}, &)
+          ::ANSI::Table.new(data, options, &)
+        end
+
+        # Terminal width, based on {::ANSI::Terminal.terminal_width}
+        #
+        def width
+          ::ANSI::Terminal.terminal_width - 5
+        end
+
+        # Humanize a string
+        #
+        def humanize(string)
+          string.to_s.tr('_', ' ').split.map(&:capitalize).join(' ')
+        end
+
+        # Return date formatted by interval
+        #
+        def date(date, interval = 'day')
+          case interval
+          when 'minute'
+            "#{date.strftime('%a %m/%d %H:%M')} – #{(date + 60).strftime('%H:%M')}"
+          when 'hour'
+            "#{date.strftime('%a %m/%d %H:%M')} – #{(date + (60 * 60)).strftime('%H:%M')}"
+          when 'day'
+            date.strftime('%a %m/%d')
+          when 'week'
+            days_to_monday = date.wday.zero? ? 6 : date.wday - 1
+            days_to_sunday = date.wday.zero? ? 0 : 7 - date.wday
+            start = (date - (days_to_monday * 24 * 60 * 60)).strftime('%a %m/%d')
+            stop  = (date + (days_to_sunday * 24 * 60 * 60)).strftime('%a %m/%d')
+            "#{start} – #{stop}"
+          when 'month'
+            date.strftime('%B %Y')
+          when 'year'
+            date.strftime('%Y')
+          else
+            date.strftime('%Y-%m-%d %H:%M')
+          end
+        end
+
+        # Output divider
+        #
+        def ___
+          ('─' * Helpers.width).ansi(:faint)
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/response.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/ansi/response.rb
@@ -1,0 +1,72 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module OpenSearch
+  module Extensions
+    module ANSI
+      # Wrapper for the OpenSearch response body, which adds a {#to_ansi} method
+      #
+      class ResponseBody < DelegateClass(Hash)
+        # Return a [colorized and formatted](http://en.wikipedia.org/wiki/ANSI_escape_code)
+        # representation of the OpenSearch response for:
+        #
+        # * Search results (hits and highlights)
+        # * Facets (terms, statistical, histogram, date_histogram)
+        # * Analyze API output
+        # * Shard allocation
+        #
+        # @example Display formatted search results
+        #
+        #     require 'opensearch/extensions/ansi'
+        #     puts OpenSearch::Client.new.search.to_ansi
+        #
+        # @todo Add all facets and handlers for remaining response parts / types
+        #
+        def to_ansi(options = {})
+          output = Actions.public_methods.select do |m|
+            m.to_s =~ /^display_/
+          end.map do |m|
+            Actions.send(m, self, options)
+          end
+
+          if output.compact.empty?
+            respond_to?(:awesome_inspect) ? awesome_inspect : inspect
+          else
+            output.compact.join("\n")
+          end
+        end
+      end
+    end
+  end
+end
+
+module OpenSearch
+  module Transport
+    module Transport
+      class Response
+        # Wrap the response body in the {Extensions::ANSI::ResponseBody} class
+        #
+        def body_to_ansi
+          Extensions::ANSI::ResponseBody.new @body
+        end
+
+        alias body_original body
+        alias body body_to_ansi
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/backup.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/backup.rb
@@ -1,0 +1,192 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+require 'pathname'
+require 'fileutils'
+
+require 'multi_json'
+
+begin
+  require 'oj'
+rescue LoadError
+  warn('The "oj" gem could not be loaded. JSON parsing and serialization performance may not be optimal.')
+end
+
+begin
+  require 'patron'
+rescue LoadError
+  warn('The "patron" gem could not be loaded. HTTP requests may not be performed optimally.')
+end
+
+require 'elasticsearch'
+
+module Backup
+  module Database
+    # Integration with the Backup gem [http://backup.github.io/backup/v4/]
+    #
+    # This extension allows to backup OpenSearch indices as flat JSON files on the disk.
+    #
+    # @example Use the Backup gem's DSL to configure the backup
+    #
+    #     require 'opensearch/extensions/backup'
+    #
+    #     Model.new(:elasticsearch_backup, 'OpenSearch') do
+    #
+    #       database OpenSearch do |db|
+    #         db.url     = 'http://localhost:9200'
+    #         db.indices = 'articles,people'
+    #         db.size    = 500
+    #         db.scroll  = '10m'
+    #       end
+    #
+    #       store_with Local do |local|
+    #         local.path = '/tmp/backups'
+    #         local.keep = 3
+    #       end
+    #
+    #       compress_with Gzip
+    #     end
+    #
+    # Perform the backup with the Backup gem's command line utility:
+    #
+    #     $ backup perform -t elasticsearch_backup
+    #
+    # The Backup gem can store your backup files on S3, Dropbox and other
+    # cloud providers, send notifications about the operation, and so on;
+    # read more in the gem documentation.
+    #
+    # @example Use the integration as a standalone script (eg. in a Rake task)
+    #
+    #     require 'backup'
+    #     require 'opensearch/extensions/backup'
+    #
+    #     Backup::Logger.configure do
+    #       logfile.enabled   = true
+    #       logfile.log_path  = '/tmp/backups/log'
+    #     end; Backup::Logger.start!
+    #
+    #     backup  = Backup::Model.new(:elasticsearch, 'Backup OpenSearch') do
+    #       database Backup::Database::OpenSearch do |db|
+    #         db.indices = 'test'
+    #       end
+    #
+    #       store_with Backup::Storage::Local do |local|
+    #         local.path = '/tmp/backups'
+    #       end
+    #     end
+    #
+    #     backup.perform!
+    #
+    # @example A simple recover script for the backup created in the previous examples
+    #
+    #     PATH = '/path/to/backup/'
+    #
+    #     require 'elasticsearch'
+    #     client  = OpenSearch::Client.new log: true
+    #     payload = []
+    #
+    #     Dir[ File.join( PATH, '**', '*.json' ) ].each do |file|
+    #       document = MultiJson.load(File.read(file))
+    #       item = document.merge(data: document['_source'])
+    #       document.delete('_source')
+    #       document.delete('_score')
+    #
+    #       payload << { index: item }
+    #
+    #       if payload.size == 100
+    #         client.bulk body: payload
+    #         payload = []
+    #       end
+    #
+    #       client.bulk body: payload
+    #     end
+    #
+    # @see http://backup.github.io/backup/v4/
+    #
+    class OpenSearch < Base
+      class Error < ::Backup::Error; end
+
+      attr_accessor :url, :indices, :size, :scroll, :mode
+
+      def initialize(model, database_id = nil, &)
+        super
+
+        @url     ||= 'http://localhost:9200'
+        @indices ||= '_all'
+        @size    ||= 100
+        @scroll  ||= '10m'
+        @mode    ||= 'single'
+
+        instance_eval(&) if block
+      end
+
+      def perform!
+        super
+
+        case mode
+        when 'single'
+          __perform_single
+        else
+          raise Error, "Unsupported mode [#{mode}]"
+        end
+
+        log!(:finished)
+      end
+
+      def client
+        @client ||= ::OpenSearch::Client.new url:, logger:
+      end
+
+      def path
+        Pathname.new File.join(dump_path, dump_filename.downcase)
+      end
+
+      def logger
+        logger = Backup::Logger.__send__(:logger)
+        logger.instance_eval do
+          def debug(*args); end
+          # alias :debug :info
+          alias :fatal :warn
+        end
+        logger
+      end
+
+      def __perform_single
+        r = client.search(index: indices, search_type: 'scan', scroll:, size:)
+        raise Error, "No scroll_id returned in response:\n#{r.inspect}" unless r['_scroll_id']
+
+        while ((r = client.scroll(scroll_id: r['_scroll_id'], scroll:))) && !r['hits']['hits'].empty?
+          r['hits']['hits'].each do |hit|
+            FileUtils.mkdir_p path.join(hit['_index'], hit['_type']).to_s
+            File.write("#{path.join hit['_index'], hit['_type'], __sanitize_filename(hit['_id'])}.json", MultiJson.dump(hit))
+          end
+        end
+      end
+
+      def __sanitize_filename(name)
+        name
+          .encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '�')
+          .strip
+          .tr("\u{202E}%$|:;/\t\r\n\\", '-')
+      end
+    end
+  end
+end
+
+Backup::Config::DSL::OpenSearch = Backup::Database::OpenSearch

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/reindex.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/reindex.rb
@@ -1,0 +1,186 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# encoding: utf-8
+
+module OpenSearch
+  module Extensions
+    # This module allows copying documents from one index/cluster to another one
+    #
+    # When required together with the client, it will add the `reindex` method
+    #
+    # @see Reindex::Reindex.initialize
+    # @see Reindex::Reindex#perform
+    #
+    # @see http://www.rubydoc.info/gems/elasticsearch-api/OpenSearch/API/Actions#reindex-instance_method
+    #
+    module Reindex
+      # Initialize a new instance of the Reindex class (shortcut)
+      #
+      # @see Reindex::Reindex.initialize
+      #
+      def new(arguments = {})
+        Reindex.new(arguments)
+      end; extend self
+
+      module API
+        # Copy documents from one index into another and refresh the destination index
+        #
+        # @example
+        #     client.reindex source: { index: 'test1' }, dest: { index: 'test2' }, refresh: true
+        #
+        # The method allows all the options as {Reindex::Reindex.new}.
+        #
+        # This method will be mixed into the OpenSearch client's API, if available.
+        #
+        def reindex(arguments = {})
+          arguments[:source] ||= {}
+          arguments[:source][:client] = self
+          Reindex.new(arguments).perform
+        end
+      end
+
+      # Include the `reindex` method in the API and client, if available
+      OpenSearch::API::Actions.include API if defined?(OpenSearch::API::Actions)
+      OpenSearch::Transport::Client.include API if defined?(OpenSearch::Transport::Client) && defined?(OpenSearch::API)
+
+      # Copy documents from one index into another
+      #
+      # @example Copy documents to another index
+      #
+      #   client  = OpenSearch::Client.new
+      #   reindex = OpenSearch::Extensions::Reindex.new \
+      #               source: { index: 'test1', client: client },
+      #               dest: { index: 'test2' }
+      #
+      #   reindex.perform
+      #
+      # @example Copy documents to a different cluster
+      #
+      #     source_client  = OpenSearch::Client.new url: 'http://localhost:9200'
+      #     destination_client  = OpenSearch::Client.new url: 'http://localhost:9250'
+      #
+      #     reindex = OpenSearch::Extensions::Reindex.new \
+      #                 source: { index: 'test', client: source_client },
+      #                 dest: { index: 'test', client: destination_client }
+      #     reindex.perform
+      #
+      # @example Transform the documents during re-indexing
+      #
+      #     reindex = OpenSearch::Extensions::Reindex.new \
+      #                 source: { index: 'test1', client: client },
+      #                 dest: { index: 'test2' },
+      #                 transform: lambda { |doc| doc['_source']['category'].upcase! }
+      #
+      #
+      # The reindexing process works by "scrolling" an index and sending
+      # batches via the "Bulk" API to the destination index/cluster
+      #
+      # @option arguments [String] :source The source index/cluster definition (*Required*)
+      # @option arguments [String] :dest The destination index/cluster definition (*Required*)
+      # @option arguments [Proc] :transform A block which will be executed for each document
+      # @option arguments [Integer] :batch_size The size of the batch for scroll operation (Default: 1000)
+      # @option arguments [String] :scroll The timeout for the scroll operation (Default: 5min)
+      # @option arguments [Boolean] :refresh Whether to refresh the destination index after
+      #                                      the operation is completed (Default: false)
+      #
+      # Be aware, that if you want to change the destination index settings and/or mappings,
+      # you have to do so in advance by using the "Indices Create" API.
+      #
+      # Note, that there is a native "Reindex" API in OpenSearch 2.3.x and higer versions,
+      # which will be more performant than the Ruby version.
+      #
+      # @see http://www.rubydoc.info/gems/elasticsearch-api/OpenSearch/API/Actions#reindex-instance_method
+      #
+      class Reindex
+        attr_reader :arguments
+
+        def initialize(arguments = {})
+          [
+            %i[source index],
+            %i[source client],
+            %i[dest index],
+          ].each do |required_option|
+            value = required_option.reduce(arguments) { |sum, o| sum[o] || {} }
+
+            if value.respond_to?(:empty?) ? value.empty? : value.nil?
+              raise ArgumentError,
+                    "Required argument '#{Hash[*required_option]}' missing"
+            end
+          end
+
+          @arguments = {
+            batch_size: 1000,
+            scroll: '5m',
+            refresh: false,
+          }.merge(arguments)
+
+          arguments[:dest][:client] ||= arguments[:source][:client]
+        end
+
+        # Performs the operation
+        #
+        # @return [Hash] A Hash with the information about the operation outcome
+        #
+        def perform
+          output = { errors: 0 }
+
+          response = arguments[:source][:client].search(
+            index: arguments[:source][:index],
+            scroll: arguments[:scroll],
+            size: arguments[:batch_size],
+          )
+
+          documents = response['hits']['hits']
+
+          unless documents.empty?
+            bulk_response = __store_batch(documents)
+            output[:errors] += bulk_response['items'].count { |k, _v| k.values.first['error'] }
+          end
+
+          while (response = arguments[:source][:client].scroll(scroll_id: response['_scroll_id'], scroll: arguments[:scroll]))
+            documents = response['hits']['hits']
+            break if documents.empty?
+
+            bulk_response = __store_batch(documents)
+            output[:errors] += bulk_response['items'].count { |k, _v| k.values.first['error'] }
+          end
+
+          arguments[:dest][:client].indices.refresh index: arguments[:dest][:index] if arguments[:refresh]
+
+          output
+        end
+
+        def __store_batch(documents)
+          body = documents.map do |doc|
+            doc['_index'] = arguments[:dest][:index]
+
+            arguments[:transform]&.call(doc)
+
+            doc['data'] = doc['_source']
+            doc.delete('_score')
+            doc.delete('_source')
+
+            { index: doc }
+          end
+
+          arguments[:dest][:client].bulk body:
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster.rb
@@ -1,0 +1,617 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'timeout'
+require 'net/http'
+require 'fileutils'
+require 'socket'
+require 'uri'
+require 'json'
+require 'ansi'
+require 'debug'
+$stdout.sync = true
+$stderr.sync = true
+
+class String
+  # Redefine the ANSI method: do not print ANSI when not running in the terminal
+  #
+  def ansi(*args)
+    $stdout.tty? ? ANSI.ansi(self, *args) : self
+  end
+end
+
+module OpenSearch
+  module Extensions
+    module Test
+      # A convenience Ruby class for starting and stopping an OpenSearch cluster,
+      # eg. for integration tests
+      #
+      # @example Start a cluster with default configuration,
+      #          assuming `elasticsearch` is on $PATH.
+      #
+      #      require 'opensearch/extensions/test/cluster'
+      #      OpenSearch::Extensions::Test::Cluster.start
+      #
+      # @example Start a cluster with a specific OpenSearch launch script,
+      #          eg. from a downloaded `.tar.gz` distribution
+      #
+      #      system 'wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.1.tar.gz'
+      #      system 'tar -xvf elasticsearch-5.1.1.tar.gz'
+      #
+      #      require 'opensearch/extensions/test/cluster'
+      #      OpenSearch::Extensions::Test::Cluster.start command: 'elasticsearch-5.1.1/bin/elasticsearch'
+      #
+      # @see Cluster#initialize
+      #
+      module Cluster
+        # Starts a cluster
+        #
+        # @see Cluster#start
+        #
+        def start(arguments = {})
+          Cluster.new(arguments).start
+        end
+
+        # Stops a cluster
+        #
+        # @see Cluster#stop
+        #
+        def stop(arguments = {})
+          Cluster.new(arguments).stop
+        end
+
+        # Returns true when a specific test node is running within the cluster
+        #
+        # @see Cluster#running?
+        #
+        def running?(arguments = {})
+          Cluster.new(arguments).running?
+        end
+
+        # Waits until the cluster is green and prints information
+        #
+        # @see Cluster#wait_for_green
+        #
+        def wait_for_green(arguments = {})
+          Cluster.new(arguments).wait_for_green
+        end
+
+        module_function :start, :stop, :running?, :wait_for_green
+
+        class Cluster
+          attr_reader :arguments
+
+          COMMANDS = {
+            '2.13' => lambda { |arguments, node_number|
+              <<-COMMAND.gsub('                ', '').gsub(/\n$/, '')
+                #{arguments[:command]} \
+                -E cluster.name=#{arguments[:cluster_name]} \
+                -E node.name=#{arguments[:node_name]}-#{node_number} \
+                -E http.port=#{arguments[:port].to_i + (node_number - 1)} \
+                -E path.data=#{arguments[:path_data]} \
+                -E path.logs=#{arguments[:path_logs]} \
+                -E cluster.routing.allocation.disk.threshold_enabled=false \
+                -E network.host=#{arguments[:network_host]} \
+                -E node.attr.testattr=test \
+                -E path.repo=/tmp \
+                -E repositories.url.allowed_urls=http://snapshot.test* \
+                #{"-E discovery.type=single-node" if arguments[:number_of_nodes] < 2} \
+                -E discovery.seed_hosts=#{arguments[:number_of_nodes] - 1} \
+                -E node.max_local_storage_nodes=#{arguments[:number_of_nodes]} \
+                -E logger.level=#{ENV['DEBUG'] ? 'DEBUG' : 'INFO'} \
+                #{arguments[:es_params]}
+              COMMAND
+            },
+            '2.14' => lambda { |arguments, node_number|
+              <<-COMMAND.gsub('                ', '').gsub(/\n$/, '')
+                #{arguments[:command]} \
+                -E cluster.name=#{arguments[:cluster_name]} \
+                -E node.name=#{arguments[:node_name]}-#{node_number} \
+                -E http.port=#{arguments[:port].to_i + (node_number - 1)} \
+                -E path.data=#{arguments[:path_data]} \
+                -E path.logs=#{arguments[:path_logs]} \
+                -E cluster.routing.allocation.disk.threshold_enabled=false \
+                -E network.host=#{arguments[:network_host]} \
+                -E node.attr.testattr=test \
+                -E path.repo=/tmp \
+                -E repositories.url.allowed_urls=http://snapshot.test* \
+                #{"-E discovery.type=single-node" if arguments[:number_of_nodes] < 2} \
+                -E discovery.seed_hosts=#{arguments[:number_of_nodes] - 1} \
+                -E node.max_local_storage_nodes=#{arguments[:number_of_nodes]} \
+                -E logger.level=#{ENV['DEBUG'] ? 'DEBUG' : 'INFO'} \
+                #{arguments[:es_params]}
+              COMMAND
+            },
+          }.freeze
+
+          # Create a new instance of the Cluster class
+          #
+          # @option arguments [String]  :cluster_name Cluster name (default: `opensearch_test`)
+          # @option arguments [Integer] :number_of_nodes Number of desired nodes (default: 2)
+          # @option arguments [String]  :command      OpenSearch command (default: `opensearch`)
+          # @option arguments [String]  :port         Starting port number; will be auto-incremented (default: 9250)
+          # @option arguments [String]  :node_name    The node name (will be appended with a number)
+          # @option arguments [String]  :path_data    Path to the directory to store data in
+          # @option arguments [String]  :path_work    Path to the directory with auxiliary files
+          # @option arguments [String]  :path_logs    Path to the directory with log files
+          # @option arguments [Boolean] :multicast_enabled Whether multicast is enabled (default: true)
+          # @option arguments [Integer] :timeout      Timeout when starting the cluster (default: 60)
+          # @option arguments [Integer] :timeout_version Timeout when waiting for `elasticsearch --version` (default: 2.13.0)
+          # @option arguments [String]  :network_host The host that nodes will bind on and publish to
+          # @option arguments [Boolean] :clear_cluster Wipe out cluster content on startup (default: true)
+          # @option arguments [Boolean] :quiet         Disable printing to STDERR (default: false)
+          #
+          # You can also use environment variables to set the constructor options (see source).
+          #
+          # @see Cluster#start
+          #
+          def initialize(arguments = {})
+            @arguments = arguments.dup
+
+            @arguments[:command]           ||= ENV.fetch('TEST_CLUSTER_COMMAND',   'opensearch')
+            @arguments[:port]              ||= ENV.fetch('TEST_CLUSTER_PORT',      9250).to_i
+            @arguments[:cluster_name]      ||= ENV.fetch('TEST_CLUSTER_NAME',      __default_cluster_name).chomp
+            @arguments[:node_name]         ||= ENV.fetch('TEST_CLUSTER_NODE_NAME', 'node')
+            @arguments[:path_data]         ||= ENV.fetch('TEST_CLUSTER_DATA',      '/tmp/opensearch_test')
+            @arguments[:path_work]         ||= ENV.fetch('TEST_CLUSTER_TMP',       '/tmp')
+            @arguments[:path_logs]         ||= ENV.fetch('TEST_CLUSTER_LOGS',      '/tmp/log/opensearch')
+            @arguments[:es_params]         ||= ENV.fetch('TEST_CLUSTER_PARAMS',    '')
+            @arguments[:multicast_enabled] ||= ENV.fetch('TEST_CLUSTER_MULTICAST', 'true')
+            @arguments[:timeout]           ||= ENV.fetch('TEST_CLUSTER_TIMEOUT',   60).to_i
+            @arguments[:timeout_version]   ||= ENV.fetch('TEST_CLUSTER_TIMEOUT_VERSION', '2.13.0').to_i
+            @arguments[:number_of_nodes]   ||= ENV.fetch('TEST_CLUSTER_NODES', 2).to_i
+            @arguments[:network_host]      ||= ENV.fetch('TEST_CLUSTER_NETWORK_HOST', __default_network_host)
+            @arguments[:quiet]             ||= !ENV.fetch('QUIET', '').empty?
+
+            @clear_cluster = if @arguments[:clear_cluster].nil?
+                               (ENV.fetch('TEST_CLUSTER_CLEAR', 'true') != 'false')
+                             else
+                               !!@arguments[:clear_cluster]
+                             end
+
+            # Make sure `cluster_name` is not dangerous
+            raise ArgumentError, 'The `cluster_name` argument cannot be empty string or a slash' \
+              if %r{^[/\\]?$}.match?(@arguments[:cluster_name])
+          end
+
+          # Starts a cluster
+          #
+          # Launches the specified number of nodes in a test-suitable configuration and prints
+          # information about the cluster -- unless this specific cluster is already running.
+          #
+          # @example Start a cluster with the default configuration (2 nodes, installed version, etc)
+          #      OpenSearch::Extensions::Test::Cluster::Cluster.new.start
+          #
+          # @example Start a cluster with a custom configuration
+          #      OpenSearch::Extensions::Test::Cluster::Cluster.new(
+          #        cluster_name: 'my-cluster',
+          #        number_of_nodes: 3,
+          #        node_name: 'my-node',
+          #        port: 9350
+          #      ).start
+          #
+          # @example Start a cluster with a different OpenSearch version
+          #      OpenSearch::Extensions::Test::Cluster::Cluster.new(
+          #        command: "/usr/local/Cellar/elasticsearch/1.0.0.Beta2/bin/elasticsearch"
+          #      ).start
+          #
+          # @return Boolean,Array
+          # @see Cluster#stop
+          #
+          def start
+            if running?
+              __log '[!] OpenSearch cluster already running'.ansi(:red)
+              return false
+            end
+
+            __remove_cluster_data if @clear_cluster
+
+            __log 'Starting '.ansi(:faint) + arguments[:number_of_nodes].to_s.ansi(:bold, :faint) +
+                  " OpenSearch #{arguments[:number_of_nodes] < 2 ? 'node' : 'nodes'}..".ansi(:faint),
+                  :print
+
+            pids = []
+
+            __log "\nUsing OpenSearch version [#{version}]" if ENV['DEBUG']
+
+            arguments[:number_of_nodes].times do |n|
+              n += 1
+
+              command =  __command(version, arguments, n)
+              command += '> /dev/null' unless ENV['DEBUG']
+
+              __log command.gsub(/ {1,}/, ' ').ansi(:bold) if ENV['DEBUG']
+
+              pid = Process.spawn(command)
+              Process.detach pid
+              pids << pid
+              sleep 1
+            end
+
+            __check_for_running_processes(pids)
+            wait_for_green
+            __log __cluster_info
+
+            true
+          end
+
+          # Stops the cluster
+          #
+          # Fetches the PID numbers from "Nodes Info" API and terminates matching nodes.
+          #
+          # @example Stop the default cluster
+          #      OpenSearch::Extensions::Test::Cluster::Cluster.new.stop
+          #
+          # @example Stop the cluster reachable on specific port
+          #      OpenSearch::Extensions::Test::Cluster::Cluster.new(port: 9350).stop
+          #
+          # @return Boolean,Array
+          # @see Cluster#start
+          #
+          def stop
+            begin
+              nodes = __get_nodes
+            rescue Exception => e
+              __log "[!] Exception raised when stopping the cluster: #{e.inspect}".ansi(:red)
+              nil
+            end
+
+            return false if nodes.blank?
+
+            pids = nodes['nodes'].map { |_id, info| info['process']['id'] }
+
+            return false if pids.empty?
+
+            __log 'Stopping OpenSearch nodes... '.ansi(:faint), :print
+
+            pids.each_with_index do |pid, _i|
+              %w[INT KILL].each do |signal|
+                begin
+                  Process.kill signal, pid
+                rescue Exception => e
+                  __log "[#{e.class}] PID #{pid} not found. ".ansi(:red), :print
+                end
+
+                # Give the system some breathing space to finish...
+                Kernel.sleep 1
+
+                # Check that pid really is dead
+                begin
+                  Process.getpgid pid
+                  # `getpgid` will raise error if pid is dead, so if we get here, try next signal
+                  next
+                rescue Errno::ESRCH
+                  __log "Stopped PID #{pid}".ansi(:green) +
+                        (ENV['DEBUG'] ? " with #{signal} signal".ansi(:green) : '') +
+                        '. '.ansi(:green),
+                        :print
+                  break # pid is dead
+                end
+              end
+            end
+
+            __log "\n"
+
+            pids
+          end
+
+          # Returns true when a specific test node is running within the cluster
+          #
+          # @return Boolean
+          #
+          def running?
+            if (cluster_health = begin
+              Timeout.timeout(0.25) { __get_cluster_health }
+            rescue StandardError
+              nil
+            end)
+              return cluster_health['cluster_name']    == arguments[:cluster_name] &&
+                     cluster_health['number_of_nodes'] == arguments[:number_of_nodes]
+            end
+            false
+          end
+
+          # Waits until the cluster is green and prints information about it
+          #
+          # @return Boolean
+          #
+          def wait_for_green
+            __wait_for_status('green', arguments[:timeout])
+          end
+
+          # Returns the major version of OpenSearch
+          #
+          # @return String
+          # @see __determine_version
+          #
+          def version
+            @version ||= __determine_version
+          end
+
+          # Returns default `:network_host` setting based on the version
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __default_network_host
+            case version
+            when /^2/
+              '0.0.0.0'
+            else
+              '_local_'
+            end
+          end
+
+          # Returns a reasonably unique cluster name
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __default_cluster_name
+            "opensearch-test-#{Socket.gethostname.downcase}"
+          end
+
+          # Returns the HTTP URL for the cluster based on `:network_host` setting
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __cluster_url
+            if arguments[:network_host] == '_local_'
+              "http://localhost:#{arguments[:port]}"
+            else
+              "http://#{arguments[:network_host]}:#{arguments[:port]}"
+            end
+          end
+
+          # Determine OpenSearch version to be launched
+          #
+          # Tries to get the version from the arguments passed,
+          # if not available, it parses the version number from the `lib/elasticsearch-X.Y.Z.jar` file,
+          # if that is not available, uses `elasticsearch --version` or `elasticsearch -v`
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __determine_version
+            path_to_lib = "#{File.dirname(arguments[:command])}/../lib/"
+            version = if arguments[:version]
+                        arguments[:version]
+                      else
+                        if ENV['DEBUG']
+                          __log "[!] Cannot find OpenSearch .jar from path to command [#{arguments[:command]}], using `#{arguments[:command]} --version`"
+                        end
+
+                        unless File.exist? arguments[:command]
+                          __log "File [#{arguments[:command]}] does not exists, checking full path by `which`: ", :print if ENV['DEBUG']
+
+                          begin
+                            full_path = `which #{arguments[:command]}`.strip
+                            __log "#{full_path.inspect}\n", :print if ENV['DEBUG']
+                          rescue Exception
+                            raise "Cannot determine full path to [#{arguments[:command]}] with 'which'"
+                          end
+
+                          if full_path.empty?
+                            raise Errno::ENOENT, "Cannot find OpenSearch launch script from [#{arguments[:command]}] -- did you pass a correct path?"
+                          end
+                        end
+
+                        output = ''
+
+                        begin
+                          # First, try the new `--version` syntax...
+                          __log "Running [#{arguments[:command]} --version] to determine version" if ENV['DEBUG']
+                          io = IO.popen("#{arguments[:command]} --version")
+                          pid = io.pid
+
+                          Timeout.timeout(arguments[:timeout_version]) do
+                            Process.wait(pid)
+                            output = io.read
+                          end
+                        rescue Timeout::Error
+                          # ...else, the old `-v` syntax
+                          __log "Running [#{arguments[:command]} -v] to determine version" if ENV['DEBUG']
+                          output = `#{arguments[:command]} -V`
+                        ensure
+                          if pid
+                            begin
+                              Process.kill('INT', pid)
+                            rescue StandardError
+                              Errno::ESRCH
+                            end
+                          end
+                          io.close unless io.closed?
+                        end
+
+                        warn "> #{output}" if ENV['DEBUG']
+
+                        if output.empty?
+                          raise "Cannot determine OpenSearch version from [#{arguments[:command]} --version] or [#{arguments[:command]} -v]"
+                        end
+
+                        @dist = output.match(%r{Build: ([a-z]+)/})&.[](1)
+
+                        unless (m = output.match(/Version: (\d+\.\d+.\d+).*,/))
+                          raise "Cannot determine OpenSearch version from opensearch --version output [#{output}]"
+                        end
+
+                        m[1]
+
+                      end
+
+            return version.split(".")[0..1].join(".")
+          end
+
+          # Returns the launch command for a specific version
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __command(version, arguments, node_number)
+            raise ArgumentError, "Cannot find command for version [#{version}]" unless (command = COMMANDS[version])
+
+            arguments[:dist] = @dist
+            command.call(arguments, node_number)
+          end
+
+          # Blocks the process and waits for the cluster to be in a "green" state
+          #
+          # Prints information about the cluster on STDOUT if the cluster is available.
+          #
+          # @param status  [String]  The status to wait for (yellow, green)
+          # @param timeout [Integer] The explicit timeout for the operation
+          #
+          # @api private
+          #
+          # @return Boolean
+          #
+          def __wait_for_status(status = 'green', timeout = 30)
+            begin
+              Timeout.timeout(timeout) do
+                loop do
+                  response = __get_cluster_health(status)
+                  __log response if ENV['DEBUG']
+
+                  if response && response['status'] == status && (arguments[:number_of_nodes].nil? || arguments[:number_of_nodes].to_i == response['number_of_nodes'].to_i)
+                    break
+                  end
+
+                  __log '.'.ansi(:faint), :print
+                  sleep 1
+                end
+              end
+            rescue Timeout::Error => e
+              message = "\nTimeout while waiting for cluster status [#{status}]"
+              message += " and [#{arguments[:number_of_nodes]}] nodes" if arguments[:number_of_nodes]
+              __log message.ansi(:red, :bold)
+              raise e
+            end
+
+            true
+          end
+
+          # Return information about the cluster
+          #
+          # @api private
+          #
+          # @return String
+          #
+          def __cluster_info
+            health = JSON.parse(Net::HTTP.get(URI("#{__cluster_url}/_cluster/health")))
+            nodes  = if version == '0.90'
+                       JSON.parse(Net::HTTP.get(URI("#{__cluster_url}/_nodes/?process&http")))
+                     else
+                       JSON.parse(Net::HTTP.get(URI("#{__cluster_url}/_nodes/process,http")))
+                     end
+            master = JSON.parse(Net::HTTP.get(URI("#{__cluster_url}/_cluster/state")))['master_node']
+
+            result = [
+              "\n",
+              ('-' * 80).ansi(:faint),
+              'Cluster: '.ljust(20).ansi(:faint) + health['cluster_name'].to_s.ansi(:faint),
+              'Status:  '.ljust(20).ansi(:faint) + health['status'].to_s.ansi(:faint),
+              'Nodes:   '.ljust(20).ansi(:faint) + health['number_of_nodes'].to_s.ansi(:faint),
+            ].join("\n")
+
+            nodes['nodes'].each do |id, info|
+              m = id == master ? '*' : '-'
+              result << ("\n" +
+                        ''.ljust(20) +
+                        "#{m} ".ansi(:faint) +
+                        "#{info['name'].ansi(:bold)} ".ansi(:faint) +
+                        "| version: #{begin
+                          info['version']
+                        rescue StandardError
+                          'N/A'
+                        end}, ".ansi(:faint) +
+                        "pid: #{begin
+                          info['process']['id']
+                        rescue StandardError
+                          'N/A'
+                        end}, ".ansi(:faint) +
+                        "address: #{begin
+                          info['http']['bound_address']
+                        rescue StandardError
+                          'N/A'
+                        end}".ansi(:faint))
+            end
+
+            result
+          end
+
+          # Tries to load cluster health information
+          #
+          # @api private
+          #
+          # @return Hash,Nil
+          #
+          def __get_cluster_health(status = nil)
+            uri = URI("#{__cluster_url}/_cluster/health")
+            uri.query = "wait_for_status=#{status}" if status
+
+            begin
+              response = Net::HTTP.get(uri)
+            rescue Exception => e
+              warn e.inspect if ENV['DEBUG']
+              return nil
+            end
+            JSON.parse(response)
+          end
+
+          # Remove the data directory
+          #
+          # @api private
+          #
+          def __remove_cluster_data
+            FileUtils.rm_rf arguments[:path_data]
+          end
+
+          # Check whether process for PIDs are running
+          #
+          # @api private
+          #
+          def __check_for_running_processes(pids)
+            return unless `ps -p #{pids.join(' ')}`.split("\n").size < arguments[:number_of_nodes] + 1
+
+            __log "\n[!!!] Process failed to start (see output above)".ansi(:red)
+            exit(1)
+          end
+
+          # Get the information about nodes
+          #
+          # @api private
+          #
+          def __get_nodes
+            JSON.parse(Net::HTTP.get(URI("#{__cluster_url}/_nodes/process")))
+          end
+
+          # Print to STDERR
+          #
+          def __log(message, mode = :puts)
+            $stderr.__send__ mode, message unless @arguments[:quiet]
+          end
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster/tasks.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster/tasks.rb
@@ -1,0 +1,30 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'opensearch/extensions/test/cluster'
+
+namespace :opensearch do
+  desc 'Start OpenSearch cluster for tests'
+  task :start do
+    OpenSearch::Extensions::Test::Cluster.start
+  end
+
+  desc 'Stop OpenSearch cluster for tests'
+  task :stop do
+    OpenSearch::Extensions::Test::Cluster.stop
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/test/profiling.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/test/profiling.rb
@@ -1,0 +1,127 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'ruby-prof'
+require 'benchmark'
+require 'ansi'
+
+module OpenSearch
+  module Extensions
+    module Test
+      # Allows to define and execute profiling tests within [Shoulda](https://github.com/thoughtbot/shoulda) contexts.
+      #
+      # Measures operations and reports statistics, including code profile.
+      #
+      # Uses the "benchmark" standard library and the "ruby-prof" gem.
+      #
+      #     File: profiling_test.rb
+      #
+      #     require 'test/unit'
+      #     require 'shoulda/context'
+      #     require 'opensearch/extensions/test/profiling'
+      #
+      #     class ProfilingTest < Test::Unit::TestCase
+      #       extend OpenSearch::Extensions::Test::Profiling
+      #
+      #       context "Mathematics" do
+      #         measure "divide numbers", count: 10_000 do
+      #           assert_nothing_raised { 1/2 }
+      #         end
+      #       end
+      #
+      #     end
+      #
+      #     $ QUIET=y ruby profiling_test.rb
+      #
+      #     ...
+      #     ProfilingTest
+      #
+      #     -------------------------------------------------------------------------------
+      #     Context: Mathematics should divide numbers (10000x)
+      #     mean: 0.03ms | avg: 0.03ms | max: 0.14ms
+      #     -------------------------------------------------------------------------------
+      #          PASS (0:00:00.490) test: Mathematics should divide numbers (10000x).
+      #     ...
+      #
+      module Profiling
+        # Profiles the passed block of code.
+        #
+        #     measure "divide numbers", count: 10_000 do
+        #      assert_nothing_raised { 1/2 }
+        #     end
+        #
+        # @todo Try to make progress bar not to interfere with tests
+        #
+        def measure(name, options = {}, &block)
+          ___          = '-' * ANSI::Terminal.terminal_width
+          test_name    = name
+          suite_name   = self.name.split('::').last
+          context_name = context(nil) {}.first.parent.name
+          count        = Integer(ENV['COUNT'] || options[:count] || 1_000)
+          ticks        = []
+          progress     = ANSI::Progressbar.new(suite_name, count) unless ENV['QUIET'] || options[:quiet]
+
+          should "#{test_name} (#{count}x)" do
+            RubyProf.start
+
+            begin
+              count.times do
+                ticks << Benchmark.realtime { instance_eval(&block) }
+
+                next unless progress
+
+                RubyProf.pause
+                progress.inc
+                RubyProf.resume
+              end
+            ensure
+              result = RubyProf.stop
+              progress&.finish
+            end
+
+            total = result.threads.reduce(0) do |t, info|
+              t += info.total_time
+              t
+            end
+            mean  = ticks.sort[(ticks.size / 2).round - 1] * 1000
+            avg   = (ticks.inject { |sum, el|
+                       sum += el
+                       sum
+                     }.to_f / ticks.size) * 1000
+            min   = ticks.min * 1000
+            max   = ticks.max * 1000
+
+            result.eliminate_methods!([/Integer#times|Benchmark.realtime|ANSI::Code#.*|ANSI::ProgressBar#.*/])
+            printer = RubyProf::FlatPrinter.new(result)
+            # printer = RubyProf::GraphPrinter.new(result)
+
+            puts "\n",
+                 ___,
+                 "#{suite_name}: #{ANSI.bold(context_name)} should #{ANSI.bold(name)} (#{count}x)",
+                 "total: #{sprintf('%.2f', total)}s | " \
+                 "mean: #{sprintf('%.2f', mean)}ms | " \
+                 "avg: #{sprintf('%.2f',  avg)}ms | " \
+                 "min: #{sprintf('%.2f',  min)}ms | " \
+                 "max: #{sprintf('%.2f',  max)}ms",
+                 ___
+            printer.print($stdout, {}) unless ENV['QUIET'] || options[:quiet]
+          end
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/test/startup_shutdown.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/test/startup_shutdown.rb
@@ -1,0 +1,73 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module OpenSearch
+  module Extensions
+    module Test
+      # Startup/shutdown support for test suites
+      #
+      # Example:
+      #
+      #     class MyTest < Test::Unit::TestCase
+      #       extend OpenSearch::Extensions::Test::StartupShutdown
+      #
+      #       startup  { puts "Suite starting up..." }
+      #       shutdown { puts "Suite shutting down..." }
+      #     end
+      #
+      # *** IMPORTANT NOTE: **********************************************************
+      #
+      # You have to register the handler for shutdown before requiring 'test/unit':
+      #
+      #     # File: test_helper.rb
+      #     at_exit { MyTest.__run_at_exit_hooks }
+      #     require 'test/unit'
+      #
+      # The API follows Test::Unit 2.0
+      # <https://github.com/test-unit/test-unit/blob/master/lib/test/unit/testcase.rb>
+      #
+      module StartupShutdown
+        @@started           = false
+        @@shutdown_blocks ||= []
+
+        def startup(&block)
+          return if started?
+
+          @@started = true
+          yield block if block
+        end
+
+        def shutdown(&block)
+          @@shutdown_blocks << block if block
+        end
+
+        def started?
+          !!@@started
+        end
+
+        def __run_at_exit_hooks
+          return unless started?
+
+          warn ANSI.faint('Running at_exit hooks...')
+          puts ANSI.faint('-' * 80)
+          @@shutdown_blocks.each(&:call)
+          puts ANSI.faint('-' * 80)
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/version.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/version.rb
@@ -1,0 +1,22 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module OpenSearch
+  module Extensions
+    VERSION = '0.0.1'.freeze
+  end
+end

--- a/local_gems/opensearch-extensions/lib/opensearch_extensions.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch_extensions.rb
@@ -1,0 +1,6 @@
+# Licensed to OpenSearch B.V under one or more agreements.
+# OpenSearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+#
+
+require 'opensearch/extensions'

--- a/local_gems/opensearch-extensions/lib/opensearch_extensions.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch_extensions.rb
@@ -1,5 +1,5 @@
-# Licensed to OpenSearch B.V under one or more agreements.
-# OpenSearch B.V licenses this file to you under the Apache 2.0 License.
+# Copied initially from https://rubygems.org/gems/elasticsearch-extensions/versions/0.0.20?locale=en
+# Converted to support OpenSearch and included the Apache 2.0 License.
 # See the LICENSE file in the project root for more information
 #
 

--- a/local_gems/opensearch-extensions/opensearch-extensions.gemspec
+++ b/local_gems/opensearch-extensions/opensearch-extensions.gemspec
@@ -1,0 +1,42 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# coding: utf-8
+
+require 'English'
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opensearch/extensions/version'
+
+Gem::Specification.new do |s|
+  s.name          = 'opensearch-extensions'
+  s.version       = OpenSearch::Extensions::VERSION
+  s.authors       = ['Jon Rogers']
+  s.email         = ['jon@rcode5.com']
+  s.description   = 'Extensions for the OpenSearch Rubygem'
+  s.summary       = 'Extensions for the OpenSearch Rubygem'
+  s.license       = 'Apache-2.0'
+  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.require_paths = ['lib']
+
+  s.add_dependency 'ansi'
+  s.add_dependency 'opensearch-ruby'
+
+  s.metadata['rubygems_mfa_required'] = 'true'
+end

--- a/local_gems/opensearch-extensions/test/ansi/unit/ansi_test.rb
+++ b/local_gems/opensearch-extensions/test/ansi/unit/ansi_test.rb
@@ -1,0 +1,79 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+require 'opensearch/extensions/ansi'
+
+module OpenSearch
+  module Extensions
+    class AnsiTest < OpenSearch::Test::UnitTestCase
+      context 'The ANSI extension' do
+        setup do
+          @client = OpenSearch::Client.new
+          @client.stubs(:perform_request).returns \
+            OpenSearch::Transport::Transport::Response.new(200,
+                                                           {
+                                                             'ok' => true,
+                                                             'status' => 200,
+                                                             'name' => 'Hit-Maker',
+                                                             'version' => {
+                                                               'number' => '0.90.7',
+                                                               'build_hash' => 'abc123',
+                                                               'build_timestamp' => '2013-11-13T12:06:54Z',
+                                                               'build_snapshot' => false,
+                                                               'lucene_version' => '4.5.1',
+                                                             },
+                                                             'tagline' => 'You Know, for Search',
+                                                           })
+        end
+
+        should 'wrap the response' do
+          response = @client.info
+
+          assert_instance_of OpenSearch::Extensions::ANSI::ResponseBody, response
+          assert_instance_of Hash, response.to_hash
+        end
+
+        should 'extend the response object with `to_ansi`' do
+          response = @client.info
+
+          assert_respond_to response, :to_ansi
+          assert_instance_of String, response.to_ansi
+        end
+
+        should "call the 'awesome_inspect' method when available and no handler found" do
+          @client.stubs(:perform_request).returns \
+            OpenSearch::Transport::Transport::Response.new(200, { 'index-1' => { 'aliases' => {} } })
+          response = @client.cat.aliases
+
+          response.instance_eval do
+            def awesome_inspect = '---PRETTY---'
+          end
+          assert_equal '---PRETTY---', response.to_ansi
+        end
+
+        should 'call `to_s` method when no pretty printer or handler found' do
+          @client.stubs(:perform_request).returns \
+            OpenSearch::Transport::Transport::Response.new(200, { 'index-1' => { 'aliases' => {} } })
+          response = @client.cat.aliases
+
+          assert_equal '{"index-1"=>{"aliases"=>{}}}', response.to_ansi
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/backup/unit/backup_test.rb
+++ b/local_gems/opensearch-extensions/test/backup/unit/backup_test.rb
@@ -1,0 +1,132 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+require 'logger'
+
+# Mock the Backup modules and classes so we're not depending on the gem in the unit test
+#
+module Backup
+  class Error < StandardError; end
+
+  class Logger < ::Logger
+    def self.logger
+      new($stderr)
+    end
+  end
+
+  module Config
+    module DSL
+    end
+  end
+
+  module Database
+    class Base
+      def dump_path = 'dump_path'
+      def dump_filename = 'dump_filename'
+
+      def log!(*_args)
+        puts 'LOGGING...' if ENV['DEBUG']
+      end
+
+      def perform!
+        puts 'PERFORMING...' if ENV['DEBUG']
+      end
+    end
+  end
+end
+
+require 'opensearch/extensions/backup'
+require 'debug'
+module OpenSearch
+  module Extensions
+    class BackupTest < OpenSearch::Test::UnitTestCase
+      context 'The Backup gem extension' do
+        setup do
+          @model = stub trigger: true
+          @subject = ::Backup::Database::OpenSearch.new(@model)
+        end
+
+        should 'have a client' do
+          assert_instance_of OpenSearch::Client, @subject.client
+        end
+
+        should 'have a path' do
+          assert_instance_of Pathname, @subject.path
+        end
+
+        should 'have defaults' do
+          assert_equal 'http://localhost:9200', @subject.url
+          assert_equal '_all', @subject.indices
+        end
+
+        should 'be configurable' do
+          @subject = ::Backup::Database::OpenSearch.new(@model) do |db|
+            db.url = 'https://example.com'
+            db.indices = 'foo,bar'
+          end
+
+          assert_equal 'https://example.com', @subject.url
+          assert_equal 'foo,bar', @subject.indices
+        end
+
+        should 'perform the backup' do
+          @subject.expects(:__perform_single)
+          @subject.perform!
+        end
+
+        should 'raise an expection for an unsupported type of backup' do
+          @subject = ::Backup::Database::OpenSearch.new(@model) { |db| db.mode = 'foobar' }
+          assert_raise ::Backup::Database::OpenSearch::Error do
+            @subject.perform!
+          end
+        end
+
+        should 'scan and scroll the index' do
+          @subject = ::Backup::Database::OpenSearch.new(@model) { |db| db.indices = 'test' }
+
+          @subject.client
+                  .expects(:search)
+                  .with do |params|
+            assert_equal 'test', params[:index]
+            true # Thanks, Ruby 2.2
+          end
+            .returns({ '_scroll_id' => 'abc123' })
+
+          @subject.client
+                  .expects(:scroll)
+                  .twice
+                  .returns({
+                             '_scroll_id' => 'def456',
+                             'hits' => { 'hits' => [{ '_index' => 'test', '_type' => 'doc', '_id' => '1', '_source' => { 'title' => 'Test' } }] },
+                           })
+                  .then
+                  .returns({
+                             '_scroll_id' => 'ghi789',
+                             'hits' => { 'hits' => [] },
+                           })
+
+          @subject.__perform_single
+        end
+
+        should 'sanitize filename' do
+          assert_equal 'foo-bar-baz', @subject.__sanitize_filename("foo/bar\nbaz")
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/reindex/integration/reindex_test.rb
+++ b/local_gems/opensearch-extensions/test/reindex/integration/reindex_test.rb
@@ -1,0 +1,110 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+require 'opensearch/extensions/reindex'
+
+module OpenSearch
+  module Extensions
+    class ReindexIntegrationTest < OpenSearch::Test::IntegrationTestCase
+      context 'The Reindex extension' do
+        setup do
+          @port = (ENV['TEST_CLUSTER_PORT'] || 9250).to_i
+
+          @logger = ::Logger.new($stderr)
+          @logger.formatter = proc do |severity, _datetime, _progname, msg|
+            color = case severity
+                    when /INFO/ then :green
+                    when /ERROR|WARN|FATAL/ then :red
+                    when /DEBUG/ then :cyan
+                    else :white
+                    end
+            "#{ANSI.ansi("#{severity[0]} ", color, :faint)}#{ANSI.ansi(msg, :white, :faint)}\n"
+          end
+
+          @client = OpenSearch::Client.new host: "#{TEST_HOST}:#{TEST_PORT}", logger: @logger
+          @client.indices.delete index: '_all'
+
+          @client.index index: 'test1', type: 'd', id: 1, body: { title: 'TEST 1', category: 'one' }
+          @client.index index: 'test1', type: 'd', id: 2, body: { title: 'TEST 2', category: 'two' }
+          @client.index index: 'test1', type: 'd', id: 3, body: { title: 'TEST 3', category: 'three' }
+          @client.indices.refresh index: 'test1'
+
+          @client.indices.create index: 'test2'
+
+          @client.cluster.health wait_for_status: 'yellow'
+        end
+
+        teardown do
+          @client.indices.delete index: '_all'
+        end
+
+        should 'copy documents from one index to another' do
+          reindex = OpenSearch::Extensions::Reindex.new \
+            source: { index: 'test1', client: @client },
+            dest: { index: 'test2' },
+            batch_size: 2,
+            refresh: true
+
+          result = reindex.perform
+
+          assert_equal 0, result[:errors]
+          assert_equal 3, @client.search(index: 'test2')['hits']['total']['value']
+        end
+
+        should 'transform documents with a lambda' do
+          reindex = OpenSearch::Extensions::Reindex.new \
+            source: { index: 'test1', client: @client },
+            dest: { index: 'test2' },
+            transform: ->(d) { d['_source']['category'].upcase! },
+            refresh: true
+
+          result = reindex.perform
+
+          assert_equal 0, result[:errors]
+          assert_equal 3, @client.search(index: 'test2')['hits']['total']['value']
+          assert_equal 'ONE', @client.get(index: 'test2', type: 'd', id: 1)['_source']['category']
+        end
+
+        should 'return the number of errors' do
+          @client.indices.create index: 'test3', body: { mappings: { properties: { category: { type: 'integer' } } } }
+          @client.cluster.health wait_for_status: 'yellow'
+
+          reindex = OpenSearch::Extensions::Reindex.new \
+            source: { index: 'test1', client: @client },
+            dest: { index: 'test3' }
+
+          result = reindex.perform
+
+          @client.indices.refresh index: 'test3'
+
+          assert_equal 3, result[:errors]
+          assert_equal 0, @client.search(index: 'test3')['hits']['total']['value']
+        end
+
+        should 'reindex via the API integration' do
+          @client.indices.create index: 'test4'
+
+          @client.reindex source: { index: 'test1' }, dest: { index: 'test4' }
+          @client.indices.refresh index: 'test4'
+
+          assert_equal 3, @client.search(index: 'test4')['hits']['total']['value']
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/reindex/unit/reindex_test.rb
+++ b/local_gems/opensearch-extensions/test/reindex/unit/reindex_test.rb
@@ -1,0 +1,134 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+require 'opensearch/extensions/reindex'
+
+module OpenSearch
+  module Extensions
+    class ReindexTest < OpenSearch::Test::UnitTestCase
+      context 'The Reindex extension module' do
+        DEFAULT_OPTIONS = { source: { index: 'foo', client: Object.new }, dest: { index: 'bar' } }.freeze
+
+        should 'require options' do
+          assert_raise ArgumentError do
+            OpenSearch::Extensions::Reindex.new
+          end
+        end
+
+        should 'allow to initialize the class' do
+          assert_instance_of OpenSearch::Extensions::Reindex::Reindex,
+                             OpenSearch::Extensions::Reindex.new(DEFAULT_OPTIONS)
+        end
+
+        should 'add the reindex to the API and client' do
+          assert_includes OpenSearch::API::Actions.public_instance_methods.sort, :reindex
+          assert_respond_to OpenSearch::Client.new, :reindex
+        end
+
+        should 'pass the client when used in API mode' do
+          skip('verify open search fails for some reason')
+          client = OpenSearch::Client.new
+
+          OpenSearch::Extensions::Reindex::Reindex
+            .expects(:new)
+            .with({ source: { client: } })
+            .returns(stub(perform: {}))
+
+          client.reindex(body: {})
+        end
+
+        context 'when performing the operation' do
+          setup do
+            d = { '_id' => 'foo', '_type' => 'type', '_source' => { 'foo' => 'bar' } }
+            @default_response = { 'hits' => { 'hits' => [d] } }
+            @empty_response   = { 'hits' => { 'hits' => [] } }
+            @bulk_request     = [
+              {
+                index: {
+                  '_index' => 'bar',
+                  '_type' => d['_type'],
+                  '_id' => d['_id'],
+                  'data' => d['_source'],
+                },
+              },
+            ]
+            @bulk_response = { 'errors' => false, 'items' => [{ 'index' => {} }, { 'index' => {} }] }
+            @bulk_response_error = { 'errors' => true, 'items' => [{ 'index' => {} }, { 'index' => { 'error' => 'FOOBAR' } }] }
+          end
+
+          should 'scroll through the index and save batches in bulk' do
+            client  = mock
+            subject = OpenSearch::Extensions::Reindex.new source: { index: 'foo', client: },
+                                                          dest: { index: 'bar' }
+
+            client.expects(:search)
+                  .returns({ '_scroll_id' => 'scroll_id_1' }.merge(Marshal.load(Marshal.dump(@default_response))))
+            client.expects(:scroll)
+                  .returns(Marshal.load(Marshal.dump(@default_response)))
+                  .then
+                  .returns(@empty_response).times(2)
+            client.expects(:bulk)
+                  .with(body: @bulk_request)
+                  .returns(@bulk_response).times(2)
+
+            result = subject.perform
+
+            assert_equal 0, result[:errors]
+          end
+
+          should 'return the number of errors' do
+            client  = mock
+            subject = OpenSearch::Extensions::Reindex.new source: { index: 'foo', client: },
+                                                          dest: { index: 'bar' }
+
+            client.expects(:search).returns({ '_scroll_id' => 'scroll_id_1' }.merge(@default_response))
+            client.expects(:scroll).returns(@empty_response)
+            client.expects(:bulk).with(body: @bulk_request).returns(@bulk_response_error)
+
+            result = subject.perform
+
+            assert_equal 1, result[:errors]
+          end
+
+          should 'transform the documents with a lambda' do
+            client  = mock
+            subject = OpenSearch::Extensions::Reindex.new \
+              source: { index: 'foo', client: },
+              dest: { index: 'bar' },
+              transform: lambda { |d|
+                           d['_source']['foo'].upcase!
+                           d
+                         }
+
+            client.expects(:search).returns({ '_scroll_id' => 'scroll_id_1' }.merge(@default_response))
+            client.expects(:scroll).returns(@empty_response)
+            client.expects(:bulk).with do |arguments|
+              assert_equal 'BAR', arguments[:body][0][:index]['data']['foo']
+              true
+            end
+                  .returns(@bulk_response)
+
+            result = subject.perform
+
+            assert_equal 0, result[:errors]
+          end
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/test/cluster/integration/cluster_test.rb
+++ b/local_gems/opensearch-extensions/test/test/cluster/integration/cluster_test.rb
@@ -1,0 +1,66 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+require 'pathname'
+
+require 'opensearch/extensions/test/cluster'
+
+module OpenSearch
+  module Extensions
+    class TestClusterIntegrationTest < OpenSearch::Test::IntegrationTestCase
+      context 'The Test::Cluster' do
+        PATH_TO_BUILDS = Pathname(ENV['PATH_TO_BUILDS'] || File.expand_path('../../../../../tmp/builds', __dir__))
+
+        unless PATH_TO_BUILDS.exist?
+          puts "Path to builds doesn't exist, skipping TestClusterIntegrationTest"
+          exit(0)
+        end
+
+        @builds = begin
+          PATH_TO_BUILDS.entries.reject { |f| f.to_s =~ /^\./ }.sort
+        rescue Errno::ENOENT
+          []
+        end
+
+        $stdout.puts %(Builds: \n#{@builds.map { |b| "  * #{b}" }.join("\n")}) unless ENV['QUIET']
+
+        @builds.each do |build|
+          should "start and stop #{build}" do
+            puts ("----- #{build} " + ('-' * (80 - 7 - build.to_s.size))).to_s.ansi(:bold)
+            begin
+              OpenSearch::Extensions::Test::Cluster.start \
+                command: PATH_TO_BUILDS.join(build.join('bin/elasticsearch')).to_s,
+                port: 9260,
+                cluster_name: 'elasticsearch-ext-integration-test',
+                path_data: '/tmp/elasticsearch-ext-integration-test'
+
+              # Index some data to create the data directory
+              client = OpenSearch::Client.new host: 'localhost:9260'
+              client.index index: 'test1', type: 'd', id: 1, body: { title: 'TEST' }
+            ensure
+              OpenSearch::Extensions::Test::Cluster.stop \
+                command: PATH_TO_BUILDS.join(build.join('bin/elasticsearch')).to_s,
+                port: 9260,
+                cluster_name: 'elasticsearch-ext-integration-test'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/test/cluster/unit/cluster_test.rb
+++ b/local_gems/opensearch-extensions/test/test/cluster/unit/cluster_test.rb
@@ -1,0 +1,374 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+require 'opensearch/extensions/test/cluster'
+
+module OpenSearch
+  module Extensions
+    class TestClusterTest < OpenSearch::Test::UnitTestCase
+      include OpenSearch::Extensions::Test
+      context 'The Test::Cluster' do
+        context 'module' do
+          should 'delegate the methods to the class' do
+            Cluster::Cluster
+              .expects(:new)
+              .with({ foo: 'bar' })
+              .returns(mock(start: true, stop: true, running?: true, wait_for_green: true))
+              .times(4)
+
+            OpenSearch::Extensions::Test::Cluster.start foo: 'bar'
+            OpenSearch::Extensions::Test::Cluster.stop foo: 'bar'
+            OpenSearch::Extensions::Test::Cluster.running? foo: 'bar'
+            OpenSearch::Extensions::Test::Cluster.wait_for_green foo: 'bar'
+          end
+        end
+
+        context 'class' do
+          setup do
+            OpenSearch::Extensions::Test::Cluster::Cluster.any_instance.stubs(:__default_network_host).returns('_local_')
+
+            @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new(number_of_nodes: 1)
+            @subject.stubs(:__remove_cluster_data).returns(true)
+          end
+
+          teardown do
+            ENV.delete('TEST_CLUSTER_PORT')
+          end
+
+          should 'be initialized with parameters' do
+            c = Cluster::Cluster.new port: 9400
+
+            assert_equal 9400, c.arguments[:port]
+          end
+
+          should 'not modify the arguments' do
+            args = { port: 9400 }.freeze
+
+            assert_nothing_raised { Cluster::Cluster.new args }
+            assert_nil args[:command]
+          end
+
+          should 'take parameters from environment variables' do
+            ENV['TEST_CLUSTER_PORT'] = '9400'
+
+            c = Cluster::Cluster.new
+
+            assert_equal 9400, c.arguments[:port]
+          end
+
+          should 'raise exception for dangerous cluster name' do
+            assert_raise(ArgumentError) { Cluster::Cluster.new cluster_name: '' }
+            assert_raise(ArgumentError) { Cluster::Cluster.new cluster_name: '/' }
+          end
+
+          should 'have a version' do
+            @subject.unstub(:version)
+            @subject.expects(:__determine_version).returns('2.0')
+            assert_equal '2.0', @subject.version
+          end
+
+          should 'have a default network host' do
+            Cluster::Cluster.any_instance.unstub(:__default_network_host)
+            Cluster::Cluster.any_instance.stubs(:version).returns('5.0')
+
+            assert_equal '_local_', Cluster::Cluster.new.__default_network_host
+          end
+
+          should 'have a default cluster name' do
+            Socket.stubs(:gethostname).returns('FOOBAR')
+
+            assert_equal 'elasticsearch-test-foobar', Cluster::Cluster.new.__default_cluster_name
+          end
+
+          should 'have a cluster URL for new versions' do
+            assert_equal  'http://localhost:9250', Cluster::Cluster.new(network_host: '_local_').__cluster_url
+          end
+
+          should 'have a cluster URL for old versions' do
+            assert_equal  'http://192.168.1.1:9250', Cluster::Cluster.new(network_host: '192.168.1.1').__cluster_url
+          end
+
+          should 'return corresponding command to a version' do
+            assert_match(/-D es\.foreground=yes/, @subject.__command('2.0', @subject.arguments, 1))
+          end
+
+          should 'raise an error when a corresponding command cannot be found' do
+            assert_raise ArgumentError do
+              @subject.__command('FOOBAR', @subject.arguments, 1)
+            end
+          end
+
+          should 'remove cluster data' do
+            @subject.unstub(:__remove_cluster_data)
+            FileUtils.expects(:rm_rf).with('/tmp/opensearch_test')
+
+            @subject.__remove_cluster_data
+          end
+
+          should 'not log when :quiet' do
+            c = Cluster::Cluster.new quiet: true
+
+            $stderr.expects(:puts).never
+            c.__log 'QUIET'
+          end
+
+          context 'when starting a cluster, ' do
+            should "return false when it's already running" do
+              Process.expects(:spawn).never
+
+              c = Cluster::Cluster.new
+
+              c.expects(:running?).returns(true)
+
+              assert_equal false, c.start
+            end
+
+            should 'start the specified number of nodes' do
+              Process.expects(:spawn).times(3)
+              Process.expects(:detach).times(3)
+
+              c = Cluster::Cluster.new number_of_nodes: 3
+
+              c.expects(:running?).returns(false)
+
+              c.unstub(:__remove_cluster_data)
+              c.expects(:__remove_cluster_data).returns(true)
+
+              c.expects(:wait_for_green).returns(true)
+              c.expects(:__check_for_running_processes).returns(true)
+              c.expects(:__determine_version).returns('5.0')
+              c.expects(:__cluster_info).returns('CLUSTER INFO')
+
+              assert_equal true, c.start
+            end
+          end
+
+          context 'when stopping a cluster' do
+            setup do
+              @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new
+            end
+
+            should 'print information about an exception' do
+              @subject.expects(:__get_nodes).raises(Errno::ECONNREFUSED)
+
+              assert_nothing_raised do
+                assert_equal false, @subject.stop
+              end
+            end
+
+            should 'return false when the nodes are empty' do
+              @subject.expects(:__get_nodes).returns({})
+              assert_equal false, @subject.stop
+            end
+
+            should 'kill each node' do
+              @subject.expects(:__get_nodes).returns({
+                                                       'nodes' => {
+                                                         'n1' => { 'process' => { 'id' => 1 } },
+                                                         'n2' => { 'process' => { 'id' => 2 } },
+                                                       },
+                                                     })
+
+              Kernel.stubs(:sleep)
+              Process.expects(:kill).with('INT', 1)
+              Process.expects(:kill).with('INT', 2)
+              Process.expects(:getpgid).with(1).raises(Errno::ESRCH)
+              Process.expects(:getpgid).with(2).raises(Errno::ESRCH)
+
+              assert_equal [1, 2], @subject.stop
+            end
+          end
+
+          context 'when checking if the cluster is running' do
+            setup do
+              @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new \
+                cluster_name: 'test',
+                number_of_nodes: 2
+            end
+
+            should 'return true' do
+              @subject.expects(:__get_cluster_health).returns({ 'cluster_name' => 'test', 'number_of_nodes' => 2 })
+              assert_equal true, @subject.running?
+            end
+
+            should 'return false' do
+              @subject.expects(:__get_cluster_health).returns({ 'cluster_name' => 'test', 'number_of_nodes' => 1 })
+              assert_equal false, @subject.running?
+            end
+          end
+
+          context 'when waiting for the green state' do
+            should 'return true' do
+              @subject.expects(:__wait_for_status).returns(true)
+              assert_equal true, @subject.wait_for_green
+            end
+          end
+
+          context 'when waiting for cluster state' do
+            setup do
+              @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new \
+                cluster_name: 'test',
+                number_of_nodes: 1
+            end
+
+            should 'return true' do
+              @subject
+                .expects(:__get_cluster_health)
+                .with('yellow')
+                .returns({ 'status' => 'yellow', 'cluster_name' => 'test', 'number_of_nodes' => 1 })
+
+              @subject.__wait_for_status('yellow')
+            end
+          end
+
+          context 'when getting the cluster health' do
+            should 'return the response' do
+              Net::HTTP
+                .expects(:get)
+                .with(URI('http://localhost:9250/_cluster/health'))
+                .returns(JSON.dump({ 'status' => 'yellow', 'cluster_name' => 'test', 'number_of_nodes' => 1 }))
+
+              @subject.__get_cluster_health
+            end
+
+            should 'wait for status' do
+              Net::HTTP
+                .expects(:get)
+                .with(URI('http://localhost:9250/_cluster/health?wait_for_status=green'))
+                .returns(JSON.dump({ 'status' => 'yellow', 'cluster_name' => 'test', 'number_of_nodes' => 1 }))
+
+              @subject.__get_cluster_health('green')
+            end
+          end
+
+          context 'when getting the list of nodes' do
+            should 'return the response' do
+              Net::HTTP
+                .expects(:get)
+                .with(URI('http://localhost:9250/_nodes/process'))
+                .returns(JSON.dump({ 'nodes' => { 'n1' => {}, 'n2' => {} } }))
+
+              assert_equal 'n1', @subject.__get_nodes['nodes'].keys.first
+            end
+          end
+
+          context 'when determining a version' do
+            setup do
+              @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new command: '/foo/bar/bin/elasticsearch'
+            end
+
+            should 'return version from lib/elasticsearch.X.Y.Z.jar' do
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(true)
+              Dir.expects(:entries).with('/foo/bar/bin/../lib/').returns([
+                                                                           'foo.jar',
+                                                                           'elasticsearch-foo-1.0.0.jar',
+                                                                           'elasticsearch-2.3.0.jar',
+                                                                           'elasticsearch-bar-9.9.9.jar',
+                                                                         ])
+
+              assert_equal '2.0', @subject.__determine_version
+            end
+
+            should 'return version from `elasticsearch --version`' do
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(false)
+              File.expects(:exist?).with('/foo/bar/bin/elasticsearch').returns(true)
+
+              io = mock('IO')
+              io.expects(:pid).returns(123)
+              io.expects(:read).returns('Version: 2.3.0-SNAPSHOT, Build: d1c86b0/2016-03-30T10:43:20Z, JVM: 1.8.0_60')
+              io.expects(:closed?).returns(false)
+              io.expects(:close)
+              IO.expects(:popen).returns(io)
+
+              Process.stubs(:wait)
+              Process.expects(:kill).with('INT', 123)
+
+              assert_equal '2.0', @subject.__determine_version
+            end
+
+            should 'return version from `elasticsearch --version` when version reaches double digits' do
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(false)
+              File.expects(:exist?).with('/foo/bar/bin/elasticsearch').returns(true)
+
+              io = mock('IO')
+              io.expects(:pid).returns(123)
+              io.expects(:read).returns('Version: 7.11.0-SNAPSHOT, Build: d1c86b0/2016-03-30T10:43:20Z, JVM: 1.8.0_60')
+              io.expects(:closed?).returns(false)
+              io.expects(:close)
+              IO.expects(:popen).returns(io)
+
+              Process.stubs(:wait)
+              Process.expects(:kill).with('INT', 123)
+
+              assert_equal '7.0', @subject.__determine_version
+            end
+
+            should 'return version from arguments' do
+              cluster = OpenSearch::Extensions::Test::Cluster::Cluster.new command: '/foo/bar/bin/elasticsearch', version: '5.2'
+              assert_equal '5.0', cluster.__determine_version
+            end
+
+            should 'raise an exception when the version cannot be parsed from .jar' do
+              # Incorrect jar version (no dots)
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(true)
+              Dir.expects(:entries).with('/foo/bar/bin/../lib/').returns(['elasticsearch-100.jar'])
+
+              assert_raise(RuntimeError) { @subject.__determine_version }
+            end
+
+            should 'raise an exception when the version cannot be parsed from command output' do
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(false)
+              File.expects(:exist?).with('/foo/bar/bin/elasticsearch').returns(true)
+
+              io = mock('IO')
+              io.expects(:pid).returns(123)
+              io.expects(:read).returns('Version: FOOBAR')
+              io.expects(:closed?).returns(false)
+              io.expects(:close)
+              IO.expects(:popen).returns(io)
+
+              Process.stubs(:wait)
+              Process.expects(:kill).with('INT', 123)
+
+              assert_raise(RuntimeError) { @subject.__determine_version }
+            end
+
+            should 'raise an exception when the version cannot be converted to short version' do
+              # There's no OpenSearch version 3...
+              File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(true)
+              Dir.expects(:entries).with('/foo/bar/bin/../lib/').returns(['elasticsearch-3.2.1.jar'])
+
+              assert_raise(RuntimeError) { @subject.__determine_version }
+            end
+
+            should 'raise an exception when the command cannot be found' do
+              @subject = OpenSearch::Extensions::Test::Cluster::Cluster.new
+
+              File.expects(:exist?).with('./../lib/').returns(false)
+              File.expects(:exist?).with('opensearch').returns(false)
+              @subject.expects(:`).returns('')
+
+              assert_raise(Errno::ENOENT) { @subject.__determine_version }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/local_gems/opensearch-extensions/test/test_helper.rb
+++ b/local_gems/opensearch-extensions/test/test_helper.rb
@@ -1,0 +1,82 @@
+# Licensed to OpenSearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. OpenSearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ELASTICSEARCH_HOSTS = if (hosts = ENV['TEST_ES_SERVER'] || ENV.fetch('ELASTICSEARCH_HOSTS', nil))
+                        hosts.split(',').map do |host|
+                          %r{(http://)?(\S+)}.match(host)[2]
+                        end
+                      end.freeze
+
+TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOSTS
+
+JRUBY = defined?(JRUBY_VERSION)
+
+if ENV['COVERAGE'] && ENV['CI'].nil?
+  require 'simplecov'
+  SimpleCov.start { add_filter '/test|test_' }
+end
+
+require 'minitest/autorun'
+require 'shoulda-context'
+require 'mocha/minitest'
+
+require 'minitest/reporters'
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+
+require 'ansi/code'
+require 'logger'
+
+require 'opensearch/extensions'
+require 'opensearch/extensions/test/startup_shutdown'
+require 'opensearch/extensions/test/cluster'
+
+module OpenSearch
+  module Test
+    module Assertions
+      def assert_nothing_raised(*)
+        yield
+      end
+    end
+
+    class UnitTestCase < ::Minitest::Test
+      include Assertions
+      alias assert_not_nil refute_nil
+      alias assert_raise assert_raises
+    end
+
+    class IntegrationTestCase < ::Minitest::Test
+      include Assertions
+      alias assert_not_nil refute_nil
+      alias assert_raise assert_raises
+
+      include OpenSearch::Extensions::Test
+      extend  StartupShutdown
+
+      startup do
+        if ENV['SERVER'] && !OpenSearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
+          OpenSearch::Extensions::Test::Cluster.start(number_of_nodes: 2)
+        end
+      end
+
+      shutdown do
+        if ENV['SERVER'] && OpenSearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
+          OpenSearch::Extensions::Test::Cluster.stop(number_of_nodes: 2)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/art_pieces.rb
+++ b/spec/factories/art_pieces.rb
@@ -5,9 +5,7 @@ FactoryBot.define do
     year { (Time.zone.now - Random.rand(10).years).year }
     medium
     price { rand(1..1000) + rand.round(2) }
-    artist do
-      FactoryBot.create(:artist, :active)
-    end
+    association :artist, :active
 
     photo { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/art.png'), 'image/png') }
     trait :with_tag do

--- a/spec/fixtures/vcr_cassettes/server_status.yml
+++ b/spec/fixtures/vcr_cassettes/server_status.yml
@@ -40,12 +40,54 @@ http_interactions:
       - '0.198084'
     body:
       encoding: UTF-8
-      string: Challenger 7.1.0
+      string: Impala 9.0.0
     http_version:
   recorded_at: Sat, 08 Sep 2018 23:03:07 GMT
 - request:
     method: get
     uri: http://localhost:9250/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "node-1",
+          "cluster_name" : "elasticsearch-test-kinda",
+          "cluster_uuid" : "L9_X_7rzTwuwP2_wtct-fg",
+          "version" : {
+            "number" : "6.2.2",
+            "build_hash" : "10b1edd",
+            "build_date" : "2018-02-16T19:01:30.685723Z",
+            "build_snapshot" : false,
+            "lucene_version" : "7.2.1",
+            "minimum_wire_compatibility_version" : "5.6.0",
+            "minimum_index_compatibility_version" : "5.0.0"
+          },
+          "tagline" : "You Know, for Search"
+        }
+    http_version:
+  recorded_at: Sat, 08 Sep 2018 23:03:07 GMT
+- request:
+    method: get
+    uri: http://localhost:9200/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/models/art_piece_spec.rb
+++ b/spec/models/art_piece_spec.rb
@@ -14,13 +14,13 @@ describe ArtPiece do
 
   describe 'new' do
     it 'allows quotes' do
-      p = valid_attrs.merge(title: 'what"ever')
+      p = valid_attrs.merge(title: 'what"ever', artist_id: artist.id)
       ap = ArtPiece.new(p)
       expect(ap).to be_valid
     end
 
     it 'encodes quotes to html numerically' do
-      p = valid_attrs.merge(title: 'what"ever')
+      p = valid_attrs.merge(title: 'what"ever', artist_id: artist.id)
       ap = ArtPiece.new(p)
       expect(ap.safe_title).to eq('what&quot;ever')
     end

--- a/spec/services/search/open_search/search_service_spec.rb
+++ b/spec/services/search/open_search/search_service_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+describe Search::OpenSearch::SearchService do
+  before do
+    allow(Search::OpenSearchClient).to receive(:delete)
+    allow(Search::OpenSearchClient).to receive(:index)
+    allow(Search::OpenSearchClient).to receive(:update)
+    allow(Search::OpenSearchClient).to receive(:multi_index_search)
+    allow(Search::OpenSearchClient).to receive(:create_index)
+    allow(Search::OpenSearchClient).to receive(:delete_index)
+  end
+
+  let(:artist) { create(:artist, :with_art) }
+
+  describe '.index' do
+    it 'indexes the object' do
+      described_class.index(artist)
+      expect(Search::OpenSearchClient).to have_received(:index)
+    end
+    it 'does nothing if the object has no info' do
+      described_class.index(build(:artist))
+      expect(Search::OpenSearchClient).not_to have_received(:index)
+    end
+  end
+
+  describe '.reindex' do
+    it 'deletes and reads the object to the index' do
+      described_class.reindex(artist)
+      expect(Search::OpenSearchClient).to have_received(:delete).with(
+        'artists', artist.id
+      )
+      expect(Search::OpenSearchClient).to have_received(:index).with(
+        'artists', artist.id, artist.as_indexed_json
+      )
+    end
+    it 'does nothing if the object has no info' do
+      described_class.index(build(:artist))
+      expect(Search::OpenSearchClient).not_to have_received(:delete)
+      expect(Search::OpenSearchClient).not_to have_received(:index)
+    end
+  end
+
+  describe '.remove' do
+    let(:artist) { build(:artist, id: 123) }
+    it 'removes the object from the instance' do
+      described_class.remove(artist)
+      expect(Search::OpenSearchClient).to have_received(:delete).with(
+        'artists', artist.id
+      )
+    end
+  end
+
+  describe '.update' do
+    it 'udpates object in the index' do
+      described_class.update(artist)
+      expect(Search::OpenSearchClient).to have_received(:update).with(
+        'artists', artist.id, artist.as_indexed_json
+      )
+    end
+    it 'does nothing if the object has no info' do
+      described_class.update(build(:artist))
+      expect(Search::OpenSearchClient).not_to have_received(:update)
+    end
+  end
+
+  describe '.reindex_all' do
+    let(:art_piece) { create(:art_piece) }
+    before do
+      art_piece
+    end
+    it 'reindexes all objects for the class' do
+      described_class.reindex_all(ArtPiece)
+
+      expect(Search::OpenSearchClient).to have_received(:delete).with('art_pieces', art_piece.id)
+      expect(Search::OpenSearchClient).to have_received(:index).with(
+        'art_pieces',
+        art_piece.id,
+        art_piece.as_indexed_json,
+      )
+    end
+  end
+
+  describe '.create_index' do
+    it 'creates the index' do
+      described_class.create_index(Studio)
+      expect(Search::OpenSearchClient).to have_received(:create_index).with(
+        'studios',
+        settings: Search::Indexer::INDEX_SETTINGS,
+        analysis: Search::Indexer::ANALYZERS_TOKENIZERS,
+        mappings: Search::SearchableObject.mappings_by_object_type(Studio),
+      )
+    end
+  end
+
+  describe '.delete_index' do
+    it 'deletes the index' do
+      described_class.delete_index(Artist)
+      expect(Search::OpenSearchClient).to have_received(:delete_index).with('artists')
+    end
+  end
+
+  describe '.search' do
+    it 'calls the search endpoint' do
+      described_class.search('leonardo da vi')
+      expect(Search::OpenSearchClient).to have_received(:multi_index_search).with(
+        an_array_matching(%w[artists art_pieces studios]),
+        {
+          query: {
+            multi_match: {
+              query: 'leonardo da vi',
+              fields: Search::Indexer::MULTI_MATCH_QUERY_FIELDS,
+              type: 'most_fields',
+              fuzziness: 0,
+            },
+          },
+          size: 100,
+        },
+      )
+    end
+  end
+end

--- a/spec/services/search/open_search_client_spec.rb
+++ b/spec/services/search/open_search_client_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+describe Search::OpenSearchClient do
+  let(:mock_client_indices) do
+    instance_double(OpenSearch::API::Indices::Actions,
+                    {
+                      create: true,
+                      delete: true,
+                      close: true,
+                      open: true,
+                      put_settings: true,
+                      put_mapping: true,
+                      exists?: true,
+                    })
+  end
+
+  let(:mock_client) do
+    instance_double(OpenSearch::Client,
+                    {
+                      index: true,
+                      delete: true,
+                      update: true,
+                      search: true,
+                      indices: mock_client_indices,
+                    })
+  end
+
+  let(:index) { 'the-index' }
+  let(:id) { 5 }
+  let(:document) { { whatever: { name: 'a dummy document', id: } } }
+  let(:settings) do
+    {
+      max_ngram_diff: 4,
+      number_of_shards: 1,
+      number_of_replicas: 0,
+      blocks: {
+        read_only_allow_delete: 'false',
+      },
+    }
+  end
+  let(:analysis) do
+    {
+      analyzer: {
+        my_analyzer: {
+          tokenizer: :my_tokenizer,
+        },
+      },
+      tokenizer: {
+        my_tokenizer: {
+          type: 'ngram',
+        },
+      },
+    }
+  end
+  let(:mappings) do
+    {
+      my_object: {
+        my_field: { type: 'text', analyzer: :my_analyzer },
+        other_field: { type: 'text', index: false },
+      },
+    }
+  end
+
+  before do
+    allow(OpenSearch::Client).to receive(:new).and_return(mock_client)
+  end
+
+  describe '.index' do
+    it 'indexes the document' do
+      described_class.index(index, id, document)
+      expect(mock_client).to have_received(:index).with(index:, id:, body: document, refresh: true)
+    end
+  end
+
+  describe '.delete' do
+    it 'deletes the document' do
+      described_class.delete(index, id)
+      expect(mock_client).to have_received(:delete).with(index:, id:, ignore: 404)
+    end
+  end
+  describe '.update' do
+    it 'updates the document' do
+      described_class.update(index, id, document)
+      expect(mock_client).to have_received(:update).with(
+        index:, id:, body: { doc: document },
+      )
+    end
+    context 'if the client update raises not found error' do
+      before do
+        allow(mock_client).to receive(:update).and_raise(OpenSearch::Transport::Transport::Errors::NotFound, 'crap')
+      end
+      it 'ignores' do
+        expect do
+          described_class.update(index, id, document)
+        end.not_to raise_error
+        expect(mock_client).to have_received(:update).with(
+          index:, id:, body: { doc: document },
+        )
+      end
+    end
+  end
+  describe '.create_index' do
+    it 'creates an index with settings' do
+      described_class.create_index(index,
+                                   settings:,
+                                   analysis:,
+                                   mappings:)
+      expect(mock_client_indices).to have_received(:create).with(
+        index:,
+        body: {
+          mappings: {
+            properties: mappings,
+          },
+          settings: {
+            **settings,
+            analysis:,
+          },
+        },
+      )
+    end
+  end
+  describe '.delete_index' do
+    it 'deletes an index' do
+      described_class.delete_index(index)
+      expect(mock_client_indices).to have_received(:delete).with(
+        index:, ignore: 404,
+      )
+    end
+  end
+
+  describe '.multi_index_search' do
+    it 'searches multiple indexes' do
+      described_class.multi_index_search(%w[stuffs haystacks], 'needle')
+      expect(mock_client).to have_received(:search).with(
+        index: 'stuffs,haystacks',
+        body: 'needle',
+      )
+    end
+  end
+end

--- a/spec/services/search/query_runner_spec.rb
+++ b/spec/services/search/query_runner_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe Search::QueryRunner do
+  subject(:runner) { described_class.new(query) }
+  let(:query) { 'looking for' }
+
+  describe '.search' do
+    let(:results) do
+      {
+        'took' => 7,
+        'timed_out' => false,
+        '_shards' => {
+          'total' => 3,
+          'successful' => 3,
+          'skipped' => 0,
+          'failed' => 0,
+        },
+        'hits' => {
+          'total' => {
+            'value' => 13,
+            'relation' => 'eq',
+          },
+          'max_score' => 22.3708,
+          'hits' => [
+            {
+              '_index' => 'artists',
+              '_id' => '5',
+              '_score' => 22.3708,
+              '_source' => {
+                'artist' => {
+                  'firstname' => 'Jon',
+                  'lastname' => 'Rogers',
+                  'nomdeplume' => '',
+                  'slug' => 'administrator',
+                  'artist_name' => 'Jon Rogers',
+                  'studio_name' => 'Runolfsson LLC1',
+                  'bio' => " statement\r\nMy work explores stuff",
+                  'os_participant' => true,
+                  'images' => {
+                    'small' => 'http://localhost:3000/rails/active_storage/representations/redirect/7eddcea/autobianchi-runabout.jpg',
+                    'medium' => 'http://localhost:3000/rails/active_storage/representations/redirect/7ecea/autobianchi-runabout.jpg',
+                    'large' => 'http://localhost:3000/rails/active_storage/representations/redirect/c9789f/autobianchi-runabout.jpg',
+                    'original' => 'http://localhost:3000/rails/active_storage/representations/redirect/aabc/autobianchi-runabout.jpg',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }
+    end
+    before do
+      allow(Search::SearchService).to receive(:search).and_return(results)
+    end
+
+    it 'returns an array of SearchHits' do
+      expect(runner.search).to eq [
+        Search::SearchHit.new(results['hits']['hits'].first),
+      ]
+    end
+
+    context 'when there are no hits' do
+      let(:results) { {} }
+      it 'returns nil' do
+        expect(runner.search).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/search/searchable_object_spec.rb
+++ b/spec/services/search/searchable_object_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+describe Search::SearchableObject do
+  describe '.index_by_object_type' do
+    it 'returns the name as the class underscored and pluralized' do
+      expect(described_class.index_by_object_type(Artist)).to eq 'artists'
+      expect(described_class.index_by_object_type(ArtPiece)).to eq 'art_pieces'
+      expect(described_class.index_by_object_type(Studio)).to eq 'studios'
+    end
+    it 'raises if you try with a class that we know is not an index' do
+      expect { described_class.index_by_object_type(Hash) }.to raise_error(described_class::NotSearchableObject, /hashes is not included/)
+    end
+  end
+
+  describe '.mappings_by_object_type' do
+    it 'returns mappings for artists' do
+      expect(described_class.mappings_by_object_type(Artist)).to eq(
+        {
+          'artist' => {
+            properties: {
+              artist_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+              firstname: { type: 'text', analyzer: :mau_ngram_analyzer },
+              lastname: { type: 'text', analyzer: :mau_ngram_analyzer },
+              nomdeplume: { type: 'text', analyzer: :mau_ngram_analyzer },
+              studio_name: { type: 'text', analyzer: :mau_ngram_analyzer },
+              bio: { type: 'text', index: false },
+            },
+          },
+        },
+      )
+    end
+    it 'returns mappings for art_pieces' do
+      expect(described_class.mappings_by_object_type(ArtPiece)).to eq(
+        {
+          'art_piece' => {
+            properties: {
+              title: { type: 'text', analyzer: 'english' },
+              title_ngram: {
+                type: 'text', analyzer: :mau_ngram_analyzer
+              },
+              year: { type: 'text' },
+              medium: {
+                type: 'text', analyzer: 'english'
+              },
+              artist_name: {
+                type: 'text', analyzer: :mau_ngram_analyzer
+              },
+              studio_name: {
+                type: 'text', analyzer: :mau_ngram_analyzer
+              },
+              tags: {
+                type: 'text', analyzer: 'english'
+              },
+            },
+          },
+
+        },
+      )
+    end
+    it 'returns mappings for studios' do
+      expect(described_class.mappings_by_object_type(Studio)).to eq(
+        {
+          'studio' => {
+            properties: {
+              name: { type: 'text', analyzer: :mau_ngram_analyzer },
+              address: { type: 'text', analyzer: :mau_ngram_analyzer },
+            },
+          },
+        },
+      )
+    end
+    it 'returns nothing for a document type we don\'t have' do
+      expect(described_class.mappings_by_object_type(Hash)).to eq({})
+    end
+  end
+
+  describe '#index_name' do
+    it 'returns the name as the class underscored and pluralized' do
+      expect(described_class.new(Artist.new).index_name).to eq 'artists'
+      expect(described_class.new(ArtPiece.new).index_name).to eq 'art_pieces'
+      expect(described_class.new(Studio.new).index_name).to eq 'studios'
+    end
+    it 'raises if you try with a class that we know is not an index' do
+      expect { described_class.new({}).index_name }.to raise_error(described_class::NotSearchableObject, /hashes is not included/)
+    end
+  end
+
+  describe '#document_type' do
+    it 'returns the name as the class underscored and pluralized' do
+      expect(described_class.new(Artist.new).document_type).to eq 'artist'
+      expect(described_class.new(ArtPiece.new).document_type).to eq 'art_piece'
+      expect(described_class.new(Studio.new).document_type).to eq 'studio'
+    end
+  end
+
+  describe '#document' do
+    let(:artist) { build(:artist) }
+    let(:art_piece) { build(:art_piece) }
+    let(:studio) { build(:studio) }
+
+    it 'returns the document as json' do
+      expect(described_class.new(artist).document).to eq artist.as_indexed_json
+      expect(described_class.new(art_piece).document).to eq art_piece.as_indexed_json
+      expect(described_class.new(studio).document).to eq studio.as_indexed_json
+    end
+  end
+end

--- a/spec/services/server_status_spec.rb
+++ b/spec/services/server_status_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe ServerStatus, vcr: { cassette_name: 'server_status', record: :none } do
+  before do
+    VCR.configure do |c|
+      c.unignore_hosts '127.0.0.1', 'localhost'
+    end
+  end
+  after do
+    VCR.configure do |c|
+      c.ignore_localhost = true
+    end
+  end
   describe '.run' do
     subject(:run_status) { described_class.run }
     it 'returns the status of the server' do

--- a/spec/support/active_storage_migration_helpers.rb
+++ b/spec/support/active_storage_migration_helpers.rb
@@ -1,4 +1,4 @@
-require_relative 'test_es_server'
+require_relative 'test_search_server'
 
 RSpec.configure do |config|
   config.before do |example|

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -1,4 +1,4 @@
-require_relative 'test_es_server'
+require_relative 'test_search_server'
 
 module RSpec
   module Elasticsearch
@@ -22,7 +22,7 @@ RSpec.configure do |config|
     case example.metadata[:elasticsearch]
     when true
       begin
-        TestEsServer.start unless ENV['CI']
+        TestSearchServer.start unless ENV['CI']
       rescue Exception => e
         puts "Failed to start Elasticsearch: #{e}"
       end
@@ -31,7 +31,6 @@ RSpec.configure do |config|
         mock = elasticsearch_double(name: "EsDoubleFor#{clz.name}")
         allow_any_instance_of(clz).to receive('__elasticsearch__').and_return mock
       end
-    # when false
     else
       # stub elastic search calls
       allow(Search::Indexer).to receive(:index)
@@ -42,7 +41,7 @@ RSpec.configure do |config|
 end
 
 at_exit do
-  TestEsServer.stop unless ENV['CI']
+  TestSearchServer.stop unless ENV['CI']
 rescue Exception => e
   puts "Failed to stop Elasticsearch: #{e}"
 end

--- a/spec/support/mock_search_service.rb
+++ b/spec/support/mock_search_service.rb
@@ -1,18 +1,15 @@
 module MockSearchService
   def stub_query_runner!
     runner = Search::QueryRunner.new('query')
-    allow(runner).to receive(:search).and_call_original
-    allow(runner).to receive(:multi_index_search).and_return JSON.parse(mock_search_results)
+    allow(runner).to receive(:search).and_return JSON.parse(mock_search_results)
     allow(Search::QueryRunner).to receive(:new).and_return(runner)
   end
 
   def stub_indexer!
-    mock_indexer = double(Search::Indexer::ObjectSearchService)
-    allow(mock_indexer).to receive(:index)
-    allow(mock_indexer).to receive(:reindex)
-    allow(mock_indexer).to receive(:update)
-    allow(mock_indexer).to receive(:remove)
-    allow(Search::Indexer::ObjectSearchService).to receive(:new).and_return(mock_indexer)
+    allow(Search::SearchService).to receive(:index)
+    allow(Search::SearchService).to receive(:reindex)
+    allow(Search::SearchService).to receive(:update)
+    allow(Search::SearchService).to receive(:remove)
   end
 
   def stub_search_service!

--- a/spec/support/test_search_server.rb
+++ b/spec/support/test_search_server.rb
@@ -1,12 +1,14 @@
 require 'elasticsearch/extensions/test/cluster'
-class TestEsServer
+require 'opensearch/extensions/test/cluster'
+
+class TestSearchServer
   DEFAULT_TEST_ARGS = {
     number_of_nodes: 1,
     clear_cluster: true,
   }.freeze
 
   def self.cluster
-    Elasticsearch::Extensions::Test::Cluster
+    FeatureFlags.use_open_search? ? OpenSearch::Extensions::Test::Cluster : Elasticsearch::Extensions::Test::Cluster
   end
 
   def self.port
@@ -24,7 +26,7 @@ class TestEsServer
   def self.start
     return if running?
 
-    puts "Starting elasticsearch cluster on port #{port}"
+    puts "Starting #{cluster.name} cluster on port #{port}"
     cluster.start(server_args) unless running?
   end
 


### PR DESCRIPTION
problem
-------

Elasticsearch used to be free, but it's getting harder to manage without some licensing.
OpenSearch is a fork that is designed to be used in open source projects.

This PR builds in support with a feature flag for us to move to OpenSearch.
There are only a few important but subtle mods that have to happen.

strategy
-------

Below the `Search::indexer` and `Search::QueryRunner` we need to build service classes that know which service is live (ES or OS) and based on that make the right calls with the right structure.

Previous search connections were relatively well compartmentalized except for the use of `elasticsearch-rails` which adds a bunch of search stuff to the models.  With this PR, that moves into the `Search::SearchableObject` which basically maintains settings for different search objects based on the model name but does not put it *in* the AR model code.

changes
------

* extract helper search service functions from `Search::Indexer`
* build `Search::SearchService` which reads the feature flag and decides whether or not to use OpenSearch or ES
* copy `elasticsearch-extensions` gem and make it ready for opensearch
* add Search::OpenSearch::SearchService and Search::OpenSearchClient
* add Search::SearchableObject to contain search settings for different models and not attach them to the AR model code
* add FeatureFlags.use_open_search?
* update circle to use `opensearchproject/opensource` docker image and update urls for testing

notes
-----

After this PR, we can remove the elasticsearch model code additions and the elasticsearch gem

Deployment will mean shutting down ES and a notification should be present because during this time, search will not work and there *may* be issues uploading/updating art though it appears with some testing that the search service is safe against ES not working
