### PR TITLE
Bundle audit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     capybara-select-2 (0.5.1)
-    cgi (0.3.6)
+    cgi (0.3.7)
     childprocess (5.1.0)
       logger (~> 1.5)
     code_analyzer (0.5.5)
@@ -418,7 +418,7 @@ GEM
       mojo_magick (~> 0.6.5)
       rqrcode_core (~> 1.0)
     racc (1.8.1)
-    rack (3.1.10)
+    rack (3.1.11)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-proxy (0.7.7)


### PR DESCRIPTION
problem
-----

bundle audit failed

solution
-----

bump cgi/rack

```
Name: cgi
Version: 0.3.6
CVE: CVE-2025-27220
GHSA: GHSA-mhwm-jh88-3gjf
Criticality: Medium
URL: https://www.cve.org/CVERecord?id=CVE-2025-27220
Title: CVE-2025-27220 - ReDoS in CGI::Util#escapeElement.
Solution: update to '~> 0.3.5.1', '~> 0.3.7', '>= 0.4.2'
```

```
Name: rack
Version: 3.1.10
CVE: CVE-2025-27111
GHSA: GHSA-8cgq-6mh2-7j6v
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-8cgq-6mh2-7j6v
Title: Escape Sequence Injection vulnerability in Rack lead to Possible Log Injection
Solution: update to '~> 2.2.12', '~> 3.0.13', '>= 3.1.11'
```
