### PR TITLE
Cache current os for 1 day

### DIFF
--- a/app/services/open_studios_event_service.rb
+++ b/app/services/open_studios_event_service.rb
@@ -27,7 +27,7 @@ class OpenStudiosEventService
     cached_event = SafeCache.read(CURRENT_CACHE_KEY)
     unless cached_event
       cached_event = OpenStudiosEvent.current
-      SafeCache.write(CURRENT_CACHE_KEY, cached_event)
+      SafeCache.write(CURRENT_CACHE_KEY, cached_event, expires_in: Conf.cache_expiry['current_open_studios'])
     end
     cached_event
   end

--- a/config/config.yml
+++ b/config/config.yml
@@ -27,9 +27,6 @@ development:
     use_open_search: true
   S3_REGION: 'us-west-1'
   cache_expiry:
-    feed: 300
-    search: 20
-    objects: 0
     new_art: 300
   pagination:
     artists:
@@ -53,10 +50,8 @@ production:
     use_open_search: false
   S3_REGION: 'us-west-1'
   cache_expiry:
-    feed: 3600
-    search: 300
-    objects: 0
     new_art: 86400
+    current_open_studios: 86400 # 24hrs
   subdomain: openstudios
   bryant_street_studios_webhook_url: https://www.1890bryant.com/webhook
 
@@ -83,10 +78,9 @@ common:
   cache_server: localhost:11211
   signup_secret_word: eat-shit-hackers
   cache_expiry:
-    feed: 300
-    search: 20
-    objects:
+    current_open_studios: 300 # 5 minutes
     new_art: 300
+
 
   shop_url: http://www.cafepress.com/MissionArtists
   # minimum artists before we show a studio

--- a/spec/controllers/open_studios_subdomain/artists_controller_spec.rb
+++ b/spec/controllers/open_studios_subdomain/artists_controller_spec.rb
@@ -11,7 +11,9 @@ describe OpenStudiosSubdomain::ArtistsController do
   describe '#show' do
     context 'with virtual_open_studios flag on' do
       before do
-        mock_app_config(:features, { virtual_open_studios: true })
+        mock_app_config_fallback
+        mock_app_config(:features, { virtual_open_studios: true, use_open_search: true })
+        mock_app_config(:cache_expiry, { current_open_studios: 20 })
       end
 
       it 'renders successfully if the artist is active and doing open studios' do
@@ -41,7 +43,9 @@ describe OpenStudiosSubdomain::ArtistsController do
 
     context 'with virtual open studios flag off' do
       before do
-        mock_app_config(:features, { virtual_open_studios: false })
+        mock_app_config_fallback
+        mock_app_config(:features, { virtual_open_studios: false, use_open_search: true })
+        mock_app_config(:cache_expiry, { current_open_studios: 20 })
       end
       it 'renders error page' do
         get :show, params: { id: active_artist_doing_open_studios }

--- a/spec/services/open_studios_event_service_spec.rb
+++ b/spec/services/open_studios_event_service_spec.rb
@@ -23,8 +23,23 @@ describe OpenStudiosEventService do
   end
 
   describe '.current' do
+    before do
+      allow(SafeCache).to receive(:write).and_call_original
+      allow(SafeCache).to receive(:read).and_call_original
+    end
     it 'returns the current os' do
       expect(service.current).to eq current_os
+    end
+    it 'sets the cache time based on config' do
+      service.current
+      expect(SafeCache).to have_received(:write).with(:current_os_event, current_os, expires_in: 300)
+    end
+    it 'reads from the cache if it is available' do
+      service.current
+      service.current
+      service.current
+      expect(SafeCache).to have_received(:write).once
+      expect(SafeCache).to have_received(:read).exactly(3).times
     end
   end
 

--- a/spec/support/app_config.rb
+++ b/spec/support/app_config.rb
@@ -3,6 +3,12 @@ module MockAppConfig
     value.stringify_keys! if value.is_a? Hash
     allow(Conf).to receive(:method_missing).with(key.to_sym).and_return(value)
   end
+
+  # if you have multiple mock_app_config calls, you need this at the end
+  def mock_app_config_fallback
+    # fallback for any other calls
+    allow(Conf).to receive(:method_missing).and_return(nil)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
problem
-------

if the current open studios is cached and that cache lasts beyond the "active" time, there are places where we just say if we got a current thing, we show stuff. The current thing is cached and does not become uncached when the end of activation date passes.

instead if we make the cache expire every 24 hours, then at some point it'll auto clear and then we can make sure that within 1 day of the end activation we'll get the current version that will be "inactive" and current will return nil.

solution
----

Add a cache expiry so the value will expire every day

fixes #503
