### PR TITLE
Don't show inactive favorites

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -7,7 +7,7 @@ class Favorite < ApplicationRecord
   scope :art_pieces, -> { where(favoritable_type: ArtPiece.name) }
   scope :artists, -> { where(favoritable_type: Artist.name) }
   scope :by_recency, -> { order(created_at: :desc) }
-
+  scope :active_owners, -> { includes(:owner).where(owner: { state: 'active' }) }
   FAVORITABLE_TYPES = %w[Artist ArtPiece].freeze
 
   def uniqueness_of_owner_and_item

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -83,9 +83,10 @@ class UserPresenter < ViewPresenter
 
   def who_favorites_me
     @who_favorites_me ||=
+      # Because of STI issues we can't do `favoritable: model` - already tried
       Favorite.where(favoritable_type: model.class.name, favoritable_id: model.id)
-              .includes(:owner)
-              .order('created_at desc')
+              .merge(Favorite.active_owners)
+              .order(created_at: :desc)
               .distinct(:owner)
               .map(&:owner).flatten
   end

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -103,4 +103,19 @@ describe UserPresenter do
       expect(presenter.who_i_favorite).not_to include fan
     end
   end
+
+  describe '#who_favorites_me' do
+    let(:active_with_art) { create :artist, :active, :with_art }
+    let(:inactive_with_art) { create :artist, :with_art, state: :suspended }
+
+    before do
+      create_favorite active_with_art, user
+      create_favorite inactive_with_art, user
+    end
+
+    it 'includes only active artists' do
+      expect(presenter.who_favorites_me).to include active_with_art
+      expect(presenter.who_favorites_me).not_to include inactive_with_art
+    end
+  end
 end


### PR DESCRIPTION
problem
------

our `who_favorites_me` query was not concerned about active.  On the
frontend, this means some of your favorites link to suspended users.

solution
-----

update the query so that we only include active owners.

Fixes #512
