### PR TITLE
Fix up featured on instagram/facebook admin snippets

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,6 +4,7 @@ module Admin
 
     def show
       @user = ArtistPresenter.new(@user)
+      @current_open_studios = OpenStudiosEventPresenter.new(OpenStudiosEventService.current)
     end
 
     private

--- a/app/presenters/open_studios_event_presenter.rb
+++ b/app/presenters/open_studios_event_presenter.rb
@@ -134,6 +134,10 @@ class OpenStudiosEventPresenter < ViewPresenter
     [model.start_time, model.end_time].join('-')
   end
 
+  def year
+    model.start_date.year
+  end
+
   def display_logo
     if available? && logo?
       logo.url(:square)

--- a/app/views/admin/users/_featured_on_facebook.html.slim
+++ b/app/views/admin/users/_featured_on_facebook.html.slim
@@ -1,5 +1,6 @@
 / expects artist as ArtistPresenter
-div Mission Open Studios : April 16-17, 2016, noon-6pm
+/ expects current_open_studios as OpenStudiosEventPresenter
+div Mission Open Studios : #{current_open_studios.date_range_with_year} #{current_open_studios.time_range}
 div
 - if artist.facebook?
   = "@#{artist.facebook_handle}"
@@ -9,6 +10,6 @@ div
   '
   span  ##{artist.primary_medium_hashtag}
 div &nbsp;
-div MissionArtists.org http://MissionArtists.org/artists/#{artist.login}
+div www.MissionArtists.org #{artist_url(artist.login)}
 div &nbsp;
-div #missionopenstudios #missionopenstudios2016 #openstudios #springopenstudios #missionart #missionartists #SFArt #SFArtist #sanfrancisco
+div #missionopenstudios #missionopenstudios#{current_open_studios.year} #openstudios #springopenstudios #missionart #missionartists #SFArt #SFArtist #sanfrancisco

--- a/app/views/admin/users/_featured_on_instagram.html.slim
+++ b/app/views/admin/users/_featured_on_instagram.html.slim
@@ -1,5 +1,6 @@
 / expects artist as ArtistPresenter
-div Mission Open Studios : April 16-17, 2016, noon-6pm
+/ expects current_open_studios as OpenStudiosEventPresenter
+div Mission Open Studios : #{current_open_studios.date_range_with_year} #{current_open_studios.time_range}
 div
 - if artist.instagram?
   = "@#{artist.instagram_handle}"
@@ -9,6 +10,6 @@ div
   '
   span  ##{artist.primary_medium_hashtag}
 div &nbsp;
-div MissionArtists.org http://MissionArtists.org/artists/#{artist.login}
+div MissionArtists.org #{artist_url(artist.login)}
 div &nbsp;
-div #missionopenstudios #missionopenstudios2016 #openstudios #springopenstudios #missionart #missionartists #SFArt #SFArtist #sanfrancisco
+div #missionopenstudios #missionopenstudios#{current_open_studios.year} #openstudios #springopenstudios #missionart #missionartists #SFArt #SFArtist #sanfrancisco

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -58,7 +58,7 @@
         tr.admin-user__profile-table__row
           td Activation Date
           td = @user.activation_date
-    - if @user.artist? && @user.doing_open_studios?
+    - if current_open_studios.available? && @user.artist? && @user.doing_open_studios?
       .admin-user__os-info.info-block
         h3 = "Open Studios Participant Information for #{current_open_studios.date_range_with_year}"
         = render partial: "open_studios_participation", locals: { open_studios_participant: @user.current_open_studios_participant }
@@ -95,50 +95,52 @@
         - else
           h4 No art here
     .pure-u-1-2.padded-content
-      .featured-snippet.mod-facebook.info-block
-        h4
-          = link_to Conf.social_links['facebook']
-            .info-block-icon.fa-ico-invert.fa.fa-facebook
-          | For Facebook
-        .instructions
-          p
-            | Check for <span class="info-block-instructions-callout">#{@user.login}</span> and
-            |  <span class="info-block-instructions-callout">#{@user.full_name}</span> on
-            '
-            = link_to "facebook", "https://www.facebook.com/search/top/?q=#{@user.full_name}", target: '_blank'
-            '
-            | and see if you can find their handle.
-            - if @user.facebook?
-              | We think it might be
+      - if @current_open_studios.available?
+        .featured-snippet.mod-facebook.info-block
+          h4
+            = link_to Conf.social_links['facebook']
+              .info-block-icon.fa-ico-invert.fa.fa-facebook
+            | For Facebook
+          .instructions
+            p
+              | Check for <span class="info-block-instructions-callout">#{@user.login}</span> and
+              |  <span class="info-block-instructions-callout">#{@user.full_name}</span> on
               '
-              = link_to @user.facebook_handle, @user.facebook
+              = link_to "facebook", "https://www.facebook.com/search/top/?q=#{@user.full_name}", target: '_blank'
               '
-              | based on their MAU profile.
-          p ALSO: tag the artist in the photo
+              | and see if you can find their handle.
+              - if @user.facebook?
+                | We think it might be
+                '
+                = link_to @user.facebook_handle, @user.facebook
+                '
+                | based on their MAU profile.
+            p ALSO: tag the artist in the photo
 
-        .content
-          = render "featured_on_facebook", artist: @user
+          .content
+            = render "featured_on_facebook", artist: @user, current_open_studios: @current_open_studios
     .pure-u-1-2.padded-content
-      .featured-snippet.mod-instagram.info-block
-        h4
-          = link_to Conf.social_links['instagram']
-            .info-block-icon.fa.fa-ico-invert.fa-instagram
-          | For Instagram
+      - if @current_open_studios.available?
+        .featured-snippet.mod-instagram.info-block
+          h4
+            = link_to Conf.social_links['instagram']
+              .info-block-icon.fa.fa-ico-invert.fa-instagram
+            | For Instagram
 
-        .instructions
-          p
-            | Check for <span class="info-block-instructions-callout">#{@user.login}</span> and
-            |  <span class="info-block-instructions-callout">#{@user.full_name}</span> on
-            '
-            = link_to 'instagram', "http://instagram.com/explore/tags/sfmau", target: '_blank'
-            '
-            | and see if you can find their handle.
-          - if @user.instagram?
-            .hint
-              | We think it might be
+          .instructions
+            p
+              | Check for <span class="info-block-instructions-callout">#{@user.login}</span> and
+              |  <span class="info-block-instructions-callout">#{@user.full_name}</span> on
               '
-              = link_to @user.instagram_handle, @user.instagram
+              = link_to 'instagram', "http://instagram.com/explore/tags/sfmau", target: '_blank'
               '
-              | based on their MAU profile.
-        .content
-          = render "featured_on_instagram", artist: @user
+              | and see if you can find their handle.
+            - if @user.instagram?
+              .hint
+                | We think it might be
+                '
+                = link_to @user.instagram_handle, @user.instagram
+                '
+                | based on their MAU profile.
+          .content
+            = render "featured_on_instagram", artist: @user, current_open_studios: @current_open_studios


### PR DESCRIPTION
problem
----
as an admin user
when I visit the admin/artists page and then go to see the artist details by clicking the 'info' icon
then I see a bunch of helper text for if I'm going to post to instagram or Facebook or twitter.
so that we can better promote our events.

fixes #444

solution
---
that content needs to be updated.

the url should be changed from http://MissionArtists.org/ to https://www.missionartists.org (lowercase and https and www).
the open studios dates should use the OpenStudiosEventService.current.

If there is no open studios, the sample should just include the link to the artist
