### PR TITLE
Fix up use of spinner in a couple places

### DIFF
--- a/app/webpack/js/app/helpers.js
+++ b/app/webpack/js/app/helpers.js
@@ -17,6 +17,7 @@ export function each(data, cb) {
     });
   }
 }
+
 export function groupBy(arr, keyOrCb) {
   let cb = keyOrCb;
   if (!isFunction(keyOrCb)) {

--- a/app/webpack/reactjs/components/art_page.tsx
+++ b/app/webpack/reactjs/components/art_page.tsx
@@ -1,11 +1,11 @@
 import Flash from "@js/app/flash";
+import { isEmpty } from "@js/app/helpers";
 import { ArtPiece } from "@models/art_piece.model";
 import { ArtCard } from "@reactjs/components/art_card";
 import { Spinner } from "@reactjs/components/spinner";
 import { ArtPiecesProvider } from "@reactjs/contexts/art_pieces.context";
 import { jsonApi as api } from "@services/json_api";
 import React, { FC, useEffect, useState } from "react";
-
 interface ArtPageProps {
   artistId: number;
   initialArtPieceId?: number;
@@ -26,7 +26,7 @@ export const ArtPage: FC<ArtPageProps> = ({ artistId, initialArtPieceId }) => {
       });
   }, [artistId, initialArtPieceId]);
 
-  if (!artPieces) {
+  if (!artPieces || isEmpty(artPieces)) {
     return <Spinner />;
   }
 

--- a/app/webpack/reactjs/components/art_piece_browser.tsx
+++ b/app/webpack/reactjs/components/art_piece_browser.tsx
@@ -287,7 +287,7 @@ const ArtPieceBrowserWrapper: FC<ArtPieceBrowserWrapperProps> = ({
     }
   }, []);
 
-  if (!artist || (!artPieces && !isEmpty(artPieces)) || !studio) {
+  if (!artist || (!artPieces && isEmpty(artPieces)) || !studio) {
     return (
       <div className="mau-spinner-wrapper--takeover">
         <Spinner />

--- a/app/webpack/reactjs/components/spinner.tsx
+++ b/app/webpack/reactjs/components/spinner.tsx
@@ -2,6 +2,8 @@ import React, { FC } from "react";
 
 interface SpinnerProps {}
 
+// This is fully css animated and controlled
+// by _spinner.scss
 export const Spinner: FC<SpinnerProps> = () => {
   return (
     <div className="mau-spinner" role="progressbar">


### PR DESCRIPTION
problem
-----

in an effort to move away from jQuery I looked into our use of spinners
and found a couple places where we weren't maybe doing exactly the right thing.

current spinner in JS is purely divs and CSS so no fancy javascript needed.

but... we were doing a bad check for null vs empty in a couple spots.

solution
-----

leverage `isEmpty` better so we can more reliably show spinners when we need to.
