### PR TITLE
Fix Deployment issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :development do
   gem 'capistrano', require: false
   gem 'capistrano3-puma',   require: false
   gem 'capistrano-bundler', require: false
-  gem 'capistrano-local-precompile', '~> 1.2', require: false
+  gem 'capistrano-local-precompile', git: 'https://github.com/rcode5/capistrano-local-precompile', require: false
   gem 'capistrano-rails', require: false
   gem 'capistrano-rbenv', require: false
   gem 'debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/rcode5/capistrano-local-precompile
+  revision: 91a7f9157d3b74786abc4a6b85e46c4128941a37
+  specs:
+    capistrano-local-precompile (1.2.1)
+      capistrano (>= 3.8)
+
 PATH
   remote: local_gems/opensearch-extensions
   specs:
@@ -92,7 +99,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    airbrussh (1.5.2)
+    airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
     ast (2.4.2)
@@ -137,15 +144,13 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
-    capistrano (3.19.1)
+    capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
     capistrano-bundler (2.1.1)
       capistrano (~> 3.1)
-    capistrano-local-precompile (1.2.0)
-      capistrano (>= 3.8)
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
@@ -379,7 +384,7 @@ GEM
       net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.0)
       net-protocol
-    net-ssh (7.2.3)
+    net-ssh (7.3.0)
     nio4r (2.7.3)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
@@ -387,6 +392,7 @@ GEM
     opensearch-ruby (3.4.0)
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -559,11 +565,12 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
-    sshkit (1.23.0)
+    sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+      ostruct
     stringio (3.1.1)
     sys-uname (1.3.0)
       ffi (~> 1.1)
@@ -622,7 +629,7 @@ DEPENDENCIES
   byebug
   capistrano
   capistrano-bundler
-  capistrano-local-precompile (~> 1.2)
+  capistrano-local-precompile!
   capistrano-rails
   capistrano-rbenv
   capistrano3-puma

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -2,5 +2,6 @@ namespace :assets do
   # task precompile: ['webpacker:compile', :environment]
   # task clobber: ['webpacker:clobber', :environment]
   # # for Capistrano local precompile gem
-  # task clean: ['webpacker:clobber', :environment]
+  desc 'No-op task to please Capistrano deploy:assets:prepare task'
+  task clean: [:environment]
 end


### PR DESCRIPTION
problem
------

`capistrano-local-precompile` gem hasn't been updated in several years.
Moving to ruby 3.3 exposed a bug in that gem which is still using deprecated (and now > ruby3.2 removed) `Dir.exists?`

solution
------

Built a fork of the `capistrano-local-precompile` ready for ruby 3.3 and use it.


testing
-------

to prove this out we leveraged the `--dry-run`

```
bundle exec cap acceptance deploy --dry-run
```
