### PR TITLE
Reinstante group studios list on open studios promo page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     capybara-select-2 (0.5.1)
-    cgi (0.3.6)
+    cgi (0.3.7)
     childprocess (5.1.0)
       logger (~> 1.5)
     code_analyzer (0.5.5)
@@ -418,7 +418,7 @@ GEM
       mojo_magick (~> 0.6.5)
       rqrcode_core (~> 1.0)
     racc (1.8.1)
-    rack (3.1.10)
+    rack (3.1.11)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-proxy (0.7.7)

--- a/app/views/open_studios/index.html.slim
+++ b/app/views/open_studios/index.html.slim
@@ -11,7 +11,7 @@
 .pure-g.tab-content
   .pure-u-1-1#about
     .pure-g
-      .pure-u-1-1.pure-u-md-5-6.pure-u-lg-4-5.padded-content
+      .pure-u-1-1.pure-u-md-5-6.pure-u-lg-4-5.padded-content.open-studios-index__container
         = render_cms_content @presenter.packaged_summary
         = render_cms_content @presenter.packaged_preview_reception
         .section.open-studios-index__section
@@ -20,12 +20,24 @@
               .pure-u-1-1.pure-u-sm-1-1.pure-u-md-2-3.pure-u-lg-4-5
                 .map-spinner
                 #map-canvas
-          .open-studios-index__list-container
-            h4.section.open-studios-index__header Participating Artists
+        - if @presenter.participating_studios.present?
+          .section.open-studios-index__list-container
+            h4.open-studios-index__header Participating Group Studios
             ul.open-studios-index__participant-list
-              - @presenter.participating_artists.each do |artist|
+              - @presenter.participating_studios.each do |s|
                 li.open-studios-index__participant
-                  = @presenter.link_to_artist(artist)
+                  = link_to(s.name,s)
+                  '
+                  = "(#{pluralize(s.artists.to_a.count(&:doing_open_studios?), 'artist')})"
+        - if @presenter.participating_indies.present?
+          .section.open-studios-index__list-container
+            h4.open-studios-index__header Participating Independent Artists
+            ul.open-studios-index__participant-list
+              - @presenter.participating_indies.each do |a|
+                li.open-studios-index__participant
+                  = link_to(a.get_name, a)
+                  '
+                  = a&.address&.street
 
           = render :partial => '/main/info_footer'
 

--- a/app/webpack/stylesheets/gto/main/_open_studios.scss
+++ b/app/webpack/stylesheets/gto/main/_open_studios.scss
@@ -10,8 +10,6 @@
   }
 }
 .open-studios-index__section {
-  margin-top: 30px;
-  margin-bottom: 30px;
   & > * {
     margin-bottom: 20px;
   }
@@ -26,25 +24,13 @@
   font-size: 1.2rem;
   font-weight: v.$font-weight-bold;
 }
+.open-studios-index__container {
+  & > * {
+    margin-bottom: 30px;
+  }
+}
 .open-studios-index__participant-list {
   margin-top: 0;
   display: flex;
-  flex-wrap: wrap;
-}
-.open-studios-index__participant {
-  @include m.ellipsis;
-  width: 30%;
-  padding-right: 1rem;
-  @media screen and (max-width: v.$screen-lg-max) {
-    width: 47%;
-  }
-  @media screen and (max-width: v.$screen-md-max) {
-    width: 47%;
-  }
-  @media screen and (max-width: v.$screen-sm-max) {
-    width: 100%;
-  }
-  @media screen and (max-width: v.$screen-xs-max) {
-    width: 100%;
-  }
+  flex-direction: column;
 }

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -23,7 +23,8 @@ Given /^there is a studio named "(.*)" with artists$/ do |studio|
 end
 
 Given /there are artists with art in the system$/ do
-  @artists = FactoryBot.create_list(:artist, 3, :with_art, :with_links, :with_studio, number_of_art_pieces: 5)
+  @artists = FactoryBot.create_list(:artist, 3, :with_art, :with_links, :with_studio, number_of_art_pieces: 5) +
+     FactoryBot.create_list(:artist, 1, :with_art, :with_links, number_of_art_pieces: 3)
   @art_pieces = @artists.map(&:art_pieces).flatten
 end
 

--- a/features/step_definitions/open_studios_steps.rb
+++ b/features/step_definitions/open_studios_steps.rb
@@ -65,7 +65,8 @@ end
 
 Then /I see the open studios promo page$/ do
   expect(page).to have_selector 'h2', text: /Open Studios/
-  expect(page).to have_content /participating artists/i
+  expect(page).to have_content /participating independent artists/i
+  expect(page).to have_content /participating group studios/i
   expect(current_path).to eq open_studios_path
 end
 

--- a/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster.rb
+++ b/local_gems/opensearch-extensions/lib/opensearch/extensions/test/cluster.rb
@@ -422,7 +422,7 @@ module OpenSearch
           #
           def __command(version, arguments, node_number)
             command_proc = case version
-                           when '2.13', '2.14', '2.15', '2.16', '2.17'
+                           when '2.13', '2.14', '2.15', '2.16', '2.17', '2.18', '2.19'
                              lambda { |arguments, node_number|
                                <<-COMMAND.gsub('                ', '').gsub(/\n$/, '')
                     #{arguments[:command]} \


### PR DESCRIPTION
problem
-----

Now that covid is over and we're more in person, we'd like the group studios showing
more prominently on the open studios promo page.

This work mostly undoes work done in #130 and some other little steps along the way.

solution
-------

Add list of open studios artists *and* group studios back onto the map page

screenshot
------
<img width="1191" alt="Screenshot 2025-03-09 at 10 51 21 AM" src="https://github.com/user-attachments/assets/8cc2d66e-25ee-44b6-b43e-a17940dda791" />
