### PR TITLE
Maybe improve feature spec speed

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -9,7 +9,7 @@
     "port": 3036
   },
   "test": {
-    "autoBuild": true,
+    "autoBuild": false,
     "publicOutputDir": "vite-test",
     "port": 3038
   }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,3 +57,6 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+# Prebuild assets
+ViteRuby.commands.build

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,3 +63,5 @@ RSpec.configure do |config|
     request.env['HTTP_REFERER'] = SHARED_REFERER
   end
 end
+
+ViteRuby.commands.build


### PR DESCRIPTION
problem
----

current feature specs are pretty slow.

this tip from https://mattbrictson.com/blog/faster-vite-test-without-autobuild suggests that we can tell vite to prebuild and it might improve our performance.

I suspect we already run assets precompile on CI but if this makes vite do less work to check and see if everything is cool, we might gain a bit.

solution
-----

autobuild: false and force prebuilding assets for test
