### PR TITLE
bundle audit - webrick update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,7 +596,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)


### PR DESCRIPTION
ruby-advisory-db:
  advisories:	936 advisories
  last updated:	2024-10-05 13:31:36 -0700
  commit:	881667a8dda3dc0a87d6c897d75cf6159e8e7528
Name: webrick
Version: 1.8.1
CVE: CVE-2024-47220
GHSA: GHSA-6f62-3596-g6w7
Criticality: High
URL: https://github.com/advisories/GHSA-6f62-3596-g6w7
Title: HTTP Request Smuggling in ruby webrick
Solution: upgrade to '>= 1.8.2'
