### PR TITLE
Don't blow up art mailer if there is no current open studios

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -128,6 +128,8 @@ class Artist < User
   end
 
   def current_open_studios_participant
+    return false unless OpenStudiosEventService.current
+
     open_studios_participants.find_by(open_studios_event: OpenStudiosEventService.current)
   end
 

--- a/app/presenters/catalog_presenter.rb
+++ b/app/presenters/catalog_presenter.rb
@@ -20,7 +20,7 @@ class CatalogPresenter < ViewPresenter
   def all_artists
     @all_artists ||=
       begin
-        artists = OpenStudiosEventService.current.artists
+        artists = OpenStudiosEventService.current&.artists || []
         artists.exists? ? artists.includes(:studio, :artist_info) : Artist.none
       end
   end

--- a/app/services/open_studios_participation_service.rb
+++ b/app/services/open_studios_participation_service.rb
@@ -1,12 +1,16 @@
 # manage caching the list of open studios events
 class OpenStudiosParticipationService
   def self.participate(artist, open_studios_event)
+    return unless open_studios_event
+
     OpenStudiosParticipant.transaction do
       artist.open_studios_participants.create(open_studios_event:) unless artist.open_studios_participants.find_by(open_studios_event:)
     end
   end
 
   def self.refrain(artist, open_studios_event)
+    return unless open_studios_event
+
     artist.open_studios_participants.where(open_studios_event:).destroy_all
   end
 end

--- a/app/views/watcher_mailer/notify_new_art_piece.html.erb
+++ b/app/views/watcher_mailer/notify_new_art_piece.html.erb
@@ -20,9 +20,11 @@ studio = @new_art.studio
     <li>
       In studio: <%= link_to studio.name, studio_url(studio) %>
     </li>
-    <li>
-      Participating in <%= OpenStudiosEventService.current.for_display %>: <%= artist.doing_open_studios?.to_s %>
-    </li>
+    <% if OpenStudiosEventService.current %>
+      <li>
+        Participating in <%= OpenStudiosEventService.current.for_display %>: <%= artist.doing_open_studios?.to_s %>
+      </li>
+    <% end %>
   </ul>
 </p>
 <p>

--- a/spec/mailers/watcher_mailer_spec.rb
+++ b/spec/mailers/watcher_mailer_spec.rb
@@ -8,7 +8,6 @@ describe WatcherMailer do
     let(:artist) { create(:artist, :with_art, :with_studio) }
     let(:art_piece) { artist.art_pieces.first }
     let(:studio) { artist.studio }
-    let!(:open_studios) { create(:open_studios_event) }
 
     subject(:mail) { described_class.notify_new_art_piece(art_piece, to) }
 
@@ -19,26 +18,40 @@ describe WatcherMailer do
       mail.html_part.body
     end
 
-    it 'sends it to the watchlist email list with the right subject' do
-      expect(mail.to).to match_array ['someone@example.com', 'other@example.com']
-      expect(mail.subject).to eq "[MAU Art][test] #{artist.get_name} just added some art"
+    context 'when there is an active open studios event' do
+      let!(:open_studios) { create(:open_studios_event) }
+
+      it 'sends it to the watchlist email list with the right subject' do
+        expect(mail.to).to match_array ['someone@example.com', 'other@example.com']
+        expect(mail.subject).to eq "[MAU Art][test] #{artist.get_name} just added some art"
+      end
+
+      it 'renders the email with the art piece, artist, studio and open studios info' do
+        expect(mail).to have_body_text 'New Art:'
+        expect(mail_body).to have_link(art_piece.title, href: art_piece_url(art_piece))
+        expect(mail_body).to have_link(artist.get_name, href: artist_url(artist))
+        expect(mail_body).to have_link(studio.name, href: studio_url(studio))
+        expect(mail).to have_body_text("Participating in #{open_studios.for_display}: false")
+      end
+
+      it 'includes the picture' do
+        expect(mail_body).to have_css("img[src='#{art_piece.attached_photo(:original)}'][title='#{art_piece.title}']")
+      end
+
+      it 'renders a little social media snippet' do
+        tags = art_piece.tags.map { |tag| "##{tag.name}" }.join(' ')
+        expect(mail).to have_body_text tags
+      end
     end
 
-    it 'renders the email with the art piece, artist, studio and open studios info' do
-      expect(mail).to have_body_text 'New Art:'
-      expect(mail_body).to have_link(art_piece.title, href: art_piece_url(art_piece))
-      expect(mail_body).to have_link(artist.get_name, href: artist_url(artist))
-      expect(mail_body).to have_link(studio.name, href: studio_url(studio))
-      expect(mail).to have_body_text("Participating in #{open_studios.for_display}: false")
-    end
-
-    it 'includes the picture' do
-      expect(mail_body).to have_css("img[src='#{art_piece.attached_photo(:original)}'][title='#{art_piece.title}']")
-    end
-
-    it 'renders a little social media snippet' do
-      tags = art_piece.tags.map { |tag| "##{tag.name}" }.join(' ')
-      expect(mail).to have_body_text tags
+    context 'if there is no current open studios event' do
+      it 'renders the email with the art piece, artist, studio and open studios info' do
+        expect(mail).to have_body_text 'New Art:'
+        expect(mail_body).to have_link(art_piece.title, href: art_piece_url(art_piece))
+        expect(mail_body).to have_link(artist.get_name, href: artist_url(artist))
+        expect(mail_body).to have_link(studio.name, href: studio_url(studio))
+        expect(mail).to_not have_body_text('Participating in')
+      end
     end
   end
 end


### PR DESCRIPTION
problem
-----

with the recent mod to have scheduled open studios that go away,
we didn't hit all the cases where we assume the open studios event is present.

one showed up while testing something in acceptance.  Adding art generates an email which is counting on open studios event.

solution
------

Add some guards and fix the email.
