### PR TITLE
Add concurrency 1 to github builds to cancel previous

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   ruby-test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -51,6 +54,9 @@ jobs:
         run: bin/rspec spec
   cucumber-test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -90,6 +96,9 @@ jobs:
 
   yarn-test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       RAILS_ENV: test
     steps:
@@ -105,6 +114,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -148,6 +160,9 @@ jobs:
         run: bin/rails assets:precompile
   lint:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -10,12 +10,13 @@ on:
     branches: [ '**' ]
   push:
     branches: [ 'main' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruby-test:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -54,9 +55,6 @@ jobs:
         run: bin/rspec spec
   cucumber-test:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -96,9 +94,6 @@ jobs:
 
   yarn-test:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     env:
       RAILS_ENV: test
     steps:
@@ -114,9 +109,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     env:
       RAILS_ENV: test
       DB_DATABASE: test_db
@@ -160,9 +152,6 @@ jobs:
         run: bin/rails assets:precompile
   lint:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
problem
-----

when we put up a new commit on a pr, we get a new build but we don't cancel old builds.

solution
----

leverage the `concurrency` setting

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
